### PR TITLE
Simpler and more precise border production

### DIFF
--- a/komorebi-core/src/arrangement.rs
+++ b/komorebi-core/src/arrangement.rs
@@ -135,7 +135,7 @@ impl Arrangement for DefaultLayout {
 
         dimensions
             .iter_mut()
-            .for_each(|l| l.add_padding(container_padding));
+            .for_each(|l| l.add_padding(container_padding.unwrap_or_default()));
 
         dimensions
     }
@@ -258,7 +258,7 @@ impl Arrangement for CustomLayout {
 
         dimensions
             .iter_mut()
-            .for_each(|l| l.add_padding(container_padding));
+            .for_each(|l| l.add_padding(container_padding.unwrap_or_default()));
 
         dimensions
     }

--- a/komorebi-core/src/rect.rs
+++ b/komorebi-core/src/rect.rs
@@ -27,13 +27,20 @@ impl From<RECT> for Rect {
 }
 
 impl Rect {
-    pub fn add_padding(&mut self, padding: Option<i32>) {
-        if let Some(padding) = padding {
-            self.left += padding;
-            self.top += padding;
-            self.right -= padding * 2;
-            self.bottom -= padding * 2;
-        }
+    /// decrease the size of self by the padding amount.
+    pub fn add_padding(&mut self, padding: i32) {
+        self.left += padding;
+        self.top += padding;
+        self.right -= padding * 2;
+        self.bottom -= padding * 2;
+    }
+
+    /// increase the size of self by the margin amount.
+    pub fn add_margin(&mut self, margin: i32) {
+        self.left -= margin;
+        self.top -= margin;
+        self.right += margin * 2;
+        self.bottom += margin * 2;
     }
 
     #[must_use]

--- a/komorebi-core/src/rect.rs
+++ b/komorebi-core/src/rect.rs
@@ -43,4 +43,14 @@ impl Rect {
             && point.1 >= self.top
             && point.1 <= self.top + self.bottom
     }
+
+    #[must_use]
+    pub const fn scale(&self, system_dpi: i32, rect_dpi: i32) -> Rect {
+        Rect {
+            left: (self.left * rect_dpi) / system_dpi,
+            top: (self.top * rect_dpi) / system_dpi,
+            right: (self.right * rect_dpi) / system_dpi,
+            bottom: (self.bottom * rect_dpi) / system_dpi,
+        }
+    }
 }

--- a/komorebi/src/border.rs
+++ b/komorebi/src/border.rs
@@ -17,8 +17,8 @@ use crate::WindowsApi;
 use crate::BORDER_HWND;
 use crate::BORDER_OFFSET;
 use crate::BORDER_RECT;
+use crate::BORDER_WIDTH;
 use crate::TRANSPARENCY_COLOUR;
-use crate::WINDOWS_11;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Border {
@@ -75,10 +75,6 @@ impl Border {
 
         BORDER_HWND.store(hwnd.0, Ordering::SeqCst);
 
-        if *WINDOWS_11 {
-            WindowsApi::round_corners(hwnd.0)?;
-        }
-
         Ok(())
     }
 
@@ -111,6 +107,13 @@ impl Border {
                 rect.right += border_offset.right;
                 rect.bottom += border_offset.bottom;
             }
+
+            let border_width = BORDER_WIDTH.load(Ordering::SeqCst);
+
+            rect.left -= border_width;
+            rect.top -= border_width;
+            rect.right += border_width * 2;
+            rect.bottom += border_width * 2;
 
             *BORDER_RECT.lock() = rect;
 

--- a/komorebi/src/border.rs
+++ b/komorebi/src/border.rs
@@ -99,21 +99,10 @@ impl Border {
             }
 
             let mut rect = WindowsApi::window_rect(window.hwnd())?;
-
-            let border_offset = BORDER_OFFSET.lock();
-            if let Some(border_offset) = *border_offset {
-                rect.left -= border_offset.left;
-                rect.top -= border_offset.top;
-                rect.right += border_offset.right;
-                rect.bottom += border_offset.bottom;
-            }
+            rect.add_padding(-BORDER_OFFSET.load(Ordering::SeqCst));
 
             let border_width = BORDER_WIDTH.load(Ordering::SeqCst);
-
-            rect.left -= border_width;
-            rect.top -= border_width;
-            rect.right += border_width * 2;
-            rect.bottom += border_width * 2;
+            rect.add_margin(border_width);
 
             *BORDER_RECT.lock() = rect;
 

--- a/komorebi/src/lib.rs
+++ b/komorebi/src/lib.rs
@@ -191,8 +191,7 @@ lazy_static! {
     static ref BORDER_RECT: Arc<Mutex<Rect>> =
         Arc::new(Mutex::new(Rect::default()));
 
-    static ref BORDER_OFFSET: Arc<Mutex<Option<Rect>>> =
-        Arc::new(Mutex::new(None));
+    static ref BORDER_OFFSET: AtomicI32 = Default::default();
 
     // Use app-specific titlebar removal options where possible
     // eg. Windows Terminal, IntelliJ IDEA, Firefox

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -195,7 +195,6 @@ impl Monitor {
     pub fn update_focused_workspace(
         &mut self,
         offset: Option<Rect>,
-        invisible_borders: &Rect,
     ) -> Result<()> {
         let work_area = *self.work_area_size();
         let offset = if self.work_area_offset().is_some() {
@@ -206,7 +205,7 @@ impl Monitor {
 
         self.focused_workspace_mut()
             .ok_or_else(|| anyhow!("there is no workspace"))?
-            .update(&work_area, offset, invisible_borders)?;
+            .update(&work_area, offset)?;
 
         Ok(())
     }

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -304,7 +304,6 @@ impl WindowManager {
                     });
                 }
 
-                let invisible_borders = self.invisible_borders;
                 let offset = self.work_area_offset;
 
                 let mut hwnds_to_purge = vec![];
@@ -347,7 +346,7 @@ impl WindowManager {
                         .ok_or_else(|| anyhow!("there is no focused workspace"))?
                         .remove_window(hwnd)?;
 
-                    monitor.update_focused_workspace(offset, &invisible_borders)?;
+                    monitor.update_focused_workspace(offset)?;
                 }
             }
             SocketMessage::FocusedWorkspaceContainerPadding(adjustment) => {
@@ -1093,10 +1092,7 @@ impl WindowManager {
             SocketMessage::UnmanageFocusedWindow => {
                 self.unmanage_focused_window()?;
             }
-            SocketMessage::InvisibleBorders(rect) => {
-                self.invisible_borders = rect;
-                self.retile_all(false)?;
-            }
+            SocketMessage::InvisibleBorders(_rect) => {}
             SocketMessage::WorkAreaOffset(rect) => {
                 self.work_area_offset = Option::from(rect);
                 self.retile_all(false)?;
@@ -1389,9 +1385,6 @@ impl WindowManager {
             | SocketMessage::FocusWorkspaceNumber(_) => {
                 let foreground = WindowsApi::foreground_window()?;
                 let foreground_window = Window { hwnd: foreground };
-                let mut rect = WindowsApi::window_rect(foreground_window.hwnd())?;
-                rect.top -= self.invisible_borders.bottom;
-                rect.bottom += self.invisible_borders.bottom;
 
                 let monocle = BORDER_COLOUR_MONOCLE.load(Ordering::SeqCst);
                 if monocle != 0 && self.focused_workspace()?.monocle_container().is_some() {
@@ -1408,7 +1401,7 @@ impl WindowManager {
                 }
 
                 let border = Border::from(BORDER_HWND.load(Ordering::SeqCst));
-                border.set_position(foreground_window, &self.invisible_borders, false)?;
+                border.set_position(foreground_window, false)?;
             }
             SocketMessage::TogglePause => {
                 let is_paused = self.is_paused;
@@ -1418,7 +1411,7 @@ impl WindowManager {
                     border.hide()?;
                 } else {
                     let focused = self.focused_window()?;
-                    border.set_position(*focused, &self.invisible_borders, true)?;
+                    border.set_position(*focused, true)?;
                     focused.focus(false)?;
                 }
             }
@@ -1428,7 +1421,7 @@ impl WindowManager {
 
                 if tiling_enabled {
                     let focused = self.focused_window()?;
-                    border.set_position(*focused, &self.invisible_borders, true)?;
+                    border.set_position(*focused, true)?;
                     focused.focus(false)?;
                 } else {
                     border.hide()?;

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1248,17 +1248,7 @@ impl WindowManager {
                 WindowsApi::invalidate_border_rect()?;
             }
             SocketMessage::ActiveWindowBorderOffset(offset) => {
-                let mut current_border_offset = BORDER_OFFSET.lock();
-
-                let new_border_offset = Rect {
-                    left: offset,
-                    top: offset,
-                    right: offset * 2,
-                    bottom: offset * 2,
-                };
-
-                *current_border_offset = Option::from(new_border_offset);
-
+                BORDER_OFFSET.store(offset, Ordering::SeqCst);
                 WindowsApi::invalidate_border_rect()?;
             }
             SocketMessage::AltFocusHack(enable) => {

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -316,13 +316,6 @@ pub struct StaticConfig {
 impl From<&WindowManager> for StaticConfig {
     #[allow(clippy::too_many_lines)]
     fn from(value: &WindowManager) -> Self {
-        let default_invisible_borders = Rect {
-            left: 7,
-            top: 0,
-            right: 14,
-            bottom: 7,
-        };
-
         let mut monitors = vec![];
         for m in value.monitors() {
             monitors.push(MonitorConfig::from(m));
@@ -392,11 +385,7 @@ impl From<&WindowManager> for StaticConfig {
         };
 
         Self {
-            invisible_borders: if value.invisible_borders == default_invisible_borders {
-                None
-            } else {
-                Option::from(value.invisible_borders)
-            },
+            invisible_borders: None,
             resize_delta: Option::from(value.resize_delta),
             window_container_behaviour: Option::from(value.window_container_behaviour),
             cross_monitor_move_behaviour: Option::from(value.cross_monitor_move_behaviour),
@@ -775,12 +764,6 @@ impl StaticConfig {
             incoming_events: incoming,
             command_listener: listener,
             is_paused: false,
-            invisible_borders: value.invisible_borders.unwrap_or(Rect {
-                left: 7,
-                top: 0,
-                right: 14,
-                bottom: 7,
-            }),
             virtual_desktop_id: current_virtual_desktop(),
             work_area_offset: value.global_work_area_offset,
             window_container_behaviour: value
@@ -925,10 +908,6 @@ impl StaticConfig {
         } else {
             BORDER_ENABLED.store(false, Ordering::SeqCst);
             wm.hide_border()?;
-        }
-
-        if let Some(val) = value.invisible_borders {
-            wm.invisible_borders = val;
         }
 
         if let Some(val) = value.window_container_behaviour {

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -449,14 +449,14 @@ impl StaticConfig {
 
         self.active_window_border_width.map_or_else(
             || {
-                BORDER_WIDTH.store(20, Ordering::SeqCst);
+                BORDER_WIDTH.store(8, Ordering::SeqCst);
             },
             |width| {
                 BORDER_WIDTH.store(width, Ordering::SeqCst);
             },
         );
 
-        BORDER_OFFSET.store(self.active_window_border_offset.unwrap_or_default(), Ordering::SeqCst);
+        BORDER_OFFSET.store(self.active_window_border_offset.unwrap_or(-1), Ordering::SeqCst);
 
         if let Some(colours) = &self.active_window_border_colours {
             BORDER_COLOUR_SINGLE.store(

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -32,7 +32,6 @@ use crate::styles::WindowStyle;
 use crate::window_manager_event::WindowManagerEvent;
 use crate::windows_api::WindowsApi;
 use crate::ALT_FOCUS_HACK;
-use crate::BORDER_OVERFLOW_IDENTIFIERS;
 use crate::FLOAT_IDENTIFIERS;
 use crate::HIDDEN_HWNDS;
 use crate::HIDING_BEHAVIOUR;
@@ -129,7 +128,7 @@ impl Window {
         HWND(self.hwnd)
     }
 
-    pub fn center(&mut self, work_area: &Rect, invisible_borders: &Rect) -> Result<()> {
+    pub fn center(&mut self, work_area: &Rect) -> Result<()> {
         let half_width = work_area.right / 2;
         let half_weight = work_area.bottom / 2;
 
@@ -140,7 +139,6 @@ impl Window {
                 right: half_width,
                 bottom: half_weight,
             },
-            invisible_borders,
             true,
         )
     }
@@ -148,34 +146,9 @@ impl Window {
     pub fn set_position(
         &mut self,
         layout: &Rect,
-        invisible_borders: &Rect,
         top: bool,
     ) -> Result<()> {
-        let mut rect = *layout;
-
-        let border_overflows = BORDER_OVERFLOW_IDENTIFIERS.lock();
-        let regex_identifiers = REGEX_IDENTIFIERS.lock();
-
-        let title = &self.title()?;
-        let class = &self.class()?;
-        let exe_name = &self.exe()?;
-
-        let should_remove_border = !should_act(
-            title,
-            exe_name,
-            class,
-            &border_overflows,
-            &regex_identifiers,
-        );
-
-        if should_remove_border {
-            // Remove the invisible borders
-            rect.left -= invisible_borders.left;
-            rect.top -= invisible_borders.top;
-            rect.right += invisible_borders.right;
-            rect.bottom += invisible_borders.bottom;
-        }
-
+        let rect = *layout;
         WindowsApi::position_window(self.hwnd(), &rect, top)
     }
 

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -103,7 +103,7 @@ use windows::Win32::UI::WindowsAndMessaging::GWL_EXSTYLE;
 use windows::Win32::UI::WindowsAndMessaging::GWL_STYLE;
 use windows::Win32::UI::WindowsAndMessaging::GW_HWNDNEXT;
 use windows::Win32::UI::WindowsAndMessaging::HWND_BOTTOM;
-use windows::Win32::UI::WindowsAndMessaging::HWND_TOPMOST;
+use windows::Win32::UI::WindowsAndMessaging::HWND_TOP;
 use windows::Win32::UI::WindowsAndMessaging::LWA_ALPHA;
 use windows::Win32::UI::WindowsAndMessaging::LWA_COLORKEY;
 use windows::Win32::UI::WindowsAndMessaging::SET_WINDOW_POS_FLAGS;
@@ -358,7 +358,7 @@ impl WindowsApi {
             bottom: layout.bottom + shadow_rect.bottom,
         };
 
-        let position = if top { HWND_TOPMOST } else { HWND_BOTTOM };
+        let position = if top { HWND_TOP } else { HWND_BOTTOM };
         Self::set_window_pos(hwnd, &rect, position, flags.bits())
     }
 
@@ -369,7 +369,7 @@ impl WindowsApi {
     pub fn raise_window(hwnd: HWND) -> Result<()> {
         let flags = SetWindowPosition::NO_MOVE;
 
-        let position = HWND_TOPMOST;
+        let position = HWND_TOP;
         Self::set_window_pos(hwnd, &Rect::default(), position, flags.bits())
     }
 
@@ -380,12 +380,13 @@ impl WindowsApi {
             SetWindowPosition::NO_ACTIVATE
         };
 
-        // Always raise the border window to topmost, so that when it is a
-        // single-pixel inset border, it always draws atop the window (i.e.
-        // support an offset of -1 that draws over the Windows 11 default
-        // translucent single pixel border, while reamining visible in cases
-        // such as the EPIC Games launcher that uses an opaque custom border).
-        let position = HWND_TOPMOST;
+        // Always raise the border window to the top, but not overlapping
+        // topmost windows, so that when it is a single-pixel inset border, it
+        // always draws atop the window (i.e.  support an offset of -1 that
+        // draws over the Windows 11 default translucent single pixel border,
+        // while reamining visible in cases such as the EPIC Games launcher that
+        // uses an opaque custom border).
+        let position = HWND_TOP;
         Self::set_window_pos(hwnd, layout, position, flags.bits())
     }
 

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -129,8 +129,7 @@ use windows::Win32::UI::WindowsAndMessaging::WS_DISABLED;
 use windows::Win32::UI::WindowsAndMessaging::WS_EX_LAYERED;
 use windows::Win32::UI::WindowsAndMessaging::WS_EX_NOACTIVATE;
 use windows::Win32::UI::WindowsAndMessaging::WS_EX_TOOLWINDOW;
-use windows::Win32::UI::WindowsAndMessaging::WS_MAXIMIZEBOX;
-use windows::Win32::UI::WindowsAndMessaging::WS_MINIMIZEBOX;
+use windows::Win32::UI::WindowsAndMessaging::WS_EX_TOPMOST;
 use windows::Win32::UI::WindowsAndMessaging::WS_POPUP;
 use windows::Win32::UI::WindowsAndMessaging::WS_SYSMENU;
 
@@ -858,10 +857,10 @@ impl WindowsApi {
     pub fn create_border_window(name: PCWSTR, instance: HMODULE) -> Result<isize> {
         unsafe {
             let hwnd = CreateWindowExW(
-                WS_EX_TOOLWINDOW | WS_EX_LAYERED,
+                WS_EX_TOOLWINDOW | WS_EX_LAYERED | WS_EX_TOPMOST | WS_EX_NOACTIVATE,
                 name,
                 name,
-                WS_POPUP | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX,
+                WS_POPUP | WS_SYSMENU,
                 CW_USEDEFAULT,
                 CW_USEDEFAULT,
                 CW_USEDEFAULT,

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -22,6 +22,7 @@ use windows::Win32::Foundation::WPARAM;
 use windows::Win32::Graphics::Dwm::DwmGetWindowAttribute;
 use windows::Win32::Graphics::Dwm::DwmSetWindowAttribute;
 use windows::Win32::Graphics::Dwm::DWMWA_CLOAKED;
+use windows::Win32::Graphics::Dwm::DWMWA_EXTENDED_FRAME_BOUNDS;
 use windows::Win32::Graphics::Dwm::DWMWA_WINDOW_CORNER_PREFERENCE;
 use windows::Win32::Graphics::Dwm::DWMWCP_ROUND;
 use windows::Win32::Graphics::Dwm::DWMWINDOWATTRIBUTE;
@@ -53,6 +54,8 @@ use windows::Win32::System::Threading::PROCESS_ACCESS_RIGHTS;
 use windows::Win32::System::Threading::PROCESS_NAME_WIN32;
 use windows::Win32::System::Threading::PROCESS_QUERY_INFORMATION;
 use windows::Win32::UI::HiDpi::GetDpiForMonitor;
+use windows::Win32::UI::HiDpi::GetDpiForSystem;
+use windows::Win32::UI::HiDpi::GetDpiForWindow;
 use windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext;
 use windows::Win32::UI::HiDpi::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2;
 use windows::Win32::UI::HiDpi::MDT_EFFECTIVE_DPI;
@@ -471,9 +474,15 @@ impl WindowsApi {
 
     pub fn window_rect(hwnd: HWND) -> Result<Rect> {
         let mut rect = unsafe { std::mem::zeroed() };
-        unsafe { GetWindowRect(hwnd, &mut rect) }.process()?;
 
-        Ok(Rect::from(rect))
+        if Self::dwm_get_window_attribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &mut rect).is_ok() {
+            let window_scale = unsafe { GetDpiForWindow(hwnd) };
+            let system_scale = unsafe { GetDpiForSystem() };
+            Ok(Rect::from(rect).scale(system_scale.try_into()?, window_scale.try_into()?))
+        } else {
+            unsafe { GetWindowRect(hwnd, &mut rect) }.process()?;
+            Ok(Rect::from(rect))
+        }
     }
 
     fn set_cursor_pos(x: i32, y: i32) -> Result<()> {

--- a/komorebi/src/windows_callbacks.rs
+++ b/komorebi/src/windows_callbacks.rs
@@ -229,7 +229,7 @@ pub extern "system" fn border_window(
                 // wrong size.  In the future we should read the DWM properties
                 // of windows and attempt to match appropriately.
                 if *WINDOWS_11 {
-                    RoundRect(hdc, 0, 0, border_rect.right, border_rect.bottom, 14, 14);
+                    RoundRect(hdc, 0, 0, border_rect.right, border_rect.bottom, 20, 20);
                 } else {
                     Rectangle(hdc, 0, 0, border_rect.right, border_rect.bottom);
                 }

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -205,7 +205,6 @@ impl Workspace {
         &mut self,
         work_area: &Rect,
         offset: Option<Rect>,
-        invisible_borders: &Rect,
     ) -> Result<()> {
         if !INITIAL_CONFIGURATION_LOADED.load(Ordering::SeqCst) {
             return Ok(());
@@ -253,7 +252,7 @@ impl Workspace {
             if let Some(container) = self.monocle_container_mut() {
                 if let Some(window) = container.focused_window_mut() {
                     adjusted_work_area.add_padding(container_padding);
-                    window.set_position(&adjusted_work_area, invisible_borders, true)?;
+                    window.set_position(&adjusted_work_area, true)?;
                 };
             } else if let Some(window) = self.maximized_window_mut() {
                 window.maximize();
@@ -288,7 +287,7 @@ impl Workspace {
                             WindowsApi::restore_window(window.hwnd());
                         }
 
-                        window.set_position(layout, invisible_borders, false)?;
+                        window.set_position(layout, false)?;
                     }
                 }
 

--- a/schema.json
+++ b/schema.json
@@ -107,12 +107,12 @@
       }
     },
     "active_window_border_offset": {
-      "description": "Offset of the active window border (default: None)",
+      "description": "Offset of the active window border (default: -1)",
       "type": "integer",
       "format": "int32"
     },
     "active_window_border_width": {
-      "description": "Width of the active window border (default: 20)",
+      "description": "Width of the active window border (default: 8)",
       "type": "integer",
       "format": "int32"
     },


### PR DESCRIPTION
This includes three changes that could be included independently though each has some side effect that is adjusted by the latter to better align with the overall goal.

I set out to remove the inconsistent gap and miscoloration around windows. This was originating in the interactions with DWM decorations.

First the API that we're using to read window size is shifted to one that returns Window dimensions without including the DWM/theme decorations.

Next in order to fix a number of new regressions vs. the application database, we needed to remove the use of the invisible borders - these were a side effect of the DWM decorations. They're no longer needed, as application Window dimensions are now correct, with one notable interaction with theming (below).

Finally we move away from allowing/using DWM decorations on the border window. While this was giving us a rounded corner, it was causing offset bugs due to the fact that the theme is not symmetrical. This was making it impossible to draw very thin borders correctly, for example few pixel borders.

There is one final caveat noted here, the problem exists already in a different form, but for the same as yet unresolved reasons. Single pixel borders work correctly with this setup but there remain overlapping concerns with the system them. The windows DWM theme adds an active window border as well, and how opaque this border is depends upon the theme (this is present even if the drop shadow is off). That border often produces what appears to be a single semi-transparent pixel border around the window that looks like a "gap" in many scenarios. Most users will want to set border-offset to -1 and then increase the border with by 1 to get a solid active window border color underneath the whole border edge, without bleeding through to the background or similar, that otherwise looks like a gap. This leaves what has the look and feel of a single pixel border in many scenarios except as follows.

As an example the Epic launcher uses a different DWM window style, that adjusts the border behavior. The border there is completely opaque and spills over a single pixel border window, effectively making the active border window invisible. For users trying to do that single pixel border style, it will effectively disappear under those windows. The correct fix for this is to interrogate the DWM border style of the windows we are decorating and adjust for this. As it stands right now I doubt any users are affected by this, as if they're arranging for single pixel borders today, they will be missing borders on many applications that have incorrect sizing and offsetting.

One final thing that is also worth considering for a near future, aside from detecting DWM styles for border edges, is to also use that to apply a small fixup on the window corner radius for those applications. Relatedly, we could also offer a general border radius option, and a really polished fix would work on addressing DWM properties that observe the default Windows 11 corner styles, where the bottom right "resizable border" has a non-cicular inset on the corner curve - we could fill that in, or conform to it (the latter requires doing some more fancy drawing).