### PR TITLE
komorebi: report full errors in debug mode

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -44,7 +44,13 @@ pub fn listen_for_events(wm: Arc<Mutex<WindowManager>>) {
             if let Ok(event) = receiver.recv() {
                 match wm.lock().process_event(event) {
                     Ok(()) => {}
-                    Err(error) => tracing::error!("{}", error),
+                    Err(error) => {
+                        if cfg!(debug_assertions) {
+                            tracing::error!("{:?}", error)
+                        } else {
+                            tracing::error!("{}", error)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This gives us a stack trace style error report in the log when in debug mode, which makes it much quicker to track down the origin of an error.