### PR TITLE
Updated documentation to make binding a display to a given index clearer

### DIFF
--- a/docs/common-workflows/set-display-index.md
+++ b/docs/common-workflows/set-display-index.md
@@ -1,0 +1,15 @@
+# Setting a given display to a specific index
+
+If you have issues with `komorebi` forgetting monitor index positions, you will
+need to set the display_index_preferences entry in the json schema.
+
+Every display ID can be found using `komorebic state | findstr -I -N device_id`
+
+Then, in komorebi.json, you simply need to add:
+
+```json
+    "display_index_preferences": {
+        "0": "<display_id>",
+        "1": "<display_id>",
+    }
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - common-workflows/mouse-follows-focus.md
       - common-workflows/custom-layouts.md
       - common-workflows/dynamic-layout-switching.md
+      - common-workflows/set-display-index.md
   - Release notes:
       - release/v0-1-22.md
   - Configuration reference: https://komorebi.lgug2z.com/schema

--- a/schema.json
+++ b/schema.json
@@ -336,7 +336,13 @@
       "format": "int32"
     },
     "display_index_preferences": {
-      "description": "Set display index preferences",
+      "description": "Set display index preferences.  You can find the id with `komorebic state | findstr -I -N device_id`.",
+      "examples": [{
+        "display_index_preferences": {
+          "0":"<display_id>",
+          "1":"<display_id>"
+        }
+      }],
       "type": "object",
       "additionalProperties": {
         "type": "string"


### PR DESCRIPTION
Hey, I had a hard time figuring out how to do this with what was posted in the github issues + documentation, so I wrote what I found.

I couldn't really discern style from the other workflow examples, but hopefully the common-workflow doesn't need much extra work to bring it to that.

(special thanks to javierportillo, who I do not know but [found a usable config line](https://github.com/javierportillo/.dotfiles/blob/227e1bdc5bd9cd262685e2d5a676e050f66beb8e/home/.config/komorebi/komorebi.json#L14) via github codesearch)