### PR TITLE
fix(wm): fix focus changes with stackbar enabled

### DIFF
--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -499,11 +499,11 @@ impl WindowManager {
                 );
 
                 self.focus_monitor(monitor_idx)?;
-                self.update_focused_workspace(self.mouse_follows_focus)?;
+                self.update_focused_workspace(self.mouse_follows_focus, true)?;
             }
             SocketMessage::FocusMonitorNumber(monitor_idx) => {
                 self.focus_monitor(monitor_idx)?;
-                self.update_focused_workspace(self.mouse_follows_focus)?;
+                self.update_focused_workspace(self.mouse_follows_focus, true)?;
             }
             SocketMessage::Retile => self.retile_all(false)?,
             SocketMessage::FlipLayout(layout_flip) => self.flip_layout(layout_flip)?,
@@ -914,7 +914,7 @@ impl WindowManager {
                     }
                 }
 
-                self.update_focused_workspace(false)?;
+                self.update_focused_workspace(false, false)?;
             }
             SocketMessage::FocusFollowsMouse(mut implementation, enable) => {
                 if !CUSTOM_FFM.load(Ordering::SeqCst) {
@@ -1020,7 +1020,7 @@ impl WindowManager {
             SocketMessage::CompleteConfiguration => {
                 if !INITIAL_CONFIGURATION_LOADED.load(Ordering::SeqCst) {
                     INITIAL_CONFIGURATION_LOADED.store(true, Ordering::SeqCst);
-                    self.update_focused_workspace(false)?;
+                    self.update_focused_workspace(false, false)?;
                 }
             }
             SocketMessage::WatchConfiguration(enable) => {
@@ -1127,7 +1127,7 @@ impl WindowManager {
                 let resize: Vec<Option<Rect>> = serde_json::from_reader(file)?;
 
                 workspace.set_resize_dimensions(resize);
-                self.update_focused_workspace(false)?;
+                self.update_focused_workspace(false, false)?;
             }
             SocketMessage::Save(ref path) => {
                 let workspace = self.focused_workspace_mut()?;
@@ -1150,7 +1150,7 @@ impl WindowManager {
                 let resize: Vec<Option<Rect>> = serde_json::from_reader(file)?;
 
                 workspace.set_resize_dimensions(resize);
-                self.update_focused_workspace(false)?;
+                self.update_focused_workspace(false, false)?;
             }
             SocketMessage::AddSubscriberSocket(ref socket) => {
                 let mut sockets = SUBSCRIPTION_SOCKETS.lock();
@@ -1295,7 +1295,7 @@ impl WindowManager {
             SocketMessage::ToggleTitleBars => {
                 let current = REMOVE_TITLEBARS.load(Ordering::SeqCst);
                 REMOVE_TITLEBARS.store(!current, Ordering::SeqCst);
-                self.update_focused_workspace(false)?;
+                self.update_focused_workspace(false, false)?;
             }
             // Deprecated commands
             SocketMessage::AltFocusHack(_)

--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -92,14 +92,7 @@ impl WindowManager {
 
         // All event handlers below this point should only be processed if the event is
         // related to a window that should be managed by the WindowManager.
-        if !should_manage
-            && !matches!(
-                event,
-                WindowManagerEvent::DisplayChange(_)
-                    | WindowManagerEvent::ForceUpdate(_)
-                    | WindowManagerEvent::FocusChange(_, _)
-            )
-        {
+        if !should_manage && !matches!(event, WindowManagerEvent::DisplayChange(_)) {
             return Ok(());
         }
 

--- a/komorebi/src/stackbar.rs
+++ b/komorebi/src/stackbar.rs
@@ -55,6 +55,8 @@ use komorebi_core::Rect;
 
 use crate::window::Window;
 use crate::windows_api::WindowsApi;
+use crate::winevent_listener::event_tx;
+use crate::WindowManagerEvent;
 use crate::DEFAULT_CONTAINER_PADDING;
 use crate::STACKBAR_FOCUSED_TEXT_COLOUR;
 use crate::STACKBAR_TAB_BACKGROUND_COLOUR;
@@ -234,8 +236,6 @@ impl Stackbar {
             for (i, window) in windows.iter().enumerate() {
                 if window.hwnd == focused_hwnd {
                     SetTextColor(hdc, COLORREF(focused_text_colour));
-
-                    window.focus(false)?;
                 } else {
                     SetTextColor(hdc, COLORREF(unfocused_text_colour));
                 }

--- a/komorebi/src/stackbar.rs
+++ b/komorebi/src/stackbar.rs
@@ -55,9 +55,6 @@ use komorebi_core::Rect;
 
 use crate::window::Window;
 use crate::windows_api::WindowsApi;
-use crate::winevent::WinEvent;
-use crate::winevent_listener;
-use crate::WindowManagerEvent;
 use crate::DEFAULT_CONTAINER_PADDING;
 use crate::STACKBAR_FOCUSED_TEXT_COLOUR;
 use crate::STACKBAR_TAB_BACKGROUND_COLOUR;
@@ -116,12 +113,9 @@ impl Stackbar {
 
                         if x >= left && x <= right && y >= top && y <= bottom {
                             let window = Window { hwnd: *win_hwnd };
-                            let event_sender = winevent_listener::event_tx();
-                            let _ = event_sender.send(WindowManagerEvent::FocusChange(
-                                WinEvent::ObjectFocus,
-                                window,
-                            ));
-                            let _ = event_sender.send(WindowManagerEvent::ForceUpdate(window));
+                            if let Err(err) = window.focus(false) {
+                                tracing::error!("Stackbar focus error: HWND:{} {}", *win_hwnd, err);
+                            }
                         }
                     }
                 }

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -315,7 +315,10 @@ impl Window {
 
     #[tracing::instrument(fields(exe, title))]
     pub fn should_manage(self, event: Option<WindowManagerEvent>) -> Result<bool> {
-        #[allow(clippy::question_mark)]
+        if !self.is_window() {
+            return Ok(false);
+        }
+
         if self.title().is_err() {
             return Ok(false);
         }

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -357,6 +357,33 @@ impl Workspace {
         Ok(())
     }
 
+    // focus_changed performs updates in response to the fact that a focus
+    // change event has occurred. The focus change is assumed to be valid, and
+    // should not result in a new  focus change - the intent here is to update
+    // focus-reactive elements, such as the stackbar.
+    pub fn focus_changed(&mut self, hwnd: isize) -> Result<()> {
+        if !self.tile() {
+            return Ok(());
+        }
+
+        let containers = self.containers_mut();
+
+        for container in containers.iter_mut() {
+            let container_windows = container.windows().clone();
+            let container_topbar = container.stackbar().clone();
+
+            if let Some(idx) = container.idx_for_window(hwnd) {
+                container.focus_window(idx);
+                container.restore();
+            }
+
+            if let Some(stackbar) = container_topbar {
+                stackbar.update(&container_windows, hwnd)?;
+            }
+        }
+        Ok(())
+    }
+
     pub fn reap_orphans(&mut self) -> Result<(usize, usize)> {
         let mut hwnds = vec![];
         let mut floating_hwnds = vec![];


### PR DESCRIPTION
Notify all stackbars on focus change, and they now respond to changes, but do not create focus changes themselves just from an update.

There's still an issue with click-stackbar-to-switch.