### PR TITLE
feat(cli): add cycle-layout command

### DIFF
--- a/komorebi-core/src/default_layout.rs
+++ b/komorebi-core/src/default_layout.rs
@@ -128,7 +128,7 @@ impl DefaultLayout {
     }
 
     #[must_use]
-    pub const fn cycle(self) -> Self {
+    pub const fn cycle_next(self) -> Self {
         match self {
             Self::BSP => Self::Columns,
             Self::Columns => Self::Rows,
@@ -136,6 +136,18 @@ impl DefaultLayout {
             Self::VerticalStack => Self::HorizontalStack,
             Self::HorizontalStack => Self::UltrawideVerticalStack,
             Self::UltrawideVerticalStack => Self::BSP,
+        }
+    }
+
+    #[must_use]
+    pub const fn cycle_previous(self) -> Self {
+        match self {
+            Self::BSP => Self::UltrawideVerticalStack,
+            Self::UltrawideVerticalStack => Self::HorizontalStack,
+            Self::HorizontalStack => Self::VerticalStack,
+            Self::VerticalStack => Self::Rows,
+            Self::Rows => Self::Columns,
+            Self::Columns => Self::BSP,
         }
     }
 }

--- a/komorebi-core/src/default_layout.rs
+++ b/komorebi-core/src/default_layout.rs
@@ -20,6 +20,7 @@ pub enum DefaultLayout {
     VerticalStack,
     HorizontalStack,
     UltrawideVerticalStack,
+    // NOTE: If any new layout is added, please make sure to register the same in `DefaultLayout::cycle`
 }
 
 impl DefaultLayout {
@@ -123,6 +124,18 @@ impl DefaultLayout {
             None
         } else {
             Option::from(r)
+        }
+    }
+
+    #[must_use]
+    pub const fn cycle(self) -> Self {
+        match self {
+            Self::BSP => Self::Columns,
+            Self::Columns => Self::Rows,
+            Self::Rows => Self::VerticalStack,
+            Self::VerticalStack => Self::HorizontalStack,
+            Self::HorizontalStack => Self::UltrawideVerticalStack,
+            Self::UltrawideVerticalStack => Self::BSP,
         }
     }
 }

--- a/komorebi-core/src/lib.rs
+++ b/komorebi-core/src/lib.rs
@@ -77,6 +77,7 @@ pub enum SocketMessage {
     AdjustContainerPadding(Sizing, i32),
     AdjustWorkspacePadding(Sizing, i32),
     ChangeLayout(DefaultLayout),
+    ToggleLayout(),
     ChangeLayoutCustom(PathBuf),
     FlipLayout(Axis),
     // Monitor and Workspace Commands

--- a/komorebi-core/src/lib.rs
+++ b/komorebi-core/src/lib.rs
@@ -77,7 +77,7 @@ pub enum SocketMessage {
     AdjustContainerPadding(Sizing, i32),
     AdjustWorkspacePadding(Sizing, i32),
     ChangeLayout(DefaultLayout),
-    ToggleLayout(),
+    CycleLayout(),
     ChangeLayoutCustom(PathBuf),
     FlipLayout(Axis),
     // Monitor and Workspace Commands

--- a/komorebi-core/src/lib.rs
+++ b/komorebi-core/src/lib.rs
@@ -77,7 +77,7 @@ pub enum SocketMessage {
     AdjustContainerPadding(Sizing, i32),
     AdjustWorkspacePadding(Sizing, i32),
     ChangeLayout(DefaultLayout),
-    CycleLayout(),
+    CycleLayout(CycleDirection),
     ChangeLayoutCustom(PathBuf),
     FlipLayout(Axis),
     // Monitor and Workspace Commands

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -448,7 +448,7 @@ impl WindowManager {
             SocketMessage::Retile => self.retile_all(false)?,
             SocketMessage::FlipLayout(layout_flip) => self.flip_layout(layout_flip)?,
             SocketMessage::ChangeLayout(layout) => self.change_workspace_layout_default(layout)?,
-            SocketMessage::ToggleLayout() => self.toggle_layout()?,
+            SocketMessage::CycleLayout() => self.cycle_layout()?,
             SocketMessage::ChangeLayoutCustom(ref path) => {
                 self.change_workspace_custom_layout(path.clone())?;
             }
@@ -1255,7 +1255,7 @@ impl WindowManager {
 
         match message {
             SocketMessage::ChangeLayout(_)
-            | SocketMessage::ToggleLayout(_)
+            | SocketMessage::CycleLayout(_)
             | SocketMessage::ChangeLayoutCustom(_)
             | SocketMessage::FlipLayout(_)
             | SocketMessage::ManageFocusedWindow

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -448,7 +448,7 @@ impl WindowManager {
             SocketMessage::Retile => self.retile_all(false)?,
             SocketMessage::FlipLayout(layout_flip) => self.flip_layout(layout_flip)?,
             SocketMessage::ChangeLayout(layout) => self.change_workspace_layout_default(layout)?,
-            SocketMessage::CycleLayout() => self.cycle_layout()?,
+            SocketMessage::CycleLayout(direction) => self.cycle_layout(direction)?,
             SocketMessage::ChangeLayoutCustom(ref path) => {
                 self.change_workspace_custom_layout(path.clone())?;
             }

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -448,6 +448,7 @@ impl WindowManager {
             SocketMessage::Retile => self.retile_all(false)?,
             SocketMessage::FlipLayout(layout_flip) => self.flip_layout(layout_flip)?,
             SocketMessage::ChangeLayout(layout) => self.change_workspace_layout_default(layout)?,
+            SocketMessage::ToggleLayout() => self.toggle_layout()?,
             SocketMessage::ChangeLayoutCustom(ref path) => {
                 self.change_workspace_custom_layout(path.clone())?;
             }
@@ -1254,6 +1255,7 @@ impl WindowManager {
 
         match message {
             SocketMessage::ChangeLayout(_)
+            | SocketMessage::ToggleLayout(_)
             | SocketMessage::ChangeLayoutCustom(_)
             | SocketMessage::FlipLayout(_)
             | SocketMessage::ManageFocusedWindow

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1707,11 +1707,11 @@ impl WindowManager {
     }
 
     #[tracing::instrument(skip(self))]
-    pub fn toggle_layout(&mut self) -> Result<()> {
+    pub fn cycle_layout(&mut self) -> Result<()> {
         tracing::info!("toggling layout");
 
         let workspace = self.focused_workspace_mut()?;
-        // Get current layout -> and toggle to the next layout in the given order
+        // Get current layout -> and cycle to the next layout in the given order
         let current_layout = workspace.layout()?;
 
         // All layouts

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1717,13 +1717,10 @@ impl WindowManager {
         // All layouts
         let layouts_size = std::mem::size_of_val(&DefaultLayout::BSP);
         for i in 0..enum_size {
-            let enum_value = DefaultLayout::from_u8(i).unwrap();
-            if enum_value == current_layout {
-                if i == (enum_size - 1) {
-                    workspace.set_layout(DefaultLayout::from_u8(0).unwrap());
-                } else {
-                    workspace.set_layout(DefaultLayout::from_u8(i + 1).unwrap());
-                }
+            let layout_value = DefaultLayout::from_u8(i).unwrap();
+            if layout_value == current_layout {
+                workspace.set_layout(DefaultLayout::from_u8(i + 1 % enum_size).unwrap());
+                break;
             }
         }
         self.update_focused_workspace(self.mouse_follows_focus)

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -78,7 +78,6 @@ pub struct WindowManager {
     pub has_pending_raise_op: bool,
     pub pending_move_op: Option<(usize, usize, usize)>,
     pub already_moved_window_handles: Arc<Mutex<HashSet<isize>>>,
-    pub all_layouts: Vec<Layout>,
 }
 
 #[allow(clippy::struct_excessive_bools)]

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1708,19 +1708,19 @@ impl WindowManager {
 
     #[tracing::instrument(skip(self))]
     pub fn cycle_layout(&mut self) -> Result<()> {
-        tracing::info!("toggling layout");
+        tracing::info!("cycling layout");
 
         let workspace = self.focused_workspace_mut()?;
-        // Get current layout -> and cycle to the next layout in the given order
         let current_layout = workspace.layout()?;
-
-        // All layouts
-        let layouts_size = std::mem::size_of_val(&DefaultLayout::BSP);
-        for i in 0..enum_size {
-            let layout_value = DefaultLayout::from_u8(i).unwrap();
-            if layout_value == current_layout {
-                workspace.set_layout(DefaultLayout::from_u8(i + 1 % enum_size).unwrap());
-                break;
+        match current_layout {
+            // For cycling, only Default Layout is supported
+            DefaultLayout => {
+                let new_layout = current_layout.cycle();
+                tracing::info!("Next layout for cycling: {:?}", new_layout);
+                current_layout.set_layout(new_layout);
+            }
+            CustomLayout => {
+                tracing::info!("Current layout is custom, skipping cycling");
             }
         }
         self.update_focused_workspace(self.mouse_follows_focus)

--- a/komorebic.lib.ahk
+++ b/komorebic.lib.ahk
@@ -196,8 +196,8 @@ ChangeLayout(default_layout) {
     RunWait("komorebic.exe change-layout " default_layout, , "Hide")
 }
 
-ToggleLayout() {
-  RunWait("komorebic.exe toggle-layout " , , "Hide")
+CycleLayout() {
+  RunWait("komorebic.exe cycle-layout " , , "Hide")
 }
 
 LoadCustomLayout(path) {

--- a/komorebic.lib.ahk
+++ b/komorebic.lib.ahk
@@ -196,8 +196,8 @@ ChangeLayout(default_layout) {
     RunWait("komorebic.exe change-layout " default_layout, , "Hide")
 }
 
-CycleLayout() {
-  RunWait("komorebic.exe cycle-layout " , , "Hide")
+CycleLayout(operation_direction) {
+    RunWait("komorebic.exe cycle-layout " operation_direction, , "Hide")
 }
 
 LoadCustomLayout(path) {

--- a/komorebic.lib.ahk
+++ b/komorebic.lib.ahk
@@ -196,6 +196,10 @@ ChangeLayout(default_layout) {
     RunWait("komorebic.exe change-layout " default_layout, , "Hide")
 }
 
+ToggleLayout() {
+  RunWait("komorebic.exe toggle-layout " , , "Hide")
+}
+
 LoadCustomLayout(path) {
     RunWait("komorebic.exe load-custom-layout " path, , "Hide")
 }

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -125,7 +125,7 @@ gen_enum_subcommand_args! {
     CycleStack: CycleDirection,
     FlipLayout: Axis,
     ChangeLayout: DefaultLayout,
-    ToggleLayout: ToggleLayout,
+    CycleLayout: CycleLayout,
     WatchConfiguration: BooleanState,
     MouseFollowsFocus: BooleanState,
     Query: StateQuery,
@@ -853,8 +853,9 @@ enum SubCommand {
     /// Set the layout on the focused workspace
     #[clap(arg_required_else_help = true)]
     ChangeLayout(ChangeLayout),
+    // Cycle between available layouts
     #[clap(arg_required_else_help = false)]
-    ToggleLayout(),
+    CycleLayout(),
     /// Load a custom layout from file for the focused workspace
     #[clap(arg_required_else_help = true)]
     LoadCustomLayout(LoadCustomLayout),
@@ -1613,8 +1614,8 @@ Stop-Process -Name:whkd -ErrorAction SilentlyContinue
         SubCommand::ChangeLayout(arg) => {
             send_message(&SocketMessage::ChangeLayout(arg.default_layout).as_bytes()?)?;
         }
-        SubCommand::ToggleLayout() => {
-            send_message(&SocketMessage::ToggleLayout().as_bytes()?)?;
+        SubCommand::CycleLayout() => {
+            send_message(&SocketMessage::CycleLayout().as_bytes()?)?;
         }
         SubCommand::LoadCustomLayout(arg) => {
             send_message(

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -125,6 +125,7 @@ gen_enum_subcommand_args! {
     CycleStack: CycleDirection,
     FlipLayout: Axis,
     ChangeLayout: DefaultLayout,
+    ToggleLayout: ToggleLayout,
     WatchConfiguration: BooleanState,
     MouseFollowsFocus: BooleanState,
     Query: StateQuery,
@@ -852,6 +853,8 @@ enum SubCommand {
     /// Set the layout on the focused workspace
     #[clap(arg_required_else_help = true)]
     ChangeLayout(ChangeLayout),
+    #[clap(arg_required_else_help = false)]
+    ToggleLayout(),
     /// Load a custom layout from file for the focused workspace
     #[clap(arg_required_else_help = true)]
     LoadCustomLayout(LoadCustomLayout),
@@ -1609,6 +1612,9 @@ Stop-Process -Name:whkd -ErrorAction SilentlyContinue
         }
         SubCommand::ChangeLayout(arg) => {
             send_message(&SocketMessage::ChangeLayout(arg.default_layout).as_bytes()?)?;
+        }
+        SubCommand::ToggleLayout() => {
+            send_message(&SocketMessage::ToggleLayout().as_bytes()?)?;
         }
         SubCommand::LoadCustomLayout(arg) => {
             send_message(

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -854,7 +854,7 @@ enum SubCommand {
     #[clap(arg_required_else_help = true)]
     ChangeLayout(ChangeLayout),
     // Cycle between available layouts
-    #[clap(arg_required_else_help = false)]
+    #[clap(arg_required_else_help = true)]
     CycleLayout(CycleLayout),
     /// Load a custom layout from file for the focused workspace
     #[clap(arg_required_else_help = true)]

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -125,7 +125,7 @@ gen_enum_subcommand_args! {
     CycleStack: CycleDirection,
     FlipLayout: Axis,
     ChangeLayout: DefaultLayout,
-    CycleLayout: CycleLayout,
+    CycleLayout: CycleDirection,
     WatchConfiguration: BooleanState,
     MouseFollowsFocus: BooleanState,
     Query: StateQuery,
@@ -855,7 +855,7 @@ enum SubCommand {
     ChangeLayout(ChangeLayout),
     // Cycle between available layouts
     #[clap(arg_required_else_help = false)]
-    CycleLayout(),
+    CycleLayout(CycleLayout),
     /// Load a custom layout from file for the focused workspace
     #[clap(arg_required_else_help = true)]
     LoadCustomLayout(LoadCustomLayout),
@@ -1614,8 +1614,8 @@ Stop-Process -Name:whkd -ErrorAction SilentlyContinue
         SubCommand::ChangeLayout(arg) => {
             send_message(&SocketMessage::ChangeLayout(arg.default_layout).as_bytes()?)?;
         }
-        SubCommand::CycleLayout() => {
-            send_message(&SocketMessage::CycleLayout().as_bytes()?)?;
+        SubCommand::CycleLayout(arg) => {
+            send_message(&SocketMessage::CycleLayout(arg.cycle_direction).as_bytes()?)?;
         }
         SubCommand::LoadCustomLayout(arg) => {
             send_message(


### PR DESCRIPTION
Resolves issue: https://github.com/LGUG2Z/komorebi/issues/555#issuecomment-1751916248.

This PR:

- Adds command to support `Cycle(CycleDirection)` using `cycle_next` and `cycle_previous` on DefaultLayout
- As per discussion, this PR will only support cycling layouts for DefaultLayout and not for CustomLayout. https://github.com/LGUG2Z/komorebi/pull/556#discussion_r1349709174 <- Discussion link