### PR TITLE
fix(komorebic): global-work-area-offset duplicate command and alias r…

### DIFF
--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -785,7 +785,6 @@ enum SubCommand {
     InvisibleBorders(InvisibleBorders),
     /// Set offsets to exclude parts of the work area from tiling
     #[clap(arg_required_else_help = true)]
-    #[clap(alias = "global-work-area-offset")]
     GlobalWorkAreaOffset(GlobalWorkAreaOffset),
     /// Set offsets for a monitor to exclude parts of the work area from tiling
     #[clap(arg_required_else_help = true)]


### PR DESCRIPTION
…untime error

Not sure how this work but first time with rust and open source. I was just trying to compile the master line and run it.

I ran `cargo run --bin komorebic -- start --await-configuration` and ran into the error below.

```
thread 'main' panicked at 'Command komorebic: command `global-work-area-offset` alias `global-work-area-offset` is duplicated'
```

After change komorebic started successfully and then ran
` cargo run --bin komorebic -- global-work-area-offset 500 0 0 0` and `cargo run --bin komorebic -- global-work-area-offset 0 0 0 0` to make sure the desired command name still worked. Seemed ok to me.