### PR TITLE
docs(example configs):  add default location for the whkdrc file

### DIFF
--- a/docs/example-configurations.md
+++ b/docs/example-configurations.md
@@ -162,7 +162,7 @@ If you like the `grid` layout in [LeftWM](https://github.com/leftwm/leftwm-layou
 ## whkdrc
 
 `whkd` is a fairly basic piece of software with a simple configuration format:
-key bindings go to the left of the, and shell commands go to the right of the
+key bindings go to the left of the colon, and shell commands go to the right of the
 colon.
 
 Please remember that `whkd` does not support overriding Microsoft's limitations

--- a/docs/example-configurations.md
+++ b/docs/example-configurations.md
@@ -163,7 +163,7 @@ If you like the `grid` layout in [LeftWM](https://github.com/leftwm/leftwm-layou
 
 `whkd` is a fairly basic piece of software with a simple configuration format:
 key bindings go to the left of the colon, and shell commands go to the right of the
-colon.
+colon. By default, the `whkdrc` file should be located in the `$Env:USERPROFILE/.config/` directory.
 
 Please remember that `whkd` does not support overriding Microsoft's limitations
 on hotkey bindings that include the `Windows` key. If this is important to you,


### PR DESCRIPTION
- Add the default location for the `whkdrc` file so it is explicit for new users
- Add missing word in the `whkdrc` section