### PR TITLE
Fix moving on floating workspaces

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -585,11 +585,19 @@ impl WindowManager {
                                 // so that we don't have ghost tiles until we force an interaction on
                                 // the origin monitor's focused workspace
                                 self.focus_monitor(origin_monitor_idx)?;
-                                self.focus_workspace(origin_workspace_idx)?;
+                                let origin_monitor = self
+                                    .monitors_mut()
+                                    .get_mut(origin_monitor_idx)
+                                    .ok_or_else(|| anyhow!("there is no monitor at this idx"))?;
+                                origin_monitor.focus_workspace(origin_workspace_idx)?;
                                 self.update_focused_workspace(false, false)?;
 
                                 self.focus_monitor(target_monitor_idx)?;
-                                self.focus_workspace(target_workspace_idx)?;
+                                let target_monitor = self
+                                    .monitors_mut()
+                                    .get_mut(target_monitor_idx)
+                                    .ok_or_else(|| anyhow!("there is no monitor at this idx"))?;
+                                target_monitor.focus_workspace(target_workspace_idx)?;
                                 self.update_focused_workspace(false, false)?;
 
                                 // Make sure to give focus to the moved window again

--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -669,6 +669,7 @@ impl WindowManager {
             }
             WindowManagerEvent::MouseCapture(..)
             | WindowManagerEvent::Cloak(..)
+            | WindowManagerEvent::LocationChange(..)
             | WindowManagerEvent::TitleUpdate(..) => {}
         };
 
@@ -714,6 +715,7 @@ impl WindowManager {
         if !matches!(
             event,
             WindowManagerEvent::Show(WinEvent::ObjectNameChange, _)
+                | WindowManagerEvent::LocationChange(_, _)
         ) {
             tracing::info!("processed: {}", event.window().to_string());
         } else {

--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -485,8 +485,21 @@ impl WindowManager {
                     // place across a monitor boundary to an empty workspace
                     .unwrap_or(&Rect::default());
 
-                // This will be true if we have moved to an empty workspace on another monitor
-                let mut moved_across_monitors = old_position == Rect::default();
+                // This will be true if we have moved to another monitor
+                let mut moved_across_monitors = false;
+
+                for (i, monitors) in self.monitors().iter().enumerate() {
+                    for workspace in monitors.workspaces() {
+                        if workspace.contains_window(window.hwnd) && i != target_monitor_idx {
+                            moved_across_monitors = true;
+                            break;
+                        }
+                    }
+                    if moved_across_monitors {
+                        break;
+                    }
+                }
+
                 if let Some((origin_monitor_idx, origin_workspace_idx, _)) = pending {
                     // If we didn't move to another monitor with an empty workspace, it is
                     // still possible that we moved to another monitor with a populated workspace

--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -530,7 +530,9 @@ impl WindowManager {
                 }
 
                 let workspace = self.focused_workspace_mut()?;
-                if workspace.contains_managed_window(window.hwnd) || moved_across_monitors {
+                if (*workspace.tile() && workspace.contains_managed_window(window.hwnd))
+                    || moved_across_monitors
+                {
                     let resize = Rect {
                         left: new_position.left - old_position.left,
                         top: new_position.top - old_position.top,

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1437,8 +1437,12 @@ impl WindowManager {
             .get_mut(monitor_idx)
             .ok_or_else(|| anyhow!("there is no monitor"))?;
 
+        let mut should_load_workspace = false;
         if let Some(workspace_idx) = workspace_idx {
-            target_monitor.focus_workspace(workspace_idx)?;
+            if workspace_idx != target_monitor.focused_workspace_idx() {
+                target_monitor.focus_workspace(workspace_idx)?;
+                should_load_workspace = true;
+            }
         }
         let target_workspace = target_monitor
             .focused_workspace_mut()
@@ -1469,7 +1473,9 @@ impl WindowManager {
             bail!("failed to find a window to move");
         }
 
-        target_monitor.load_focused_workspace(mouse_follows_focus)?;
+        if should_load_workspace {
+            target_monitor.load_focused_workspace(mouse_follows_focus)?;
+        }
         target_monitor.update_focused_workspace(offset)?;
 
         // this second one is for DPI changes when the target is another monitor

--- a/komorebi/src/window_manager_event.rs
+++ b/komorebi/src/window_manager_event.rs
@@ -28,6 +28,7 @@ pub enum WindowManagerEvent {
     Unmanage(Window),
     Raise(Window),
     TitleUpdate(WinEvent, Window),
+    LocationChange(WinEvent, Window),
 }
 
 impl Display for WindowManagerEvent {
@@ -78,6 +79,9 @@ impl Display for WindowManagerEvent {
             Self::TitleUpdate(winevent, window) => {
                 write!(f, "TitleUpdate (WinEvent: {winevent}, Window: {window})")
             }
+            Self::LocationChange(winevent, window) => {
+                write!(f, "LocationChange (WinEvent: {winevent}, Window: {window})")
+            }
         }
     }
 }
@@ -98,7 +102,8 @@ impl WindowManagerEvent {
             | Self::Raise(window)
             | Self::Manage(window)
             | Self::Unmanage(window)
-            | Self::TitleUpdate(_, window) => window,
+            | Self::TitleUpdate(_, window)
+            | Self::LocationChange(_, window) => window,
         }
     }
 
@@ -122,6 +127,7 @@ impl WindowManagerEvent {
             WindowManagerEvent::Unmanage(_) => "Unmanage",
             WindowManagerEvent::Raise(_) => "Raise",
             WindowManagerEvent::TitleUpdate(_, _) => "TitleUpdate",
+            WindowManagerEvent::LocationChange(_, _) => "LocationChange",
         }
     }
 
@@ -137,6 +143,7 @@ impl WindowManagerEvent {
             | WindowManagerEvent::MoveResizeStart(event, _)
             | WindowManagerEvent::MoveResizeEnd(event, _)
             | WindowManagerEvent::MouseCapture(event, _)
+            | WindowManagerEvent::LocationChange(event, _)
             | WindowManagerEvent::TitleUpdate(event, _) => Some(event.to_string()),
             WindowManagerEvent::Manage(_)
             | WindowManagerEvent::Unmanage(_)
@@ -202,6 +209,7 @@ impl WindowManagerEvent {
                     Option::from(Self::TitleUpdate(winevent, window))
                 }
             }
+            WinEvent::ObjectLocationChange => Option::from(Self::LocationChange(winevent, window)),
             _ => None,
         }
     }


### PR DESCRIPTION
Moves within a floating workspace were being considered as moves across monitors. This would cause a weird issue in a situation were you were trying to move a window to a monitor that had a floating workspace and already had a window there, which was matched on `floating_windows` rules so was a floating window. This floating window would be focused on top of the window we just moved with mouse once we let go of the mouse with a bunch of focus flickering between the two windows.

Since moves within a floating workspace were wrongfully being considered as across monitors the behavior above would always happen when we moved/resized a window on a floating workspace.

This PR changes how moves across monitors are defined so we don't wrongfully consider a move across monitor when it wasn't, it also ignores moves/resizes within a floating workspace (we don't care about the positions and sizes of windows on floating workspaces...) and it also fixes the issue described above when we actually preform a move across monitors.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
