### PR TITLE
Fix(wm): update monitor focus before focus-stack-window

### DIFF
--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -232,6 +232,13 @@ impl WindowManager {
                 self.focused_window()?.focus(self.mouse_follows_focus)?;
             }
             SocketMessage::FocusStackWindow(idx) => {
+                // In case you are using this command on a bar on a monitor
+                // different from the currently focused one, you'd want that
+                // monitor to be focused so that the FocusStackWindow happens
+                // on the monitor with the bar you just pressed.
+                if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
+                    self.focus_monitor(monitor_idx)?;
+                }
                 self.focus_container_window(idx)?;
                 self.focused_window()?.focus(self.mouse_follows_focus)?;
             }


### PR DESCRIPTION
This commit fixes the cases where you'd call this command on a monitor which was not focused, for example by pressing a button on a bar like `komorebi-bar` or other when you had focus on another monitor. This change ensures that first we focus the monitor where the mouse cursor is, this way it will act on the monitor that you've just pressed instead of the monitor that was focused before.