### PR TITLE
feat(wm): add tcp event notifications

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -14,7 +14,7 @@ use komorebi_core::WindowContainerBehaviour;
 
 use crate::border::Border;
 use crate::current_virtual_desktop;
-use crate::notify_subscribers;
+use crate::send_notification;
 use crate::window_manager::WindowManager;
 use crate::window_manager_event::WindowManagerEvent;
 use crate::windows_api::WindowsApi;
@@ -596,7 +596,7 @@ impl WindowManager {
             .open(hwnd_json)?;
 
         serde_json::to_writer_pretty(&file, &known_hwnds)?;
-        notify_subscribers(&serde_json::to_string(&Notification {
+        send_notification(&serde_json::to_string(&Notification {
             event: NotificationEvent::WindowManager(*event),
             state: self.as_ref().into(),
         })?)?;


### PR DESCRIPTION
This PR allow TCP to receive event notifications. That way if you want to make a custom input handler you do not have to connect to TCP socket and create a named pipe at the same time.

There are some things that I'm not sure how they should be handled

1. Which TCP Errors should be manage [here](https://github.com/Yusuf007R/komorebi/blob/0b2b75057de0b1bd4903d48690270fad94123970/komorebi/src/main.rs#L377)
2. Is this okay at [this line](https://github.com/Yusuf007R/komorebi/blob/0b2b75057de0b1bd4903d48690270fad94123970/komorebi/src/process_command.rs#L117)?


