### PR TITLE
fix parking_lot transitive features conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,12 +1543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,13 +3180,10 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "backtrace",
  "cfg-if 1.0.0",
  "libc",
- "petgraph",
  "redox_syscall 0.5.1",
  "smallvec",
- "thread-id",
  "windows-targets 0.52.5",
 ]
 
@@ -3207,16 +3198,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
 
 [[package]]
 name = "pin-project"
@@ -4188,16 +4169,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
-]
-
-[[package]]
-name = "thread-id"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,10 +3186,13 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
+ "backtrace",
  "cfg-if 1.0.0",
  "libc",
+ "petgraph",
  "redox_syscall 0.5.1",
  "smallvec",
+ "thread-id",
  "windows-targets 0.52.5",
 ]
 
@@ -3198,6 +3207,16 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project"
@@ -4169,6 +4188,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -28,7 +28,7 @@ miow = "0.6"
 nanoid = "0.4"
 net2 = "0.2"
 os_info = "3.8"
-parking_lot = { version = "0.12" }
+parking_lot = "0.12"
 paste = "1"
 regex = "1"
 schemars = "0.8"
@@ -51,4 +51,4 @@ winreg = "0.52"
 win32-display-data = { git = "https://github.com/LGUG2Z/win32-display-data", rev = "2a0f7166da154880a1750b91829b1186d9c6a00c" }
 
 [features]
-deadlock_detection = []
+deadlock_detection = ["parking_lot/deadlock_detection"]

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -28,7 +28,7 @@ miow = "0.6"
 nanoid = "0.4"
 net2 = "0.2"
 os_info = "3.8"
-parking_lot = { version = "0.12", features = ["deadlock_detection"] }
+parking_lot = { version = "0.12" }
 paste = "1"
 regex = "1"
 schemars = "0.8"

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1065,14 +1065,14 @@ impl WindowManager {
 
         target_monitor.add_container(container, workspace_idx)?;
 
-        if let Some(workspace_idx) = workspace_idx {
-            target_monitor.focus_workspace(workspace_idx)?;
-        }
-
-        target_monitor.load_focused_workspace(mouse_follows_focus)?;
-        target_monitor.update_focused_workspace(offset)?;
-
         if follow {
+            if let Some(workspace_idx) = workspace_idx {
+                target_monitor.focus_workspace(workspace_idx)?;
+            }
+
+            target_monitor.load_focused_workspace(mouse_follows_focus)?;
+            target_monitor.update_focused_workspace(offset)?;
+
             self.focus_monitor(monitor_idx)?;
         }
 


### PR DESCRIPTION
In the case when the `komorebi-client` is used in one project with some dependency that is transitively used crate `parking_lot` with feature `send_guard`, a compilation error occurs because `komorebi-client` transitively importing `parking_lot` with feature `deadlock_detection` and these features are mutually exclusive.

This fix suggests enabling `deadlock_detection` feature in `parking_lot` crate only if `deadlock_detection` enabled for `komorebi` crate, by default it is disabled so it will solve issue with `komorebi-client`