### PR TITLE
fix: Allowed support for spaces in config path

### DIFF
--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -1426,7 +1426,7 @@ fn main() -> Result<()> {
                 }
 
                 flags.push(format!(
-                    "'--config={}'",
+                    "'--config=\"{}\"'",
                     path.as_os_str()
                         .to_string_lossy()
                         .trim_start_matches(r#"\\?\"#),


### PR DESCRIPTION
fix: If the provided configuration path unfortunately includes a space (like C:/Users/FirstName LastName/...), then komorebi fails to find the configuration file as it gets `'--config=C:/Users/FirstName LastName/...'` from komorebic which looks like only `C:/User/FirstName`. Wrapping the path in quotes helps komorebi to find the configuration file.

P.S. I'm new to contributing, so if this is improper formatting, or if there's a smart way to supply the config path already without needing this change, I'm open to learning. Thanks!