### PR TITLE
Add color picker to config in vscode

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -50,7 +50,8 @@
             },
             {
               "description": "Colour represented as Hex",
-              "type": "string"
+              "type": "string",
+              "format": "color-hex"
             }
           ]
         },
@@ -88,7 +89,8 @@
             },
             {
               "description": "Colour represented as Hex",
-              "type": "string"
+              "type": "string",
+              "format": "color-hex"
             }
           ]
         },
@@ -126,7 +128,8 @@
             },
             {
               "description": "Colour represented as Hex",
-              "type": "string"
+              "type": "string",
+              "format": "color-hex"
             }
           ]
         },
@@ -164,7 +167,8 @@
             },
             {
               "description": "Colour represented as Hex",
-              "type": "string"
+              "type": "string",
+              "format": "color-hex"
             }
           ]
         }
@@ -1094,7 +1098,8 @@
                 },
                 {
                   "description": "Colour represented as Hex",
-                  "type": "string"
+                  "type": "string",
+                  "format": "color-hex"
                 }
               ]
             },
@@ -1132,7 +1137,8 @@
                 },
                 {
                   "description": "Colour represented as Hex",
-                  "type": "string"
+                  "type": "string",
+                  "format": "color-hex"
                 }
               ]
             },
@@ -1170,7 +1176,8 @@
                 },
                 {
                   "description": "Colour represented as Hex",
-                  "type": "string"
+                  "type": "string",
+                  "format": "color-hex"
                 }
               ]
             },


### PR DESCRIPTION
added `"format": "color-hex"` so that a color picker appears in vscode

![image](https://github.com/LGUG2Z/komorebi/assets/40239844/364c7ed4-0def-4659-b2bd-ffc3bc8ac63b)
