### PR TITLE
ci(winget): change Winget Releaser job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -116,7 +116,7 @@ jobs:
 
   winget:
     name: Publish to WinGet
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
 


### PR DESCRIPTION
Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.