### PR TITLE
Fix bar height for 0.1.30

### DIFF
--- a/docs/komorebi.bar.example.json
+++ b/docs/komorebi.bar.example.json
@@ -4,9 +4,9 @@
     "index": 0,
     "work_area_offset": {
       "left": 0,
-      "top": 40,
+      "top": 50,
       "right": 0,
-      "bottom": 40
+      "bottom": 50
     }
   },
   "font_family": "JetBrains Mono",


### PR DESCRIPTION
the new version seems to adjust the bar height from 40 to 50 pixels. This should fix it for a fresh install with default config. 