### PR TITLE
feat(bar): to_pretty_bytes on network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 CHANGELOG.md
 dummy.go
 komorebic/applications.yaml
+/.vs

--- a/komorebi-bar/Cargo.toml
+++ b/komorebi-bar/Cargo.toml
@@ -31,3 +31,6 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 windows = { workspace = true }
 windows-icons = "0.1"
+num = "0.4.3"
+num-derive = "0.4.2"
+num-traits = "0.2.19"


### PR DESCRIPTION
I added formatting to the network widget that prettifies bytes. 
I think it made sense to choose `KiB` as the minimum data unit, which could be changed by adding it to the settings, if needed.
I formatted the output on the activity readings with left padding to make it easier to read the values when they change constantly.
I changed the icons too, sorry 😄 

I think that the `to_pretty_bytes` function could be placed in a separate file so another widget can use it as well. For example if we want to display the size on the drives or ram.

I little bit of refactoring might be needed, I am pretty new to Rust :)

![image](https://github.com/user-attachments/assets/73b35a37-6228-4968-88f3-c7f2c61912c2)
