### PR TITLE
fix(component): fix ahk invocation by adding quotes around arguments

### DIFF
--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -1764,7 +1764,7 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
 
                 let script = format!(
                     r#"
-  Start-Process {ahk} {config} -WindowStyle hidden
+  Start-Process '{ahk}' '{config}' -WindowStyle hidden
                 "#,
                     config = config_ahk.display()
                 );


### PR DESCRIPTION
Fixes ahk launch with static config if user has spaces in arguments for ahk (ahk exe path or komorebi home directory)

Small test:
![image](https://github.com/LGUG2Z/komorebi/assets/76776123/faf3c0eb-3c08-4982-a1c1-fdee74984f0a)
