### PR TITLE
feat(wm): apply workspace-rules to floating windows

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -323,7 +323,7 @@ impl WindowManager {
 
                 for (i, monitor) in self.monitors().iter().enumerate() {
                     for (j, workspace) in monitor.workspaces().iter().enumerate() {
-                        if workspace.container_for_window(window.hwnd).is_some()
+                        if workspace.contains_window(window.hwnd)
                             && i != self.focused_monitor_idx()
                             && j != monitor.focused_workspace_idx()
                         {


### PR DESCRIPTION
This commit allows `workspace-rules` and `initial_workspace_rules` to be applied to floating windows. As a by product of this commit, now the command to show `visible-windows` will now also show the maximized windows, monocled windows and floating windows.

Should fix the issue #990

@LGUG2Z I know you wanted to handle the refactor of the `visible-windows` type of functions but since this one was needed for this PR I've already changed it...

There are two `TODO` comments I added on this commit that I would like to have your feedback on.