### PR TITLE
feat: add a rust client interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,11 +843,13 @@ dependencies = [
  "color-eyre",
  "dirs",
  "dunce",
+ "lazy_static",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
  "strum",
+ "uds_windows",
  "windows",
 ]
 

--- a/komorebi-core/Cargo.toml
+++ b/komorebi-core/Cargo.toml
@@ -16,3 +16,5 @@ color-eyre = { workspace = true }
 windows = { workspace = true }
 dunce = { workspace = true }
 dirs = { workspace = true }
+lazy_static = "1"
+uds_windows = "1"

--- a/komorebi-core/src/client.rs
+++ b/komorebi-core/src/client.rs
@@ -1,0 +1,67 @@
+use crate::SocketMessage;
+use color_eyre::Result;
+use lazy_static::lazy_static;
+use serde::de::DeserializeOwned;
+use std::io::Write;
+use std::{
+    io::{BufReader, ErrorKind},
+    path::PathBuf,
+};
+use uds_windows::{UnixListener, UnixStream};
+
+lazy_static! {
+    static ref DATA_DIR: PathBuf = dirs::data_local_dir()
+        .expect("there is no local data directory")
+        .join("komorebi");
+}
+
+fn send_message(bytes: &[u8]) -> Result<()> {
+    let socket = DATA_DIR.join("komorebi.sock");
+
+    let mut connected = false;
+    while !connected {
+        if let Ok(mut stream) = UnixStream::connect(&socket) {
+            connected = true;
+            stream.write_all(bytes)?;
+        }
+    }
+
+    Ok(())
+}
+pub trait SendMessage {
+    fn send(self) -> Result<()>;
+    fn send_receive<T: DeserializeOwned>(self) -> Result<T>;
+}
+impl SendMessage for SocketMessage {
+    fn send(self) -> Result<()> {
+        send_message(&self.as_bytes()?)
+    }
+
+    fn send_receive<T: DeserializeOwned>(self) -> Result<T> {
+        let socket = DATA_DIR.join("komorebic.sock");
+
+        match std::fs::remove_file(&socket) {
+            Ok(()) => {}
+            Err(error) => match error.kind() {
+                // Doing this because ::exists() doesn't work reliably on Windows via IntelliJ
+                ErrorKind::NotFound => {}
+                _ => {
+                    return Err(error.into());
+                }
+            },
+        };
+
+        self.send()?;
+
+        let listener = UnixListener::bind(socket)?;
+        match listener.accept() {
+            Ok(incoming) => {
+                let reader = BufReader::new(incoming.0);
+                return Ok(serde_json::from_reader(reader)?);
+            }
+            Err(error) => {
+                panic!("{}", error);
+            }
+        }
+    }
+}

--- a/komorebi-core/src/lib.rs
+++ b/komorebi-core/src/lib.rs
@@ -33,6 +33,8 @@ pub mod direction;
 pub mod layout;
 pub mod operation_direction;
 pub mod rect;
+pub mod state;
+pub mod client;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Display, JsonSchema)]
 #[serde(tag = "type", content = "content")]

--- a/komorebi-core/src/state.rs
+++ b/komorebi-core/src/state.rs
@@ -1,0 +1,85 @@
+use std::collections::{HashMap, VecDeque};
+
+use serde::Deserialize;
+
+use crate::{config_generation::IdWithIdentifier, Axis, FocusFollowsMouseImplementation, Layout, MoveBehaviour, WindowContainerBehaviour};
+
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, Eq, PartialEq)]
+pub struct Rect {
+    pub left: i32,
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Window {
+    pub hwnd: isize,
+    pub title: String,
+    pub exe: String,
+    pub class: String,
+    pub rect: Rect
+}
+#[derive(Debug, Clone, Deserialize)]
+pub struct Ring<T> {
+    pub elements: VecDeque<T>,
+    pub focused: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Container {
+    pub windows: Ring<Window>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Workspace {
+    pub name: Option<String>,
+    pub containers: Ring<Container>,
+    pub monocle_container: Option<Container>,
+    pub maximized_window: Option<Window>,
+    pub floating_windows: Vec<Window>,
+    pub layout: Layout,
+    pub layout_rules: Vec<(usize, Layout)>,
+    pub layout_flip: Option<Axis>,
+    pub workspace_padding: Option<i32>,
+    pub container_padding: Option<i32>,
+    pub resize_dimensions: Vec<Option<Rect>>,
+    pub tile: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Monitor {
+    pub id: isize,
+    pub name: String,
+    pub device: Option<String>,
+    pub device_id: Option<String>,
+    pub size: Rect,
+    pub work_area_size: Rect,
+    pub work_area_offset: Option<Rect>,
+    pub workspaces: Ring<Workspace>,
+}
+
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Deserialize)]
+pub struct State {
+    pub monitors: Ring<Monitor>,
+    pub is_paused: bool,
+    pub invisible_borders: Rect,
+    pub resize_delta: i32,
+    pub new_window_behaviour: WindowContainerBehaviour,
+    pub cross_monitor_move_behaviour: MoveBehaviour,
+    pub work_area_offset: Option<Rect>,
+    pub focus_follows_mouse: Option<FocusFollowsMouseImplementation>,
+    pub mouse_follows_focus: bool,
+    pub has_pending_raise_op: bool,
+    pub remove_titlebars: bool,
+    pub float_identifiers: Vec<IdWithIdentifier>,
+    pub manage_identifiers: Vec<IdWithIdentifier>,
+    pub layered_whitelist: Vec<IdWithIdentifier>,
+    pub tray_and_multi_window_identifiers: Vec<IdWithIdentifier>,
+    pub border_overflow_identifiers: Vec<IdWithIdentifier>,
+    pub name_change_on_launch_identifiers: Vec<IdWithIdentifier>,
+    pub monitor_index_preferences: HashMap<usize, Rect>,
+    pub display_index_preferences: HashMap<usize, String>
+}


### PR DESCRIPTION
This allows to create a pure rust client without having to go via CLI

We also make the state data available in the core so that we can deserialize

```rust
use komorebi_core::client::SendMessage;
use komorebi_core::SocketMessage;
use komorebi_core::state::State;

fn main() {
    let state: State = SocketMessage::State.send_receive().unwrap();
    println!("{:#?}", state);
}
```

My eventual goal is to make a topbar with the slint ui framework in pure rust, and make it easier to integrate with the komorebi state.

Probably there is a bit of cleanup to be merged, but I'd like to get your early feedback on wether this would be a goal to publish koromebi-core in crates.io
