### PR TITLE
ci(github): Fix nightly workflow to attach the assets correctly

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -104,10 +104,8 @@ jobs:
             --prerelease \
             --title "komorebi nightly (${GITHUB_SHA})" \
             --notes-file CHANGELOG.md
-            komorebi-nightly-x86_64-pc-windows-msvc.zip \
-            komorebi-nightly-x86_64.msi \
-            komorebi-nightly-aarch64-pc-windows-msvc.zip \
-            komorebi-nightly-aarch64.msi \
+            *.zip \
+            *.msi \
             checksums.txt
 
   release-dry-run:


### PR DESCRIPTION
This is an attempt to fix the nightly workflow to see if it attaches the artifacts properly to the release. Just in case you want to try to quickly merge and see if it fixes it. If you prefer to wait until you get back to have a proper look at this it's all good!