### PR TITLE
feat(wm): ultrawide layout resizing

### DIFF
--- a/komorebi-core/src/default_layout.rs
+++ b/komorebi-core/src/default_layout.rs
@@ -33,7 +33,7 @@ impl DefaultLayout {
         sizing: Sizing,
         delta: i32,
     ) -> Option<Rect> {
-        if !matches!(self, Self::BSP) {
+        if !matches!(self, Self::BSP) && !matches!(self, Self::UltrawideVerticalStack) {
             return None;
         };
 

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -777,6 +777,9 @@ impl Workspace {
     fn enforce_resize_constraints(&mut self) {
         match self.layout {
             Layout::Default(DefaultLayout::BSP) => self.enforce_resize_constraints_for_bsp(),
+            Layout::Default(DefaultLayout::UltrawideVerticalStack) => {
+                self.enforce_resize_for_ultrawide()
+            }
             _ => self.enforce_no_resize(),
         }
     }
@@ -804,6 +807,63 @@ impl Workspace {
         if let Some(Some(last)) = self.resize_dimensions_mut().last_mut() {
             last.bottom = 0;
             last.right = 0;
+        }
+    }
+
+    fn enforce_resize_for_ultrawide(&mut self) {
+        let mut resize_dimensions = self.resize_dimensions_mut();
+        match resize_dimensions.len() {
+            // Single window can not be resized at all
+            0 | 1 => self.enforce_no_resize(),
+            // Two windows can only be resized in the middle
+            2 => {
+                // Zero is actually on the right
+                if let Some(mut right) = resize_dimensions[0] {
+                    right.top = 0;
+                    right.bottom = 0;
+                    right.right = 0;
+                }
+
+                // One is on the left
+                if let Some(mut left) = resize_dimensions[1] {
+                    left.top = 0;
+                    left.bottom = 0;
+                    left.left = 0;
+                }
+            }
+            // Three or more windows means 0 is in center, 1 is at the left, 2.. are a vertical
+            // stack on the right
+            _ => {
+                // Central can be resized left or right
+                if let Some(mut right) = resize_dimensions[0] {
+                    right.top = 0;
+                    right.bottom = 0;
+                }
+
+                // Left one can only be resized to the right
+                if let Some(mut left) = resize_dimensions[1] {
+                    left.top = 0;
+                    left.bottom = 0;
+                    left.left = 0;
+                }
+
+                // Handle stack on the right
+                let stack_size = resize_dimensions[2..].len();
+                for (i, rect) in resize_dimensions[2..].iter_mut().enumerate() {
+                    if let Some(rect) = rect {
+                        // No containers can resize to the right
+                        rect.right = 0;
+
+                        // First container in stack cant resize up
+                        if i == 0 {
+                            rect.top = 0;
+                        } else if i == stack_size - 1 {
+                            // Last cant be resized to the bottom
+                            rect.bottom = 0;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -778,7 +778,7 @@ impl Workspace {
         match self.layout {
             Layout::Default(DefaultLayout::BSP) => self.enforce_resize_constraints_for_bsp(),
             Layout::Default(DefaultLayout::UltrawideVerticalStack) => {
-                self.enforce_resize_for_ultrawide()
+                self.enforce_resize_for_ultrawide();
             }
             _ => self.enforce_no_resize(),
         }
@@ -811,7 +811,7 @@ impl Workspace {
     }
 
     fn enforce_resize_for_ultrawide(&mut self) {
-        let mut resize_dimensions = self.resize_dimensions_mut();
+        let resize_dimensions = self.resize_dimensions_mut();
         match resize_dimensions.len() {
             // Single window can not be resized at all
             0 | 1 => self.enforce_no_resize(),
@@ -868,13 +868,11 @@ impl Workspace {
     }
 
     fn enforce_no_resize(&mut self) {
-        for rect in self.resize_dimensions_mut().iter_mut() {
-            if let Some(rect) = rect {
-                rect.left = 0;
-                rect.right = 0;
-                rect.top = 0;
-                rect.bottom = 0;
-            }
+        for rect in self.resize_dimensions_mut().iter_mut().flatten() {
+            rect.left = 0;
+            rect.right = 0;
+            rect.top = 0;
+            rect.bottom = 0;
         }
     }
 

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -775,6 +775,13 @@ impl Workspace {
     }
 
     fn enforce_resize_constraints(&mut self) {
+        match self.layout {
+            Layout::Default(DefaultLayout::BSP) => self.enforce_resize_constraints_for_bsp(),
+            _ => self.enforce_no_resize(),
+        }
+    }
+
+    fn enforce_resize_constraints_for_bsp(&mut self) {
         for (i, rect) in self.resize_dimensions_mut().iter_mut().enumerate() {
             if let Some(rect) = rect {
                 // Even containers can't be resized to the bottom
@@ -797,6 +804,17 @@ impl Workspace {
         if let Some(Some(last)) = self.resize_dimensions_mut().last_mut() {
             last.bottom = 0;
             last.right = 0;
+        }
+    }
+
+    fn enforce_no_resize(&mut self) {
+        for rect in self.resize_dimensions_mut().iter_mut() {
+            if let Some(rect) = rect {
+                rect.left = 0;
+                rect.right = 0;
+                rect.top = 0;
+                rect.bottom = 0;
+            }
         }
     }
 


### PR DESCRIPTION
Currently only BSP layout and primary container of custom layouts can be resized. BSP layout is not very good for ultrawide screens and resizing only primary container is limiting. This PR adds resizing for `ultrawide-vertical-stack` layout and refactors some code related to resize calculation.

1. `Workspace::enforce_resize_constraints` can now enforce different constraints for different layouts and for those layouts that can not be resized `resize_dimensions` is explicitly set to 0 (previously everything was constrained as for BSP)
2. New function for constraining resizing of  `ultrawide-vertical-stack` layout, which can be resized differently then BSP
3. Layout calculation for `ultrawide-vertical-stack` now apply `resize_dimensions` via new function `calculate_ultrawide_adjustment`. Base layout is kept the same, resizing changes are applied on top