### PR TITLE
komorebi{,-core}: use window bounds without shadow

### DIFF
--- a/komorebi-core/src/rect.rs
+++ b/komorebi-core/src/rect.rs
@@ -43,4 +43,14 @@ impl Rect {
             && point.1 >= self.top
             && point.1 <= self.top + self.bottom
     }
+
+    #[must_use]
+    pub const fn scale(&self, system_dpi: i32, rect_dpi: i32) -> Rect {
+        Rect {
+            left: (self.left * rect_dpi) / system_dpi,
+            top: (self.top * rect_dpi) / system_dpi,
+            right: (self.right * rect_dpi) / system_dpi,
+            bottom: (self.bottom * rect_dpi) / system_dpi,
+        }
+    }
 }


### PR DESCRIPTION
Switch to using the DWM API to get Window bounds so as to exclude the outside of window decorations from the computation.

This is getting close to a precise window size, you can now set an active border width of 1 and an offset of 1 and get a 1 pixel line around most windows, except that there's some extra top padding I have yet to find the cause of.

This implementation needs to be DPI aware, but I haven't yet tested if the DPI scaling approach is entirely valid - we may instead need to get the per-monitor DPI scale, identify the monitor the window is on, and scale to that, rather than using the system wide scale.

Maybe fixes #574
Maybe updates #622

------

This almost certainly needs some extra testing and potentially some refinement before landing, see the information in the commit message above - but it's a start!