### PR TITLE
docs(mkdocs): Add note about `Grid` layout not allowing resizing windows

### DIFF
--- a/docs/example-configurations.md
+++ b/docs/example-configurations.md
@@ -161,6 +161,7 @@ If you have an ultrawide monitor, I recommend using this layout.
 ### Grid
 
 If you like the `grid` layout in [LeftWM](https://github.com/leftwm/leftwm-layouts) this is almost exactly the same!
+The `grid` layout doesn't allow resizing the windows.
 
 ```
 +-----+-----+   +---+---+---+   +---+---+---+   +---+---+---+


### PR DESCRIPTION
This wasn't specified anywhere that I could find which would lead to users not knowing why they couldn't resize their windows and think it was a bug. Like it has happened [here](https://discord.com/channels/898554690126630914/898554690608967786/1298175871697289268) on discord.