### PR TITLE
update egui docs link in schema.bar.json

### DIFF
--- a/schema.bar.json
+++ b/schema.bar.json
@@ -19,7 +19,7 @@
       "format": "float"
     },
     "frame": {
-      "description": "Frame options (see: https://docs.rs/egui/latest/egui/containers/struct.Frame.html)",
+      "description": "Frame options (see: https://docs.rs/egui/latest/egui/containers/frame/struct.Frame.html)",
       "type": "object",
       "required": [
         "inner_margin"


### PR DESCRIPTION
Seems the egui devs changed the link in their docs for the Frame struct. Old one doesn't work so replaced it with the proper one.