### PR TITLE
Auto promote focused window

### DIFF
--- a/komorebi-core/src/lib.rs
+++ b/komorebi-core/src/lib.rs
@@ -67,6 +67,7 @@ pub enum SocketMessage {
     Minimize,
     Promote,
     PromoteFocus,
+    PromoteWindow(OperationDirection),
     ToggleFloat,
     ToggleMonocle,
     ToggleMaximize,

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -185,6 +185,10 @@ impl WindowManager {
         match message {
             SocketMessage::Promote => self.promote_container_to_front()?,
             SocketMessage::PromoteFocus => self.promote_focus_to_front()?,
+            SocketMessage::PromoteWindow(direction) => {
+                self.focus_container_in_direction(direction)?;
+                self.promote_container_to_front()?
+            }
             SocketMessage::FocusWindow(direction) => {
                 self.focus_container_in_direction(direction)?;
             }

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -172,6 +172,7 @@ gen_enum_subcommand_args! {
     WindowHidingBehaviour: HidingBehaviour,
     CrossMonitorMoveBehaviour: MoveBehaviour,
     UnmanagedWindowOperationBehaviour: OperationBehaviour,
+    PromoteWindow: OperationDirection,
 }
 
 macro_rules! gen_target_subcommand_args {
@@ -1004,6 +1005,8 @@ enum SubCommand {
     Promote,
     /// Promote the user focus to the top of the tree
     PromoteFocus,
+    /// Promote the window in the specified direction
+    PromoteWindow(PromoteWindow),
     /// Force the retiling of all managed windows
     Retile,
     /// Set the monitor index preference for a monitor identified using its size
@@ -1512,6 +1515,9 @@ fn main() -> Result<()> {
         }
         SubCommand::PromoteFocus => {
             send_message(&SocketMessage::PromoteFocus.as_bytes()?)?;
+        }
+        SubCommand::PromoteWindow(arg) => {
+            send_message(&SocketMessage::PromoteWindow(arg.operation_direction).as_bytes()?)?;
         }
         SubCommand::TogglePause => {
             send_message(&SocketMessage::TogglePause.as_bytes()?)?;


### PR DESCRIPTION
This pull request would add the ability for komorebi to always automatically promote the currently focused window.