### PR TITLE
fix(docs): correct typo in example config

### DIFF
--- a/docs/komorebi.example.json
+++ b/docs/komorebi.example.json
@@ -5,7 +5,7 @@
   "cross_monitor_move_behaviour": "Insert",
   "default_workspace_padding": 20,
   "default_container_padding": 20,
-  "border_padding": 8,
+  "border_width": 8,
   "border_offset": -1,
   "active_window_border": false,
   "active_window_border_colours": {


### PR DESCRIPTION
The example configuration mistakenly used the key `border_padding` in the place of `border_width`. As `border_padding` does not exist in the spec, modifying its value has no effect.

As this file is used by `komorebic quickstart`, new users will have this incorrect key in their default configuration. Notably, setting its value to `0` to remove gaps has no effect. The rest of the documentation uses the correct key, so users copying and pasting from that would not encounter the bug.