### PR TITLE
fix let hotwatch to read the static configuration on every event

### DIFF
--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -634,8 +634,6 @@ impl StaticConfig {
             already_moved_window_handles: Arc::new(Mutex::new(HashSet::new())),
         };
 
-        let bytes = SocketMessage::ReloadStaticConfiguration(path.clone()).as_bytes()?;
-
         wm.hotwatch.watch(path, move |event| match event {
             // Editing in Notepad sends a NoticeWrite while editing in (Neo)Vim sends
             // a NoticeRemove, presumably because of the use of swap files?
@@ -643,6 +641,7 @@ impl StaticConfig {
                 let socket = DATA_DIR.join("komorebi.sock");
                 let mut stream =
                     UnixStream::connect(socket).expect("could not connect to komorebi.sock");
+                let bytes = SocketMessage::ReloadStaticConfiguration(event.paths[0].clone()).as_bytes()?;
                 stream
                     .write_all(&bytes)
                     .expect("could not write to komorebi.sock");


### PR DESCRIPTION
I found that code do not confirm the static configuration and do not reflect the current static configuration.
I open this pull request, but It is difficult to set a rust environment on Windows for me now.
Thus, I can only submit this code.
I will try to get the environment and I will debug.
If you can confirm this code is correct, please edit it.