### PR TITLE
refactor: cleanup path handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +830,8 @@ version = "0.1.19"
 dependencies = [
  "clap",
  "color-eyre",
+ "dirs",
+ "dunce",
  "schemars",
  "serde",
  "serde_json",
@@ -840,6 +848,7 @@ dependencies = [
  "color-eyre",
  "derive-ahk",
  "dirs",
+ "dunce",
  "fs-tail",
  "heck",
  "komorebi-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
 [workspace.dependencies]
 windows-interface = { version = "0.52" }
 windows-implement = { version = "0.52" }
+dunce = "1"
+dirs = "5"
+color-eyre = "0.6"
 
 [workspace.dependencies.windows]
 version = "0.52"

--- a/komorebi-core/Cargo.toml
+++ b/komorebi-core/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-color-eyre = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 strum = { version = "0.25", features = ["derive"] }
 schemars = "0.8"
+color-eyre = { workspace = true }
 windows = { workspace = true }
+dunce = { workspace = true }
+dirs = { workspace = true }

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -15,11 +15,9 @@ komorebi-core = { path = "../komorebi-core" }
 
 bitflags = "2"
 clap = { version = "4", features = ["derive"] }
-color-eyre = "0.6"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"
 ctrlc = "3"
-dirs = "5"
 getset = "0.1"
 hotwatch = "0.4"
 lazy_static = "1"
@@ -45,6 +43,8 @@ winreg = "0.52"
 windows-interface = { workspace = true }
 windows-implement = { workspace = true }
 windows = { workspace = true }
+color-eyre = { workspace = true }
+dirs = { workspace = true }
 
 [features]
 deadlock_detection = []

--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
-use color_eyre::eyre::anyhow;
 use color_eyre::Result;
 use crossbeam_channel::Receiver;
 use crossbeam_channel::Sender;
@@ -252,7 +251,7 @@ fn setup() -> Result<(WorkerGuard, WorkerGuard)> {
         std::env::set_var("RUST_LOG", "info");
     }
 
-    let appender = tracing_appender::rolling::never(DATA_DIR.clone(), "komorebi.log");
+    let appender = tracing_appender::rolling::never(&*DATA_DIR, "komorebi.log");
     let color_appender = tracing_appender::rolling::never(std::env::temp_dir(), "komorebi.log");
     let (non_blocking, guard) = tracing_appender::non_blocking(appender);
     let (color_non_blocking, color_guard) = tracing_appender::non_blocking(color_appender);
@@ -305,13 +304,8 @@ fn setup() -> Result<(WorkerGuard, WorkerGuard)> {
 }
 
 pub fn load_configuration() -> Result<()> {
-    let home = HOME_DIR.clone();
-
-    let mut config_pwsh = home.clone();
-    config_pwsh.push("komorebi.ps1");
-
-    let mut config_ahk = home;
-    config_ahk.push("komorebi.ahk");
+    let config_pwsh = HOME_DIR.join("komorebi.ps1");
+    let config_ahk = HOME_DIR.join("komorebi.ahk");
 
     if config_pwsh.exists() {
         let powershell_exe = if which("pwsh.exe").is_ok() {
@@ -320,25 +314,13 @@ pub fn load_configuration() -> Result<()> {
             "powershell.exe"
         };
 
-        tracing::info!(
-            "loading configuration file: {}",
-            config_pwsh
-                .as_os_str()
-                .to_str()
-                .ok_or_else(|| anyhow!("cannot convert path to string"))?
-        );
+        tracing::info!("loading configuration file: {}", config_pwsh.display());
 
         Command::new(powershell_exe)
             .arg(config_pwsh.as_os_str())
             .output()?;
     } else if config_ahk.exists() && which(&*AHK_EXE).is_ok() {
-        tracing::info!(
-            "loading configuration file: {}",
-            config_ahk
-                .as_os_str()
-                .to_str()
-                .ok_or_else(|| anyhow!("cannot convert path to string"))?
-        );
+        tracing::info!("loading configuration file: {}", config_ahk.display());
 
         Command::new(&*AHK_EXE)
             .arg(config_ahk.as_os_str())
@@ -410,7 +392,7 @@ pub fn notify_subscribers(notification: &str) -> Result<()> {
     let mut subscriptions = SUBSCRIPTION_PIPES.lock();
     for (subscriber, pipe) in &mut *subscriptions {
         match writeln!(pipe, "{notification}") {
-            Ok(_) => {
+            Ok(()) => {
                 tracing::debug!("pushed notification to subscriber: {}", subscriber);
             }
             Err(error) => {
@@ -528,7 +510,7 @@ fn main() -> Result<()> {
     let wm = if let Some(config) = &opts.config {
         tracing::info!(
             "creating window manager from static configuration file: {}",
-            config.as_os_str().to_str().unwrap()
+            config.display()
         );
 
         Arc::new(Mutex::new(StaticConfig::preload(
@@ -557,9 +539,7 @@ fn main() -> Result<()> {
     }
 
     if opts.config.is_none() {
-        std::thread::spawn(|| {
-            load_configuration().expect("could not load configuration");
-        });
+        std::thread::spawn(|| load_configuration().expect("could not load configuration"));
 
         if opts.await_configuration {
             let backoff = Backoff::new();

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use color_eyre::eyre::anyhow;
+use color_eyre::eyre::bail;
 use color_eyre::Result;
 use getset::CopyGetters;
 use getset::Getters;
@@ -120,9 +121,7 @@ impl Monitor {
             .ok_or_else(|| anyhow!("there is no workspace"))?;
 
         if workspace.maximized_window().is_some() {
-            return Err(anyhow!(
-                "cannot move native maximized window to another monitor or workspace"
-            ));
+            bail!("cannot move native maximized window to another monitor or workspace");
         }
 
         let container = workspace

--- a/komorebi/src/process_movement.rs
+++ b/komorebi/src/process_movement.rs
@@ -31,7 +31,7 @@ pub fn listen_for_movements(wm: Arc<Mutex<WindowManager>>) {
                     Event::MouseMoveRelative { .. } => {
                         if !ignore_movement {
                             match wm.lock().raise_window_at_cursor_pos() {
-                                Ok(_) => {}
+                                Ok(()) => {}
                                 Err(error) => tracing::error!("{}", error),
                             }
                         }

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -241,7 +241,7 @@ impl Window {
 
         // Raise Window to foreground
         match WindowsApi::set_foreground_window(self.hwnd()) {
-            Ok(_) => {}
+            Ok(()) => {}
             Err(error) => {
                 tracing::error!(
                     "could not set as foreground window, but continuing execution of raise(): {}",
@@ -252,7 +252,7 @@ impl Window {
 
         // This isn't really needed when the above command works as expected via AHK
         match WindowsApi::set_focus(self.hwnd()) {
-            Ok(_) => {}
+            Ok(()) => {}
             Err(error) => {
                 tracing::error!(
                     "could not set focus, but continuing execution of raise(): {}",
@@ -302,7 +302,7 @@ impl Window {
             }
 
             match WindowsApi::set_foreground_window(self.hwnd()) {
-                Ok(_) => {
+                Ok(()) => {
                     foregrounded = true;
                 }
                 Err(error) => {
@@ -334,7 +334,7 @@ impl Window {
 
         // This isn't really needed when the above command works as expected via AHK
         match WindowsApi::set_focus(self.hwnd()) {
-            Ok(_) => {}
+            Ok(()) => {}
             Err(error) => {
                 tracing::error!(
                     "could not set focus, but continuing execution of focus(): {}",

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -368,7 +368,7 @@ impl WindowsApi {
 
     pub fn close_window(hwnd: HWND) -> Result<()> {
         match Self::post_message(hwnd, WM_CLOSE, WPARAM(0), LPARAM(0)) {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
             Err(_) => Err(anyhow!("could not close window")),
         }
     }

--- a/komorebi/src/winevent_listener.rs
+++ b/komorebi/src/winevent_listener.rs
@@ -61,7 +61,7 @@ impl WinEventListener {
             MessageLoop::start(10, |_msg| {
                 if let Ok(event) = WINEVENT_CALLBACK_CHANNEL.lock().1.try_recv() {
                     match outgoing.send(event) {
-                        Ok(_) => {}
+                        Ok(()) => {}
                         Err(error) => {
                             tracing::error!("{}", error);
                         }

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -108,7 +108,7 @@ impl Workspace {
         }
 
         if let Some(pathbuf) = &config.custom_layout {
-            let layout = CustomLayout::from_path_buf(pathbuf.clone())?;
+            let layout = CustomLayout::from_path(pathbuf)?;
             self.layout = Layout::Custom(layout);
             self.tile = true;
         }
@@ -129,7 +129,7 @@ impl Workspace {
         if let Some(layout_rules) = &config.custom_layout_rules {
             let rules = self.layout_rules_mut();
             for (count, pathbuf) in layout_rules {
-                let rule = CustomLayout::from_path_buf(pathbuf.clone())?;
+                let rule = CustomLayout::from_path(pathbuf)?;
                 rules.push((*count, Layout::Custom(rule)));
             }
         }

--- a/komorebic/Cargo.toml
+++ b/komorebic/Cargo.toml
@@ -15,8 +15,6 @@ derive-ahk = { path = "../derive-ahk" }
 komorebi-core = { path = "../komorebi-core" }
 
 clap = { version = "4", features = ["derive", "wrap_help"] }
-color-eyre = "0.6"
-dirs = "5"
 fs-tail = "0.1"
 heck = "0.4"
 lazy_static = "1"
@@ -30,3 +28,6 @@ sysinfo = "0.29"
 uds_windows = "1"
 which = "5"
 windows = { workspace = true }
+color-eyre = { workspace = true }
+dirs = { workspace = true }
+dunce = { workspace = true }


### PR DESCRIPTION
I was just wandering around the codebase to get a bit familiar with it and it turned to a session of small refactors around paths handling.

This PR:
- Avoids unnecessary string allocation when tracing paths
- Replaces `mut path & path.push()` with `path.join()` which is nicer and more concise and the cost is the same since it was already allocating when cloning
- Avoids unncessary cloning of paths where applicable
- Use `dunce` crate to remove `UNC` prefix
- Improve performance of resolving `~` by avoiding unnecessary string allocations
- Resolve `~`, `$Env:USERPROFILE` and `$HOME` consistenly between different code paths
- Use `PathBuf` instead of `String` for paths in CLI args

I may have missed a couple of places but I think I covered 90% of path handling in the codebase