### PR TITLE
fix(animation): Fixed cancelling logic

### DIFF
--- a/komorebi/src/animation_manager.rs
+++ b/komorebi/src/animation_manager.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy)]
+struct AnimationState {
+    pub in_progress: bool,
+    pub is_cancelled: bool,
+}
+
+#[derive(Debug)]
+pub struct AnimationManager {
+    animations: HashMap<isize, AnimationState>,
+}
+
+impl AnimationManager {
+    pub fn new() -> Self {
+        Self {
+            animations: HashMap::new(),
+        }
+    }
+
+    pub fn is_cancelled(&self, hwnd: isize) -> bool {
+        if !self.animations.contains_key(&hwnd) {
+            return false;
+        }
+
+        self.animations.get(&hwnd).unwrap().is_cancelled
+    }
+
+    pub fn in_progress(&self, hwnd: isize) -> bool {
+        if !self.animations.contains_key(&hwnd) {
+            return false;
+        }
+
+        self.animations.get(&hwnd).unwrap().in_progress
+    }
+
+    pub fn cancel(&mut self, hwnd: isize) {
+        if !self.animations.contains_key(&hwnd) {
+            return;
+        }
+
+        let state = self.animations.get_mut(&hwnd).unwrap();
+        state.is_cancelled = true;
+    }
+
+    pub fn start(&mut self, hwnd: isize) {
+        if !self.animations.contains_key(&hwnd) {
+            self.animations.insert(
+                hwnd,
+                AnimationState {
+                    in_progress: true,
+                    is_cancelled: false,
+                },
+            );
+            return;
+        }
+
+        let state = self.animations.get_mut(&hwnd).unwrap();
+
+        if !state.in_progress {
+            state.in_progress = true;
+        }
+    }
+
+    pub fn end(&mut self, hwnd: isize) {
+        if !self.animations.contains_key(&hwnd) {
+            return;
+        }
+
+        let state = self.animations.get_mut(&hwnd).unwrap();
+        state.in_progress = false;
+        state.is_cancelled = false;
+
+        self.animations.remove(&hwnd);
+    }
+}

--- a/komorebi/src/animation_manager.rs
+++ b/komorebi/src/animation_manager.rs
@@ -19,28 +19,25 @@ impl AnimationManager {
     }
 
     pub fn is_cancelled(&self, hwnd: isize) -> bool {
-        if !self.animations.contains_key(&hwnd) {
-            return false;
+        if let Some(animation_state) = self.animations.get(&hwnd) {
+            animation_state.is_cancelled
+        } else {
+            false
         }
-
-        self.animations.get(&hwnd).unwrap().is_cancelled
     }
 
     pub fn in_progress(&self, hwnd: isize) -> bool {
-        if !self.animations.contains_key(&hwnd) {
-            return false;
+        if let Some(animation_state) = self.animations.get(&hwnd) {
+            animation_state.in_progress
+        } else {
+            false
         }
-
-        self.animations.get(&hwnd).unwrap().in_progress
     }
 
     pub fn cancel(&mut self, hwnd: isize) {
-        if !self.animations.contains_key(&hwnd) {
-            return;
+        if let Some(animation_state) = self.animations.get_mut(&hwnd) {
+            animation_state.is_cancelled = true;
         }
-
-        let state = self.animations.get_mut(&hwnd).unwrap();
-        state.is_cancelled = true;
     }
 
     pub fn start(&mut self, hwnd: isize) {
@@ -55,22 +52,17 @@ impl AnimationManager {
             return;
         }
 
-        let state = self.animations.get_mut(&hwnd).unwrap();
-
-        if !state.in_progress {
-            state.in_progress = true;
+        if let Some(animation_state) = self.animations.get_mut(&hwnd) {
+            animation_state.in_progress = true;
         }
     }
 
     pub fn end(&mut self, hwnd: isize) {
-        if !self.animations.contains_key(&hwnd) {
-            return;
+        if let Some(animation_state) = self.animations.get_mut(&hwnd) {
+            animation_state.in_progress = false;
+            animation_state.is_cancelled = false;
+
+            self.animations.remove(&hwnd);
         }
-
-        let state = self.animations.get_mut(&hwnd).unwrap();
-        state.in_progress = false;
-        state.is_cancelled = false;
-
-        self.animations.remove(&hwnd);
     }
 }

--- a/komorebi/src/lib.rs
+++ b/komorebi/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod animation;
+pub mod animation_manager;
 pub mod border;
 pub mod com;
 #[macro_use]
@@ -40,6 +41,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 pub use animation::*;
+pub use animation_manager::*;
 pub use colour::*;
 pub use hidden::*;
 pub use process_command::*;
@@ -210,6 +212,9 @@ lazy_static! {
 
     static ref ANIMATION_STYLE: Arc<Mutex<AnimationStyle >> =
         Arc::new(Mutex::new(AnimationStyle::Linear));
+
+    static ref ANIMATION_MANAGER: Arc<Mutex<AnimationManager>> =
+        Arc::new(Mutex::new(AnimationManager::new()));
 
     // Use app-specific titlebar removal options where possible
     // eg. Windows Terminal, IntelliJ IDEA, Firefox

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -2,6 +2,7 @@ use crate::com::SetCloak;
 use crate::winevent_listener;
 use crate::ANIMATION_DURATION;
 use crate::ANIMATION_ENABLED;
+use crate::ANIMATION_MANAGER;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Display;
@@ -131,7 +132,7 @@ impl Window {
     pub fn new(hwnd: isize) -> Self {
         Self {
             hwnd,
-            animation: Animation::default(),
+            animation: Animation::new(hwnd),
         }
     }
 
@@ -198,9 +199,7 @@ impl Window {
     pub fn set_position(&mut self, layout: &Rect, top: bool) -> Result<()> {
         let rect = *layout;
         if ANIMATION_ENABLED.load(Ordering::SeqCst) {
-            // check if animation is in progress
-            if self.animation.in_progress {
-                // wait for cancel animation
+            if ANIMATION_MANAGER.lock().in_progress(self.hwnd) {
                 self.animation.cancel();
             }
 


### PR DESCRIPTION
Added static animation state manager for tracking "in_progress" and "is_cancelled" states. The idea is not to have states in Animation struct but to keep them in HashMap<hwnd, AnimationState> behind reference (Arc<Mutex<>>). So we each animation frame we have access to state and can cancel animation if we have to.

Need review and testings

@raggi @LGUG2Z 