### PR TITLE
komorebi: hide the border window when unmanged windows are focused

### DIFF
--- a/komorebi/src/windows_callbacks.rs
+++ b/komorebi/src/windows_callbacks.rs
@@ -198,13 +198,9 @@ pub extern "system" fn win_event_hook(
         Some(event) => event,
     };
 
-    if let Ok(should_manage) = window.should_manage(Option::from(event_type)) {
-        if should_manage {
-            winevent_listener::event_tx()
-                .send(event_type)
-                .expect("could not send message on winevent_listener::event_tx");
-        }
-    }
+    winevent_listener::event_tx()
+        .send(event_type)
+        .expect("could not send message on winevent_listener::event_tx");
 }
 
 pub extern "system" fn border_window(


### PR DESCRIPTION
Previously we were dropping events that don't pertain to managed windows, with one exception in should_manage that could probably do with further cleanup (DisplayChange). This first step fixes the latent border window problem, where we would retain a border window when the last managed window was closed and focus transitioned to an unmanaged window.