### PR TITLE
Fix default whkd configuration file

### DIFF
--- a/whkdrc.sample
+++ b/whkdrc.sample
@@ -1,8 +1,8 @@
 .shell powershell
 
 # reload swhkd configuration
-# alt + o                 : taskkill /f /im swhkd.exe && start /b swhkd # if shell is cmd
-alt + o                 : taskkill /f /im swhkd.exe && Start-Process swhkd -WindowStyle hidden # if shell is pwsh / powershell
+# alt + o                 : taskkill /f /im whkd.exe && start /b whkd # if shell is cmd
+alt + o                 : taskkill /f /im whkd.exe && Start-Process whkd -WindowStyle hidden # if shell is pwsh / powershell
 alt + shift + o         : komorebic reload-configuration
 
 # app shortcuts - these require shell to be pwsh / powershell


### PR DESCRIPTION
The whkd process does not start with an s - unless something is wrong or buggy on my computer, it is just "whkd.exe" and so it should be that in this file as well.