### PR TITLE
fix(animation): Move cancel call to Animation struct

### DIFF
--- a/komorebi/src/animation.rs
+++ b/komorebi/src/animation.rs
@@ -454,6 +454,10 @@ impl Animation {
         duration: Duration,
         mut f: impl FnMut(f64) -> Result<()>,
     ) -> Result<()> {
+        if ANIMATION_MANAGER.lock().in_progress(self.hwnd) {
+            self.cancel();
+        }
+
         ANIMATION_MANAGER.lock().start(self.hwnd);
 
         // set target frame time to match 240 fps (my max refresh rate of monitor)

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -2,7 +2,6 @@ use crate::com::SetCloak;
 use crate::winevent_listener;
 use crate::ANIMATION_DURATION;
 use crate::ANIMATION_ENABLED;
-use crate::ANIMATION_MANAGER;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Display;
@@ -199,10 +198,6 @@ impl Window {
     pub fn set_position(&mut self, layout: &Rect, top: bool) -> Result<()> {
         let rect = *layout;
         if ANIMATION_ENABLED.load(Ordering::SeqCst) {
-            if ANIMATION_MANAGER.lock().in_progress(self.hwnd) {
-                self.animation.cancel();
-            }
-
             self.animate_position(&rect, top)
         } else {
             WindowsApi::position_window(self.hwnd(), &rect, top)


### PR DESCRIPTION
Only focused window was cancelling its animation because we call cancel in window::set_position and waiting for its cancelling. And because we waiting for cancelling second window is still moving. Second window will stop moving only after the first window. So I moved `cancel` call to Animation struct so its happening in its own thread and doesn't block others animation moves and cancels.