### PR TITLE
fix: Borders on invisible border window and monocle mode fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.2"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557d0845b86eea8182f7b10dff120214fb6cd9fd937b6f4917714e546a38695"
+checksum = "751e810399bba86e9326f5762b7f32ac5a085542df78da6a78d94e07d14d7c11"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.8"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -130,13 +130,12 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.8"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
  "strsim",
  "terminal_size",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,7 +486,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -918,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -1207,11 +1229,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.21"
+version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1166,22 +1166,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "c939f902bb7d0ccc5bce4f03297e161543c2dcb30914faf032c2bd0b7a0d48fc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "6eaae920e25fffe4019b75ff65e7660e72091e59dd204cb5849bbd6a3fd343d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1274,7 +1274,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1354,7 +1354,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.23",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]

--- a/komorebi/src/border.rs
+++ b/komorebi/src/border.rs
@@ -108,25 +108,23 @@ impl Border {
                 Self::create("komorebi-border-window")?;
             }
 
-            let mut should_expand_border = false;
+            let mut should_contract_border = true;
 
             let mut rect = WindowsApi::window_rect(window.hwnd())?;
-            rect.top -= invisible_borders.bottom;
-            rect.bottom += invisible_borders.bottom;
 
             let border_overflows = BORDER_OVERFLOW_IDENTIFIERS.lock();
             if border_overflows.contains(&window.title()?)
                 || border_overflows.contains(&window.exe()?)
                 || border_overflows.contains(&window.class()?)
             {
-                should_expand_border = true;
+                should_contract_border = false;
             }
 
-            if should_expand_border {
-                rect.left -= invisible_borders.left;
-                rect.top -= invisible_borders.top;
-                rect.right += invisible_borders.right;
-                rect.bottom += invisible_borders.bottom;
+            if should_contract_border {
+                rect.left += invisible_borders.left;
+                rect.top += invisible_borders.top;
+                rect.right -= invisible_borders.right;
+                rect.bottom -= invisible_borders.bottom;
             }
 
             let border_offset = BORDER_OFFSET.lock();

--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -277,7 +277,7 @@ pub fn load_configuration() -> Result<()> {
                 .ok_or_else(|| anyhow!("cannot convert path to string"))?
         );
 
-        Command::new("autohotkey.exe")
+        Command::new(&*AHK_EXE)
             .arg(config_ahk.as_os_str())
             .output()?;
     }

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -303,7 +303,10 @@ impl WindowsApi {
     }
 
     pub fn position_window(hwnd: HWND, layout: &Rect, top: bool) -> Result<()> {
-        let flags = SetWindowPosition::NO_ACTIVATE;
+        let flags = SetWindowPosition::NO_ACTIVATE
+            | SetWindowPosition::NO_SEND_CHANGING
+            | SetWindowPosition::NO_COPY_BITS
+            | SetWindowPosition::FRAME_CHANGED;
 
         let position = if top { HWND_TOPMOST } else { HWND_BOTTOM };
         Self::set_window_pos(hwnd, layout, position, flags.bits())

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -288,9 +288,21 @@ impl Workspace {
     }
 
     pub fn focus_container_by_window(&mut self, hwnd: isize) -> Result<()> {
+        if let Some(container) = self.monocle_container_mut() {
+            if let Some(window_idx) = container
+                .windows()
+                .iter()
+                .position(|window| window.hwnd == hwnd)
+            {
+                container.focus_window(window_idx);
+
+                return Ok(());
+            }
+        }
+
         let container_idx = self
             .container_idx_for_window(hwnd)
-            .ok_or_else(|| anyhow!("there is no container/window"))?;
+            .ok_or_else(|| anyhow!("there is no container/window focus by window"))?;
 
         let container = self
             .containers_mut()
@@ -790,7 +802,7 @@ impl Workspace {
             .ok_or_else(|| anyhow!("there is no monocle container"))?;
 
         let container = container.clone();
-        if restore_idx > self.containers().len() - 1 {
+        if self.containers().len() > 0 && restore_idx > self.containers().len() - 1 {
             self.containers_mut()
                 .resize(restore_idx, Container::default());
         }


### PR DESCRIPTION
Fix for borders on invisible border windows leaving a gap (contract borders into the window to match the visible area), may only show issue when using thinner than default border width.

Fix for monocle mode border not showing when switching to second workspace as single window (no containers in workspace).

Fix for monocle window not selectable when focusing in direction across multiple screens, would previously show "no container" message as it was only looking in the focused workspace containers ring.