### PR TITLE
fix(windows_api): correctly handle monitors preference indices

### DIFF
--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -300,14 +300,21 @@ impl WindowsApi {
                 }
             }
 
-            if monitors.elements().is_empty() {
-                monitors.elements_mut().push_back(m);
-            } else if let Some(preference) = index_preference {
-                while *preference > monitors.elements().len() {
+            if let Some(preference) = index_preference {
+                while *preference >= monitors.elements().len() {
                     monitors.elements_mut().push_back(Monitor::placeholder());
                 }
 
-                monitors.elements_mut().insert(*preference, m);
+                let current_name = monitors
+                    .elements_mut()
+                    .get(*preference)
+                    .map_or("", |m| m.name());
+                if current_name == "PLACEHOLDER" {
+                    let _ = monitors.elements_mut().remove(*preference);
+                    monitors.elements_mut().insert(*preference, m);
+                } else {
+                    monitors.elements_mut().insert(*preference, m);
+                }
             } else {
                 monitors.elements_mut().push_back(m);
             }


### PR DESCRIPTION
This should fix a bug where the monitor index preferences might not be properly applied. This would affect users with 3 or more monitors the most.
Fixes #1056
(there might be other issues that are fixed by this, but I didn't have to time to go through all of them and check... might do that later...)

To explain the fix:
- Previously it was adding placeholders and then inserting the monitor at the correct index, which would shift the rest to the right, which depending on the order could end up with a wrong result
- Now we add placeholders until the current index (inclusive), then check if the current one at the index we want to put this monitor is a placeholder, if it is we replace it (remove -> insert).

@LGUG2Z I can't properly test this since I've only got two monitors. It is probably better to have someone with 3 or more monitors test this first to make sure it works and doesn't break other stuff. It would be great if you could notify testers on discord! 👍 