### PR TITLE
ci(windows): add winget releaser workflow

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -91,15 +91,17 @@ jobs:
             target/${{ matrix.target }}/release/komorebic.pdb
             target/wix/komorebi-*.msi
           retention-days: 7
+
+      # Release
       - name: Generate changelog
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
           if ! type kokai >/dev/null; then cargo install --locked kokai --force; fi
           kokai release --no-emoji --add-links github:commits,issues --ref "$(git tag --points-at HEAD)" >"CHANGELOG.md"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           version: latest
           args: release --skip-validate --rm-dist --release-notes=CHANGELOG.md
@@ -108,6 +110,19 @@ jobs:
           SCOOP_TOKEN: ${{ secrets.SCOOP_TOKEN }}
       - name: Add MSI to release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           files: "target/wix/komorebi-*.msi"
+
+  winget:
+    name: Publish to WinGet
+    runs-on: windows-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: LGUG2Z.komorebi
+          release-tag: ${{ github.ref }}
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Before merging this:
1. Add a PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN` (or rename the secret name in the workflow).

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @LGUG2Z. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Sign the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) for winget-pkgs.

If you would like to read about this action further, the documentation is [here](https://bittu.eu.org/docs/wr-intro), and the source code is [here](https://github.com/vedantmgoyal2009/winget-releaser).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).

- Resolves #152 