### PR TITLE
docs(readme): If the PowerShell user profile file does not exist create

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,9 @@ For example, to use the `~/.config/komorebi` directory:
 # Run this command to make sure that the directory has been created
 mkdir -p ~/.config/komorebi
 
+Run this command to make sure that the PowerShell profile configuration file exists. If it does not exist, this command creates one
+if (-not (Test-Path $PROFILE)) { new-item $profile -ItemType file }
+
 # Run this command to open up your PowerShell profile configuration in Notepad
 notepad $PROFILE
 


### PR DESCRIPTION
If the PowerShell user profile file does not exist (not by default), the user will get an error message. This command is safe to use because it does not overwrite the file if it exists.