### PR TITLE
fix(wm): refer AHK_EXE

### DIFF
--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -277,7 +277,7 @@ pub fn load_configuration() -> Result<()> {
                 .ok_or_else(|| anyhow!("cannot convert path to string"))?
         );
 
-        Command::new("autohotkey.exe")
+        Command::new(&*AHK_EXE)
             .arg(config_ahk.as_os_str())
             .output()?;
     }


### PR DESCRIPTION
It seems that since this commit (https://github.com/LGUG2Z/komorebi/commit/f87d4d520be4f242c3733186953b8a2558f132df), komorebi no longer supports the launch `AutoHotkey64.exe`.

I send you PR. Would you check this?