### PR TITLE
fix(wm): focus maximized windows when moving focus across monitors

### DIFF
--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1548,11 +1548,12 @@ impl WindowManager {
 
         tracing::info!("focusing container");
 
-        let new_idx = if workspace.monocle_container().is_some() {
-            None
-        } else {
-            workspace.new_idx_for_direction(direction)
-        };
+        let new_idx =
+            if workspace.maximized_window().is_some() || workspace.monocle_container().is_some() {
+                None
+            } else {
+                workspace.new_idx_for_direction(direction)
+            };
 
         let mut cross_monitor_monocle_or_max = false;
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1554,7 +1554,7 @@ impl WindowManager {
             workspace.new_idx_for_direction(direction)
         };
 
-        let mut cross_monitor_monocle = false;
+        let mut cross_monitor_monocle_or_max = false;
 
         // this is for when we are scrolling across workspaces like PaperWM
         if new_idx.is_none()
@@ -1631,14 +1631,24 @@ impl WindowManager {
                 let mouse_follows_focus = self.mouse_follows_focus;
 
                 if let Ok(focused_workspace) = self.focused_workspace_mut() {
-                    if let Some(monocle) = focused_workspace.monocle_container() {
+                    if let Some(window) = focused_workspace.maximized_window() {
+                        window.focus(mouse_follows_focus)?;
+                        // (alex-ds13): @LGUG2Z Why was this being done below on the monocle?
+                        // Should it really be done?
+                        //
+                        // WindowsApi::center_cursor_in_rect(&WindowsApi::window_rect(
+                        //     window.hwnd,
+                        // )?)?;
+
+                        cross_monitor_monocle_or_max = true;
+                    } else if let Some(monocle) = focused_workspace.monocle_container() {
                         if let Some(window) = monocle.focused_window() {
                             window.focus(mouse_follows_focus)?;
                             WindowsApi::center_cursor_in_rect(&WindowsApi::window_rect(
                                 window.hwnd,
                             )?)?;
 
-                            cross_monitor_monocle = true;
+                            cross_monitor_monocle_or_max = true;
                         }
                     } else {
                         match direction {
@@ -1675,7 +1685,7 @@ impl WindowManager {
             }
         }
 
-        if !cross_monitor_monocle {
+        if !cross_monitor_monocle_or_max {
             if let Ok(focused_window) = self.focused_window_mut() {
                 focused_window.focus(self.mouse_follows_focus)?;
             }


### PR DESCRIPTION
There was an issue where if you changed focus across monitors and the target monitor had a maximized window it would focus one of the containers beneath it instead. And if there were no containers it wouldn't focus anything, but instead keep focus on the previous monitor. This commit fixes that issue.

This was first brought up on discord [here](https://discord.com/channels/898554690126630914/1308841644853952543/1308841644853952543). The user has already tested this fix and it is working fine! Now is just a matter of deciding if we keep that code that centers the mouse on the screen, no matter what the value of "mff" is?
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
