### PR TITLE
komorebi: use a new method to focus windows

### DIFF
--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -822,10 +822,7 @@ impl WindowManager {
                 let rect = self.focused_monitor_size()?;
                 WindowsApi::center_cursor_in_rect(&rect)?;
 
-                // Calling this directly instead of the window.focus() wrapper because trying to
-                // attach to the thread of the desktop window always seems to result in "Access is
-                // denied (os error 5)"
-                match WindowsApi::set_foreground_window(desktop_window.hwnd()) {
+                match WindowsApi::raise_and_focus_window(desktop_window.hwnd()) {
                     Ok(()) => {}
                     Err(error) => {
                         tracing::warn!("{} {}:{}", error, file!(), line!());


### PR DESCRIPTION
Use the same method as FancyZones to enable setting the foreground window. This makes it possible then to remove the thread attachment behaviors that have a number of other complex side effects, and aren't always allowed. In addition, cleanup old focus/raise methods some, in particular the border window is now explicitly not activated when it is raised, as it should never be activated.

I've also left some breadcrumbs in comments from investigation that I did while doing QA, that highlighted other issues.