### PR TITLE
fix(wm): resize float windows moved across monitors

### DIFF
--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -318,15 +318,18 @@ impl Window {
         let corrected_relative_y = (window_relative_y as f32 * y_ratio) as i32;
         let window_x = current_area.left + corrected_relative_x;
         let window_y = current_area.top + corrected_relative_y;
+        let left = x_diff + window_x;
+        let top = y_diff + window_y;
+
+        let corrected_width = (current_rect.right as f32 * x_ratio) as i32;
+        let corrected_height = (current_rect.bottom as f32 * y_ratio) as i32;
 
         let new_rect = Rect {
-            left: x_diff + window_x,
-            top: y_diff + window_y,
-            right: current_rect.right,
-            bottom: current_rect.bottom,
+            left,
+            top,
+            right: corrected_width,
+            bottom: corrected_height,
         };
-        //TODO: We might need to take into account the differences in DPI for the new_rect, unless
-        //we can use the xy ratios above to the right/bottom (width/height of window) as well?
 
         self.set_position(&new_rect, true)
     }


### PR DESCRIPTION
Previously when moving floating windows across monitors we would keep the size of the window as it was. For most cases this would be ok. However for users with monitors with completely different sizes this could result on a window that would fill across monitors when moving from the bigger monitor to the smaller monitor.

This commit, attempts to resize the windows proportionally to the monitors' sizes.

There is currently a slight issue with some apps (so far I've only noticed it on 'Wezterm'...) where if the DPIs across monitors are different they don't seem to fully get the Windows OS DPI change completely applied,  but it seems that setting the `Wezterm` compatibility high DPI scaling override to "System" on the app's executable properties, fixes the issue. Since this is only 1 app (so far...) and only when the scales between monitors are different I decided to commit this anyway.

Since in the cases it was misbehaving with 'Wezterm' the result would be a wrongly resized window that is still completely visible on the target monitor anyway and the override fix seems to be good so far, I think we can merge nonetheless.

This fixes an issue brought up by a user on [Discord][1].

For anyone visiting this PR in the future the override setting I'm talking about is from this screen:
![image](https://github.com/user-attachments/assets/730fd445-8143-4e38-96e1-b6e5ecccdd4e)

Where instead of "Application" you should set it to "System". This should only be necessary if you notice that after moving a floating window across monitors with different sizes/DPIs the window moves and appears to do another resize that makes it bigger than the monitor you are trying to move to. So far I've only noticed this on Wezterm...

[1]: https://discord.com/channels/898554690126630914/1309289140482998282
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
