### PR TITLE
fix(wm): focus on workspace of uncloaked window

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -283,7 +283,9 @@ impl WindowManager {
                     }
                 }
             }
-            WindowManagerEvent::Show(_, window) | WindowManagerEvent::Manage(window) => {
+            WindowManagerEvent::Show(_, window)
+            | WindowManagerEvent::Uncloak(_, window)
+            | WindowManagerEvent::Manage(window) => {
                 let mut switch_to = None;
                 for (i, monitors) in self.monitors().iter().enumerate() {
                     for (j, workspace) in monitors.workspaces().iter().enumerate() {
@@ -582,8 +584,7 @@ impl WindowManager {
             }
             WindowManagerEvent::DisplayChange(..)
             | WindowManagerEvent::MouseCapture(..)
-            | WindowManagerEvent::Cloak(..)
-            | WindowManagerEvent::Uncloak(..) => {}
+            | WindowManagerEvent::Cloak(..) => {}
         };
 
         if !self.focused_workspace()?.tile() {


### PR DESCRIPTION
This ensures that uncloaked windows focus the correct monitor and workspace. Prior to this fix, if a user clicked on a window from the taskbar (or alt-tab, etc), it would uncloak the window and leave it in a bugged state.

Old behavior:

https://github.com/LGUG2Z/komorebi/assets/7478134/637c6c17-4821-4dd3-93c7-20ce84cb08a3

Fixed behavior:

https://github.com/LGUG2Z/komorebi/assets/7478134/5456761b-d990-496b-a856-4ea4ef8974c4