### PR TITLE
fix(wm): focus window on `Show` when there is only 1 window

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -387,6 +387,21 @@ impl WindowManager {
                                 }
                             }
                         }
+
+                        if (self.focused_workspace()?.containers().len() == 1
+                            && self.focused_workspace()?.floating_windows().is_empty())
+                            || (self.focused_workspace()?.containers().is_empty()
+                                && self.focused_workspace()?.floating_windows().len() == 1)
+                        {
+                            // If after adding this window the workspace only contains 1 window, it
+                            // means it was previously empty and we focused the desktop to unfocus
+                            // any previous window from other workspace, so now we need to focus
+                            // this window again. This is needed because sometimes some windows
+                            // first send the `FocusChange` event and only the `Show` event after
+                            // and we will be focusing the desktop on the `FocusChange` event since
+                            // it is still empty.
+                            window.focus(self.mouse_follows_focus)?;
+                        }
                     }
 
                     if workspace_contains_window {


### PR DESCRIPTION
This commit makes sure we refocus the window on `Show` event when it is the only window on the workspace. This is needed because some windows some times send the `FocusChange` event before the `Show` event and on the first event we will be focusing the desktop window to unfocus any previous window from other workspace because the workspace will still be empty. So after adding the window we need to focus it again.

This fixes an issue brought up on discord by @amnweb [here](https://discord.com/channels/898554690126630914/898556726108901386/1294848652451516436)