### PR TITLE
feat(swap-workspaces-monitor): command to swap focused monitor workspaces with another monitor

### DIFF
--- a/komorebi-core/src/lib.rs
+++ b/komorebi-core/src/lib.rs
@@ -57,6 +57,7 @@ pub enum SocketMessage {
     SendContainerToMonitorWorkspaceNumber(usize, usize),
     SendContainerToNamedWorkspace(String),
     MoveWorkspaceToMonitorNumber(usize),
+    SwapWorkspacesToMonitorNumber(usize),
     ForceFocus,
     Close,
     Minimize,

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -105,6 +105,10 @@ impl Monitor {
         }
     }
 
+    pub fn remove_workspaces(&mut self) -> VecDeque<Workspace> {
+        self.workspaces_mut().drain(..).collect()
+    }
+
     #[tracing::instrument(skip(self))]
     pub fn move_container_to_workspace(
         &mut self,

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -324,6 +324,9 @@ impl WindowManager {
             SocketMessage::MoveContainerToMonitorNumber(monitor_idx) => {
                 self.move_container_to_monitor(monitor_idx, None, true)?;
             }
+            SocketMessage::SwapWorkspacesToMonitorNumber(monitor_idx) => {
+                self.swap_focused_monitor(monitor_idx)?;
+            }
             SocketMessage::CycleMoveContainerToMonitor(direction) => {
                 let monitor_idx = direction.next_idx(
                     self.focused_monitor_idx(),

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -154,7 +154,7 @@ gen_target_subcommand_args! {
     FocusWorkspace,
     FocusWorkspaces,
     MoveWorkspaceToMonitor,
-    SwapWorkspacesToMonitor,
+    SwapWorkspacesWithMonitor,
 }
 
 macro_rules! gen_named_target_subcommand_args {
@@ -808,9 +808,9 @@ enum SubCommand {
     /// Move the focused workspace to the specified monitor
     #[clap(arg_required_else_help = true)]
     MoveWorkspaceToMonitor(MoveWorkspaceToMonitor),
-    /// Swap focused monitior workspaces with specified monitor
+    /// Swap focused monitor workspaces with specified monitor
     #[clap(arg_required_else_help = true)]
-    SwapWorkspacesToMonitor(SwapWorkspacesToMonitor),
+    SwapWorkspacesWithMonitor(SwapWorkspacesWithMonitor),
     /// Create and append a new workspace on the focused monitor
     NewWorkspace,
     /// Set the resize delta (used by resize-edge and resize-axis)
@@ -1196,7 +1196,7 @@ fn main() -> Result<()> {
         SubCommand::MoveWorkspaceToMonitor(arg) => {
             send_message(&SocketMessage::MoveWorkspaceToMonitorNumber(arg.target).as_bytes()?)?;
         }
-        SubCommand::SwapWorkspacesToMonitor(arg) => {
+        SubCommand::SwapWorkspacesWithMonitor(arg) => {
             send_message(&SocketMessage::SwapWorkspacesToMonitorNumber(arg.target).as_bytes()?)?;
         }
         SubCommand::InvisibleBorders(arg) => {

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -154,6 +154,7 @@ gen_target_subcommand_args! {
     FocusWorkspace,
     FocusWorkspaces,
     MoveWorkspaceToMonitor,
+    SwapWorkspacesToMonitor,
 }
 
 macro_rules! gen_named_target_subcommand_args {
@@ -807,6 +808,9 @@ enum SubCommand {
     /// Move the focused workspace to the specified monitor
     #[clap(arg_required_else_help = true)]
     MoveWorkspaceToMonitor(MoveWorkspaceToMonitor),
+    /// Swap focused monitior workspaces with specified monitor
+    #[clap(arg_required_else_help = true)]
+    SwapWorkspacesToMonitor(SwapWorkspacesToMonitor),
     /// Create and append a new workspace on the focused monitor
     NewWorkspace,
     /// Set the resize delta (used by resize-edge and resize-axis)
@@ -1191,6 +1195,9 @@ fn main() -> Result<()> {
         }
         SubCommand::MoveWorkspaceToMonitor(arg) => {
             send_message(&SocketMessage::MoveWorkspaceToMonitorNumber(arg.target).as_bytes()?)?;
+        }
+        SubCommand::SwapWorkspacesToMonitor(arg) => {
+            send_message(&SocketMessage::SwapWorkspacesToMonitorNumber(arg.target).as_bytes()?)?;
         }
         SubCommand::InvisibleBorders(arg) => {
             send_message(


### PR DESCRIPTION
Basically this commit adds a command that allows you to swap two monitors, well it actually swaps the workspaces between the monitors.


Sorry if the main logic is a bit weird, I'm basically new to rust, like I did a bit of rust last year on this project, then I got really busy and stopped doing any rust, so I'm still having a lot of trouble with the borrow checker


if you have any suggestions of how to make it better/cleaner please let me know
