### PR TITLE
ci(winget): update workflow

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -121,8 +121,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: LGUG2Z.komorebi
-          release-tag: ${{ github.ref }}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Winget Releaser now uses versioned tags instead of `latest`, and now uses `github.ref_name` as a fallback value for `release-tag` by default.

As mentioned in https://github.com/LGUG2Z/komorebi/pull/220#issuecomment-1260247941, please install the [Pull](https://github.com/apps/pull) app on the winget-pkgs fork to ensure that it is always updated.