### PR TITLE
Feature: handle windows that match any float_rules as float instead of being ignored

### DIFF
--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -18,6 +18,7 @@ pub use komorebi::core::CycleDirection;
 pub use komorebi::core::DefaultLayout;
 pub use komorebi::core::Direction;
 pub use komorebi::core::FocusFollowsMouseImplementation;
+pub use komorebi::core::WindowContainerBehaviour;
 pub use komorebi::core::HidingBehaviour;
 pub use komorebi::core::Layout;
 pub use komorebi::core::MoveBehaviour;

--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -77,6 +77,8 @@ pub enum SocketMessage {
     ToggleMonocle,
     ToggleMaximize,
     ToggleWindowContainerBehaviour,
+    CycleWindowContainerBehaviour(CycleDirection),
+    WindowContainerBehaviour(WindowContainerBehaviour),
     WindowHidingBehaviour(HidingBehaviour),
     ToggleCrossMonitorMoveBehaviour,
     CrossMonitorMoveBehaviour(MoveBehaviour),

--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -348,6 +348,8 @@ pub enum WindowContainerBehaviour {
     Create,
     /// Append new windows to the focused window container
     Append,
+    /// Open new windows as floating windows that can be later toggled to tiled
+    Float,
 }
 
 #[derive(

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1294,18 +1294,38 @@ impl WindowManager {
             SocketMessage::ResizeDelta(delta) => {
                 self.resize_delta = delta;
             }
-            SocketMessage::ToggleWindowContainerBehaviour => {
-                match self.window_container_behaviour {
-                    WindowContainerBehaviour::Create => {
-                        self.window_container_behaviour = WindowContainerBehaviour::Append;
+            SocketMessage::CycleWindowContainerBehaviour(direction) => {
+                match direction {
+                    crate::CycleDirection::Next => {
+                        match self.window_container_behaviour {
+                            WindowContainerBehaviour::Create => {
+                                self.window_container_behaviour = WindowContainerBehaviour::Append;
+                            }
+                            WindowContainerBehaviour::Append => {
+                                self.window_container_behaviour = WindowContainerBehaviour::Float;
+                            }
+                            WindowContainerBehaviour::Float => {
+                                self.window_container_behaviour = WindowContainerBehaviour::Create;
+                            }
+                        }
                     }
-                    WindowContainerBehaviour::Append => {
-                        self.window_container_behaviour = WindowContainerBehaviour::Float;
-                    }
-                    WindowContainerBehaviour::Float => {
-                        self.window_container_behaviour = WindowContainerBehaviour::Create;
+                    _ => {
+                        match self.window_container_behaviour {
+                            WindowContainerBehaviour::Create => {
+                                self.window_container_behaviour = WindowContainerBehaviour::Float;
+                            }
+                            WindowContainerBehaviour::Append => {
+                                self.window_container_behaviour = WindowContainerBehaviour::Create;
+                            }
+                            WindowContainerBehaviour::Float => {
+                                self.window_container_behaviour = WindowContainerBehaviour::Append;
+                            }
+                        }
                     }
                 }
+            }
+            SocketMessage::WindowContainerBehaviour(behaviour) => {
+                self.window_container_behaviour = behaviour;
             }
             SocketMessage::WindowHidingBehaviour(behaviour) => {
                 let mut hiding_behaviour = HIDING_BEHAVIOUR.lock();
@@ -1483,6 +1503,7 @@ impl WindowManager {
             }
             // Deprecated commands
             SocketMessage::AltFocusHack(_)
+            | SocketMessage::ToggleWindowContainerBehaviour
             | SocketMessage::IdentifyBorderOverflowApplication(_, _) => {}
         };
 

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1300,6 +1300,9 @@ impl WindowManager {
                         self.window_container_behaviour = WindowContainerBehaviour::Append;
                     }
                     WindowContainerBehaviour::Append => {
+                        self.window_container_behaviour = WindowContainerBehaviour::Float;
+                    }
+                    WindowContainerBehaviour::Float => {
                         self.window_container_behaviour = WindowContainerBehaviour::Create;
                     }
                 }

--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -350,6 +350,10 @@ impl WindowManager {
 
                                 stackbar_manager::send_notification();
                             }
+                            WindowContainerBehaviour::Float => {
+                                workspace.floating_windows_mut().push(window);
+                                self.update_focused_workspace(false, true)?;
+                            }
                         }
                     }
 
@@ -553,6 +557,10 @@ impl WindowManager {
                                     }
 
                                     stackbar_manager::send_notification();
+                                }
+                                WindowContainerBehaviour::Float => {
+                                    workspace.floating_windows_mut().push(window);
+                                    self.update_focused_workspace(false, true)?;
                                 }
                             }
                         }

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -314,7 +314,8 @@ impl WindowManager {
     ) -> WindowContainerBehaviour {
         if let Some(monitor) = self.monitors().get(monitor_idx) {
             if let Some(workspace) = monitor.workspaces().get(workspace_idx) {
-                return if workspace.containers().is_empty() {
+                return if workspace.containers().is_empty() && matches!(self.window_container_behaviour, WindowContainerBehaviour::Append) {
+                    // You can't append to an empty workspace
                     WindowContainerBehaviour::Create
                 } else {
                     self.window_container_behaviour

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -48,6 +48,7 @@ use komorebi_client::Axis;
 use komorebi_client::CycleDirection;
 use komorebi_client::DefaultLayout;
 use komorebi_client::FocusFollowsMouseImplementation;
+use komorebi_client::WindowContainerBehaviour;
 use komorebi_client::HidingBehaviour;
 use komorebi_client::MoveBehaviour;
 use komorebi_client::OperationBehaviour;
@@ -166,6 +167,8 @@ gen_enum_subcommand_args! {
     WatchConfiguration: BooleanState,
     MouseFollowsFocus: BooleanState,
     Query: StateQuery,
+    CycleWindowContainerBehaviour: CycleDirection,
+    NewWindowContainerBehaviour: WindowContainerBehaviour,
     WindowHidingBehaviour: HidingBehaviour,
     CrossMonitorMoveBehaviour: MoveBehaviour,
     UnmanagedWindowOperationBehaviour: OperationBehaviour,
@@ -1164,8 +1167,16 @@ enum SubCommand {
     /// Set the workspace name for the specified workspace
     #[clap(arg_required_else_help = true)]
     WorkspaceName(WorkspaceName),
+    /// DEPRECATED since v0.1.29
     /// Toggle the behaviour for new windows (stacking or dynamic tiling)
+    #[clap(hide = true)]
     ToggleWindowContainerBehaviour,
+    /// Set the window_container_behaviour when a new window is opened/shown/uncloaked
+    #[clap(arg_required_else_help = true)]
+    WindowContainerBehaviour(NewWindowContainerBehaviour),
+    /// Cycles between dynamic tiling, stacking and floating behaviour for new windows
+    #[clap(arg_required_else_help = true)]
+    CycleWindowContainerBehaviour(CycleWindowContainerBehaviour),
     /// Toggle window tiling on the focused workspace
     TogglePause,
     /// Toggle window tiling on the focused workspace
@@ -2439,8 +2450,15 @@ Stop-Process -Name:komorebi -ErrorAction SilentlyContinue
         SubCommand::ResizeDelta(arg) => {
             send_message(&SocketMessage::ResizeDelta(arg.pixels))?;
         }
+        // Deprecated
         SubCommand::ToggleWindowContainerBehaviour => {
-            send_message(&SocketMessage::ToggleWindowContainerBehaviour)?;
+            println!("Command deprecated - use new commands 'cycle-window-container-behaviour' or 'window-container-behaviour'");
+        }
+        SubCommand::WindowContainerBehaviour(arg) => {
+            send_message(&SocketMessage::WindowContainerBehaviour(arg.window_container_behaviour))?;
+        }
+        SubCommand::CycleWindowContainerBehaviour(arg) => {
+            send_message(&SocketMessage::CycleWindowContainerBehaviour(arg.cycle_direction))?;
         }
         SubCommand::WindowHidingBehaviour(arg) => {
             send_message(&SocketMessage::WindowHidingBehaviour(arg.hiding_behaviour))?;


### PR DESCRIPTION
## This PR builds on top of the #986 
This PR requires the `WindowContainerBehaviour::Float` introduced on that PR, as such it includes the commits from that PR as well. The fix suggested from this PR is just the last commit, so in order to ignore the bigger changes from the other PR it is best to look just at the changes from the last commit (they are quite simple...)


##  WHAT DOES THIS PR DO?
- It makes it so windows matched by any floating rule won't simply be ignored by komorebi, but
instead it will still handle the window by using the `WindowContainerBehaviour::Float` introduced
on the other PR mentioned above.
This means that those windows will still be tied to a specific workspace and only be shown on that
workspace instead of showing everywhere.
This would fix issues like the #990 one.

- There is one thing that almost everyone asks for when first starting using komorebi, which is a way
to restart komorebi with the current state. I believe that this hasn't been implemented yet in part
because there was no good way to handle the cases where a monitor no longer exists when restarting
again. *(@LGUG2Z feel free to correct me if this isn't the case and there are other issues with it)*
These PRs could make it so we would be able to restart with the previous state and any window that was
on a no longer existing monitor could be opened on the currently focused workspace as floating. This
way the user would immediately see all the windows that couldn't be handled and they can manually move
them to wherever they like.
***This is just an idea and I've haven't implemented nor tried to do so on these PR's yet!***

## ISSUES OR QUESTIONS WITH THIS PR
- The windows set to floating by a floating rule can still become managed by using the command
`toggle-float` or by moving them to another workspace that is tiled. This might not be wanted,
since this windows were added to said rule usually because they don't behave well when tiled.
This can probably be fixed by either having another vector on the workspace (like `floating_windows`
and `forced_floating_windows`) or by changing the `floating_windows` vector to have a wrapping struct
that holds the window and some info:
    ```rust
       struct FloatingWindow {
           window: Window,
           forced: bool,
       }
    ```
- There might still be a need to create a `ignored_rules` along with the current `float_rules` since there might be some apps that really need to be ignored, or that a user might prefer to have ignored instead of being handled as `Float`.
- Currently, `floating_windows` aren't properly handled by commands, most commands when called
check for the focused container, however the floating windows are never set to focused so this
will result in a lot of users complaining that the floating windows are being ignored when they
try to do some operation on them but instead that operation is applied to the previously managed
focused window instead. This should probably be fixed before any of this is merged to master.
- Currently, when changing workspaces the newly focused workspace shows the focused container last,
meaning that if some floating window was on top before you changed to another workspace, now it
will show behind the focused container.
Allowing `floating_windows` to be focusable like mentioned above would fix this issue.
This would fix issues like #984 

- Some questions that need to be answered before pushing with this:
    1) Should a window that is floating become tiled when moved to another workspace?
    2) Should a rule enforcing a window on a specific workspace check the `WindowContainerBehaviour`
    before moving the window and creating a tiled container for it?
    3) Should floating windows be focusable?
    4) Should there be a `WindowContainerBehaviour` per workspace? (this might be out of the scope
    of this PR but it is related to this so I decided to leave the question here anyway)

## TODO
- Currently this PR is just a draft because I'm merely checking if the windows that have a `should_manage = false` were windows that matched a floating rule identifier and if that is the case I force the `WindowContainerBehaviour::Float` when they are created. But this could probably be better handled if instead of returning a bool from the `should_manage()` function we returned some:
```rust
enum ShouldManageResult {
    Ignore,
    Tile,
    Float,
}
```