### PR TITLE
fix(wm): stop making windows disappear when using `Hide` behaviour

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -228,8 +228,7 @@ impl WindowManager {
                     .is_some();
 
                     if !window.is_window()
-                        || should_act
-                        || !programmatically_hidden_hwnds.contains(&window.hwnd)
+                        || (should_act && !programmatically_hidden_hwnds.contains(&window.hwnd))
                     {
                         hide = true;
                     }


### PR DESCRIPTION
Fixes the issue talked on discord [here](https://discord.com/channels/898554690126630914/898554690608967786/1301581412008202298) where when using `Hide` as hiding behaviour some windows were hidden and never restored, the same would happen if using stacks with apps that matched the tray_and_multi_window_identifiers