### PR TITLE
feat: add move-new-windows-to-focused-monitor

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -150,6 +150,8 @@ impl WindowManager {
                     if let Ok(class) = window.class() {
                         if class != "OleMainThreadWndClass"
                             && self.focused_monitor_idx() != monitor_idx
+                            && (!matches!(event, WindowManagerEvent::FocusChange(_, _)) || self.monitors().get(monitor_idx).unwrap().focused_workspace().unwrap().contains_window(window.hwnd))
+                            && (!matches!(event, WindowManagerEvent::Show(_, _)) || !self.move_new_windows_to_focused_monitor )
                         {
                             self.focus_monitor(monitor_idx)?;
                         }
@@ -247,30 +249,32 @@ impl WindowManager {
                 self.update_focused_workspace(self.mouse_follows_focus, false)?;
 
                 let workspace = self.focused_workspace_mut()?;
-                let floating_window_idx = workspace
-                    .floating_windows()
-                    .iter()
-                    .position(|w| w.hwnd == window.hwnd);
+                if workspace.contains_window(window.hwnd) {
+                    let floating_window_idx = workspace
+                        .floating_windows()
+                        .iter()
+                        .position(|w| w.hwnd == window.hwnd);
 
-                match floating_window_idx {
-                    None => {
-                        if let Some(w) = workspace.maximized_window() {
-                            if w.hwnd == window.hwnd {
-                                return Ok(());
+                    match floating_window_idx {
+                        None => {
+                            if let Some(w) = workspace.maximized_window() {
+                                if w.hwnd == window.hwnd {
+                                    return Ok(());
+                                }
+                            }
+
+                            if let Some(monocle) = workspace.monocle_container() {
+                                if let Some(window) = monocle.focused_window() {
+                                    window.focus(false)?;
+                                }
+                            } else {
+                                workspace.focus_container_by_window(window.hwnd)?;
                             }
                         }
-
-                        if let Some(monocle) = workspace.monocle_container() {
-                            if let Some(window) = monocle.focused_window() {
+                        Some(idx) => {
+                            if let Some(window) = workspace.floating_windows().get(idx) {
                                 window.focus(false)?;
                             }
-                        } else {
-                            workspace.focus_container_by_window(window.hwnd)?;
-                        }
-                    }
-                    Some(idx) => {
-                        if let Some(window) = workspace.floating_windows().get(idx) {
-                            window.focus(false)?;
                         }
                     }
                 }

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -369,6 +369,9 @@ pub struct StaticConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     // this option is a little special because it is only consumed by komorebic
     pub bar_configurations: Option<Vec<PathBuf>>,
+    /// Whether new windows should automatically be moved to the focused monitor
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub move_new_windows_to_focused_monitor: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -623,6 +626,7 @@ impl From<&WindowManager> for StaticConfig {
             ),
             slow_application_identifiers: Option::from(SLOW_APPLICATION_IDENTIFIERS.lock().clone()),
             bar_configurations: None,
+            move_new_windows_to_focused_monitor: Option::from(value.move_new_windows_to_focused_monitor),
         }
     }
 }
@@ -1055,6 +1059,7 @@ impl StaticConfig {
             pending_move_op: Arc::new(None),
             already_moved_window_handles: Arc::new(Mutex::new(HashSet::new())),
             uncloack_to_ignore: 0,
+            move_new_windows_to_focused_monitor: value.move_new_windows_to_focused_monitor.unwrap_or(false),
         };
 
         match value.focus_follows_mouse {
@@ -1232,6 +1237,10 @@ impl StaticConfig {
 
         if let Some(val) = value.mouse_follows_focus {
             wm.mouse_follows_focus = val;
+        }
+
+        if let Some(val) = value.move_new_windows_to_focused_monitor {
+            wm.move_new_windows_to_focused_monitor = val;
         }
 
         wm.work_area_offset = value.global_work_area_offset;

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -105,6 +105,7 @@ pub struct WindowManager {
     pub pending_move_op: Arc<Option<(usize, usize, isize)>>,
     pub already_moved_window_handles: Arc<Mutex<HashSet<isize>>>,
     pub uncloack_to_ignore: usize,
+    pub move_new_windows_to_focused_monitor: bool,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -343,6 +344,7 @@ impl WindowManager {
             pending_move_op: Arc::new(None),
             already_moved_window_handles: Arc::new(Mutex::new(HashSet::new())),
             uncloack_to_ignore: 0,
+            move_new_windows_to_focused_monitor: false
         })
     }
 


### PR DESCRIPTION
I personally prefer my windows to be spawned on the monitor i have currently selected instead of where windows decides to spawn it, so i added a config option to disable the monitor refocus when a window is shown. 

This PR also fixes an issue where for some reason a FocusChange event is called before the Show event (windows terminal is doing that for me) and because of that the window is not yet in any workspace which will for 1. throw an error in the FocusChanged match and for 2. refocus the monitor regardless of the config option