### PR TITLE
fix(wm): reduce errors from non-window events

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -92,14 +92,7 @@ impl WindowManager {
 
         // All event handlers below this point should only be processed if the event is
         // related to a window that should be managed by the WindowManager.
-        if !should_manage
-            && !matches!(
-                event,
-                WindowManagerEvent::DisplayChange(_)
-                    | WindowManagerEvent::ForceUpdate(_)
-                    | WindowManagerEvent::FocusChange(_, _)
-            )
-        {
+        if !should_manage && !matches!(event, WindowManagerEvent::DisplayChange(_)) {
             return Ok(());
         }
 

--- a/komorebi/src/stackbar.rs
+++ b/komorebi/src/stackbar.rs
@@ -55,9 +55,6 @@ use komorebi_core::Rect;
 
 use crate::window::Window;
 use crate::windows_api::WindowsApi;
-use crate::winevent::WinEvent;
-use crate::winevent_listener;
-use crate::WindowManagerEvent;
 use crate::DEFAULT_CONTAINER_PADDING;
 use crate::STACKBAR_FOCUSED_TEXT_COLOUR;
 use crate::STACKBAR_TAB_BACKGROUND_COLOUR;
@@ -116,12 +113,9 @@ impl Stackbar {
 
                         if x >= left && x <= right && y >= top && y <= bottom {
                             let window = Window { hwnd: *win_hwnd };
-                            let event_sender = winevent_listener::event_tx();
-                            let _ = event_sender.send(WindowManagerEvent::FocusChange(
-                                WinEvent::ObjectFocus,
-                                window,
-                            ));
-                            let _ = event_sender.send(WindowManagerEvent::ForceUpdate(window));
+                            if let Err(err) = window.focus(false) {
+                                tracing::error!("Stackbar focus error: HWND:{} {}", *win_hwnd, err);
+                            }
                         }
                     }
                 }

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -315,7 +315,10 @@ impl Window {
 
     #[tracing::instrument(fields(exe, title))]
     pub fn should_manage(self, event: Option<WindowManagerEvent>) -> Result<bool> {
-        #[allow(clippy::question_mark)]
+        if !self.is_window() {
+            return Ok(false);
+        }
+
         if self.title().is_err() {
             return Ok(false);
         }


### PR DESCRIPTION
As we have been working down some bugs from earlier changes, we introduced some additional error conditions in the logs. Now that the new focus approach is available, switching the stackbar to that means we can avoid needing to pass down ForceUpdate and FocusChange events for non-windows, which removes many of these cases.

In addition we do a check in should_manage that the target object is actually a window, ignoring the event if it is not.