### PR TITLE
Introducing komorebi Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Tiling Window Management for Windows.
   <a href="https://www.youtube.com/channel/UCeai3-do-9O4MNy9_xjO6mg?sub_confirmation=1">
     <img alt="YouTube" src="https://img.shields.io/youtube/channel/subscribers/UCeai3-do-9O4MNy9_xjO6mg">
   </a>
+  <a href="https://gurubase.io/g/komorebi">
+    <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20komorebi%20Guru-006BFF">
+  </a>
 </p>
 
 ![screenshot](https://user-images.githubusercontent.com/13164844/184027064-f5a6cec2-2865-4d65-a549-a1f1da589abf.png)
@@ -292,7 +295,7 @@ in `komorebi::core`.
 Below is an example of how you can subscribe to and filter on events using a named pipe in `nodejs`.
 
 ```javascript
-const { exec } = require("child_process");
+const pipeName = "\\.\\pipe\\komorebi-js";
 const net = require("net");
 
 const pipeName = "\\\\.\\pipe\\komorebi-js";

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ in `komorebi::core`.
 Below is an example of how you can subscribe to and filter on events using a named pipe in `nodejs`.
 
 ```javascript
-const pipeName = "\\.\\pipe\\komorebi-js";
+const { exec } = require("child_process");
 const net = require("net");
 
 const pipeName = "\\\\.\\pipe\\komorebi-js";


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [komorebi Guru](https://gurubase.io/g/komorebi) to Gurubase. komorebi Guru uses the data from this repo and data from the [docs](https://lgug2z.github.io/komorebi) to answer questions by leveraging the LLM.

In this PR, I showcased the "komorebi Guru", which highlights that komorebi now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable komorebi Guru in Gurubase, just let me know that's totally fine.
