### PR TITLE
fix(wm): adds special case for grid stacks to the right

### DIFF
--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1450,7 +1450,9 @@ impl WindowManager {
                 anyhow!("this is not a valid direction from the current position")
             })?;
 
-            let adjusted_new_index = if new_idx > current_container_idx {
+            let adjusted_new_index = if new_idx > current_container_idx
+                && !matches!(workspace.layout(), Layout::Default(DefaultLayout::Grid))
+            {
                 new_idx - 1
             } else {
                 new_idx


### PR DESCRIPTION
The default stacking behaviour for all layouts was to subtract 1 to the calculated index for movements to the right or down, basically, for any movement where the new index is greater than the current one. This was not working correctly for the Grid layout.

This PR adds a special case that prevents the adjustment to the target container index so it behaves correctly.