### PR TITLE
fix: switching workspaces on secondary monitor

### DIFF
--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -742,8 +742,10 @@ impl WindowManager {
                 // This is to ensure that even on an empty workspace on a secondary monitor, the
                 // secondary monitor where the cursor is focused will be used as the target for
                 // the workspace switch op
-                if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
-                    self.focus_monitor(monitor_idx)?;
+                if self.mouse_follows_focus {
+                    if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
+                        self.focus_monitor(monitor_idx)?;
+                    }
                 }
 
                 let focused_monitor = self
@@ -765,8 +767,10 @@ impl WindowManager {
                 // This is to ensure that even on an empty workspace on a secondary monitor, the
                 // secondary monitor where the cursor is focused will be used as the target for
                 // the workspace switch op
-                if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
-                    self.focus_monitor(monitor_idx)?;
+                if self.mouse_follows_focus {
+                    if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
+                        self.focus_monitor(monitor_idx)?;
+                    }
                 }
 
                 let mut can_close = false;
@@ -803,8 +807,10 @@ impl WindowManager {
                 // This is to ensure that even on an empty workspace on a secondary monitor, the
                 // secondary monitor where the cursor is focused will be used as the target for
                 // the workspace switch op
-                if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
-                    self.focus_monitor(monitor_idx)?;
+                if self.mouse_follows_focus {
+                    if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
+                        self.focus_monitor(monitor_idx)?;
+                    }
                 }
 
                 let idx = self
@@ -826,8 +832,10 @@ impl WindowManager {
                 // This is to ensure that even on an empty workspace on a secondary monitor, the
                 // secondary monitor where the cursor is focused will be used as the target for
                 // the workspace switch op
-                if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
-                    self.focus_monitor(monitor_idx)?;
+                if self.mouse_follows_focus {
+                    if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
+                        self.focus_monitor(monitor_idx)?;
+                    }
                 }
 
                 if self.focused_workspace_idx().unwrap_or_default() != workspace_idx {
@@ -838,8 +846,10 @@ impl WindowManager {
                 // This is to ensure that even on an empty workspace on a secondary monitor, the
                 // secondary monitor where the cursor is focused will be used as the target for
                 // the workspace switch op
-                if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
-                    self.focus_monitor(monitor_idx)?;
+                if self.mouse_follows_focus {
+                    if let Some(monitor_idx) = self.monitor_idx_from_current_pos() {
+                        self.focus_monitor(monitor_idx)?;
+                    }
                 }
 
                 let focused_monitor_idx = self.focused_monitor_idx();


### PR DESCRIPTION
If i understood the reason for this "re-focus" correctly this should be the proper fix for the problem. When having mouse follows focus disabled and trying to switch the workspace on another monitor by first switching focus to that monitor and then changing workspace it doesn't matter which monitor you have focused as it will automatically focus the monitor your cursor is on  