### PR TITLE
feat(bar): new grouping styles, hover effects on widgets and other small optimizations

### DIFF
--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -315,12 +315,14 @@ impl Komobar {
         let mut left_widgets = config
             .left_widgets
             .iter()
+            .filter(|config| config.enabled())
             .map(|config| config.as_boxed_bar_widget())
             .collect::<Vec<Box<dyn BarWidget>>>();
 
         let mut center_widgets = match &config.center_widgets {
             Some(center_widgets) => center_widgets
                 .iter()
+                .filter(|config| config.enabled())
                 .map(|config| config.as_boxed_bar_widget())
                 .collect::<Vec<Box<dyn BarWidget>>>(),
             None => vec![],
@@ -329,6 +331,7 @@ impl Komobar {
         let mut right_widgets = config
             .right_widgets
             .iter()
+            .filter(|config| config.enabled())
             .map(|config| config.as_boxed_bar_widget())
             .collect::<Vec<Box<dyn BarWidget>>>();
 

--- a/komorebi-bar/src/cpu.rs
+++ b/komorebi-bar/src/cpu.rs
@@ -30,17 +30,18 @@ pub struct CpuConfig {
 
 impl From<CpuConfig> for Cpu {
     fn from(value: CpuConfig) -> Self {
-        let mut system =
-            System::new_with_specifics(RefreshKind::default().without_memory().without_processes());
-
-        system.refresh_cpu_usage();
+        let data_refresh_interval = value.data_refresh_interval.unwrap_or(10);
 
         Self {
             enable: value.enable,
-            system,
-            data_refresh_interval: value.data_refresh_interval.unwrap_or(10),
+            system: System::new_with_specifics(
+                RefreshKind::default().without_memory().without_processes(),
+            ),
+            data_refresh_interval,
             label_prefix: value.label_prefix.unwrap_or(LabelPrefix::IconAndText),
-            last_updated: Instant::now(),
+            last_updated: Instant::now()
+                .checked_sub(Duration::from_secs(data_refresh_interval))
+                .unwrap(),
         }
     }
 }

--- a/komorebi-bar/src/cpu.rs
+++ b/komorebi-bar/src/cpu.rs
@@ -1,11 +1,11 @@
 use crate::config::LabelPrefix;
 use crate::render::RenderConfig;
+use crate::selected_frame::SelectableFrame;
 use crate::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Context;
 use eframe::egui::FontId;
 use eframe::egui::Label;
-use eframe::egui::Sense;
 use eframe::egui::TextFormat;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
@@ -99,13 +99,9 @@ impl BarWidget for Cpu {
                     TextFormat::simple(font_id, ctx.style().visuals.text_color()),
                 );
 
-                config.apply_on_widget(true, ui, |ui| {
-                    if ui
-                        .add(
-                            Label::new(layout_job)
-                                .selectable(false)
-                                .sense(Sense::click()),
-                        )
+                config.apply_on_widget(false, ui, |ui| {
+                    if SelectableFrame::new(false)
+                        .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                         .clicked()
                     {
                         if let Err(error) =

--- a/komorebi-bar/src/date.rs
+++ b/komorebi-bar/src/date.rs
@@ -1,11 +1,11 @@
 use crate::config::LabelPrefix;
 use crate::render::RenderConfig;
+use crate::selected_frame::SelectableFrame;
 use crate::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Context;
 use eframe::egui::FontId;
 use eframe::egui::Label;
-use eframe::egui::Sense;
 use eframe::egui::TextFormat;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
@@ -119,13 +119,14 @@ impl BarWidget for Date {
                     TextFormat::simple(font_id, ctx.style().visuals.text_color()),
                 );
 
-                config.apply_on_widget(true, ui, |ui| {
-                    if ui
-                        .add(
-                            Label::new(WidgetText::LayoutJob(layout_job.clone()))
-                                .selectable(false)
-                                .sense(Sense::click()),
-                        )
+                config.apply_on_widget(false, ui, |ui| {
+                    if SelectableFrame::new(false)
+                        .show(ui, |ui| {
+                            ui.add(
+                                Label::new(WidgetText::LayoutJob(layout_job.clone()))
+                                    .selectable(false),
+                            )
+                        })
                         .clicked()
                     {
                         self.format.next()

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -368,9 +368,10 @@ impl BarWidget for Komorebi {
                             .focused_window_idx;
 
                         let iter = titles.iter().zip(icons.iter());
+                        let len = iter.len();
 
                         for (i, (title, icon)) in iter.enumerate() {
-                            let selected = i == focused_window_idx;
+                            let selected = i == focused_window_idx && len != 1;
 
                             if SelectableFrame::new(selected)
                                 .show(ui, |ui| {

--- a/komorebi-bar/src/media.rs
+++ b/komorebi-bar/src/media.rs
@@ -1,4 +1,5 @@
 use crate::render::RenderConfig;
+use crate::selected_frame::SelectableFrame;
 use crate::ui::CustomUi;
 use crate::widget::BarWidget;
 use crate::MAX_LABEL_WIDTH;
@@ -6,7 +7,6 @@ use eframe::egui::text::LayoutJob;
 use eframe::egui::Context;
 use eframe::egui::FontId;
 use eframe::egui::Label;
-use eframe::egui::Sense;
 use eframe::egui::TextFormat;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
@@ -102,21 +102,20 @@ impl BarWidget for Media {
                     TextFormat::simple(font_id, ctx.style().visuals.text_color()),
                 );
 
-                config.apply_on_widget(true, ui, |ui| {
-                    let available_height = ui.available_height();
-                    let mut custom_ui = CustomUi(ui);
+                config.apply_on_widget(false, ui, |ui| {
+                    if SelectableFrame::new(false)
+                        .show(ui, |ui| {
+                            let available_height = ui.available_height();
+                            let mut custom_ui = CustomUi(ui);
 
-                    if custom_ui
-                        .add_sized_left_to_right(
-                            Vec2::new(
-                                MAX_LABEL_WIDTH.load(Ordering::SeqCst) as f32,
-                                available_height,
-                            ),
-                            Label::new(layout_job)
-                                .selectable(false)
-                                .sense(Sense::click())
-                                .truncate(),
-                        )
+                            custom_ui.add_sized_left_to_right(
+                                Vec2::new(
+                                    MAX_LABEL_WIDTH.load(Ordering::SeqCst) as f32,
+                                    available_height,
+                                ),
+                                Label::new(layout_job).selectable(false).truncate(),
+                            )
+                        })
                         .clicked()
                     {
                         self.toggle();

--- a/komorebi-bar/src/memory.rs
+++ b/komorebi-bar/src/memory.rs
@@ -1,11 +1,11 @@
 use crate::config::LabelPrefix;
 use crate::render::RenderConfig;
+use crate::selected_frame::SelectableFrame;
 use crate::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Context;
 use eframe::egui::FontId;
 use eframe::egui::Label;
-use eframe::egui::Sense;
 use eframe::egui::TextFormat;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
@@ -102,13 +102,9 @@ impl BarWidget for Memory {
                     TextFormat::simple(font_id, ctx.style().visuals.text_color()),
                 );
 
-                config.apply_on_widget(true, ui, |ui| {
-                    if ui
-                        .add(
-                            Label::new(layout_job)
-                                .selectable(false)
-                                .sense(Sense::click()),
-                        )
+                config.apply_on_widget(false, ui, |ui| {
+                    if SelectableFrame::new(false)
+                        .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                         .clicked()
                     {
                         if let Err(error) =

--- a/komorebi-bar/src/memory.rs
+++ b/komorebi-bar/src/memory.rs
@@ -30,17 +30,18 @@ pub struct MemoryConfig {
 
 impl From<MemoryConfig> for Memory {
     fn from(value: MemoryConfig) -> Self {
-        let mut system =
-            System::new_with_specifics(RefreshKind::default().without_cpu().without_processes());
-
-        system.refresh_memory();
+        let data_refresh_interval = value.data_refresh_interval.unwrap_or(10);
 
         Self {
             enable: value.enable,
-            system,
-            data_refresh_interval: value.data_refresh_interval.unwrap_or(10),
+            system: System::new_with_specifics(
+                RefreshKind::default().without_cpu().without_processes(),
+            ),
+            data_refresh_interval,
             label_prefix: value.label_prefix.unwrap_or(LabelPrefix::IconAndText),
-            last_updated: Instant::now(),
+            last_updated: Instant::now()
+                .checked_sub(Duration::from_secs(data_refresh_interval))
+                .unwrap(),
         }
     }
 }

--- a/komorebi-bar/src/network.rs
+++ b/komorebi-bar/src/network.rs
@@ -1,11 +1,11 @@
 use crate::config::LabelPrefix;
 use crate::render::RenderConfig;
+use crate::selected_frame::SelectableFrame;
 use crate::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Context;
 use eframe::egui::FontId;
 use eframe::egui::Label;
-use eframe::egui::Sense;
 use eframe::egui::TextFormat;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
@@ -303,13 +303,9 @@ impl BarWidget for Network {
                     TextFormat::simple(font_id, ctx.style().visuals.text_color()),
                 );
 
-                config.apply_on_widget(true, ui, |ui| {
-                    if ui
-                        .add(
-                            Label::new(layout_job)
-                                .selectable(false)
-                                .sense(Sense::click()),
-                        )
+                config.apply_on_widget(false, ui, |ui| {
+                    if SelectableFrame::new(false)
+                        .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                         .clicked()
                     {
                         if let Err(error) = Command::new("cmd.exe").args(["/C", "ncpa"]).spawn() {

--- a/komorebi-bar/src/network.rs
+++ b/komorebi-bar/src/network.rs
@@ -27,6 +27,8 @@ pub struct NetworkConfig {
     pub show_total_data_transmitted: bool,
     /// Show network activity
     pub show_network_activity: bool,
+    /// Show default interface
+    pub show_default_interface: Option<bool>,
     /// Characters to reserve for network activity data
     pub network_activity_fill_characters: Option<usize>,
     /// Data refresh interval (default: 10 seconds)
@@ -41,12 +43,13 @@ impl From<NetworkConfig> for Network {
 
         Self {
             enable: value.enable,
+            show_total_activity: value.show_total_data_transmitted,
+            show_activity: value.show_network_activity,
+            show_default_interface: value.show_default_interface.unwrap_or(true),
             networks_network_activity: Networks::new_with_refreshed_list(),
             default_interface: String::new(),
             data_refresh_interval,
             label_prefix: value.label_prefix.unwrap_or(LabelPrefix::Icon),
-            show_total_activity: value.show_total_data_transmitted,
-            show_activity: value.show_network_activity,
             network_activity_fill_characters: value
                 .network_activity_fill_characters
                 .unwrap_or_default(),
@@ -63,6 +66,7 @@ pub struct Network {
     pub enable: bool,
     pub show_total_activity: bool,
     pub show_activity: bool,
+    pub show_default_interface: bool,
     networks_network_activity: Networks,
     data_refresh_interval: u64,
     label_prefix: LabelPrefix,
@@ -250,69 +254,72 @@ impl Network {
 
 impl BarWidget for Network {
     fn render(&mut self, ctx: &Context, ui: &mut Ui, config: &mut RenderConfig) {
-        if self.show_total_activity || self.show_activity {
-            let (activity, total_activity) = self.network_activity();
-
-            if self.show_total_activity {
-                for reading in total_activity {
-                    config.apply_on_widget(true, ui, |ui| {
-                        ui.add(self.reading_to_label(ctx, reading));
-                    });
-                }
-            }
-
-            if self.show_activity {
-                for reading in activity {
-                    config.apply_on_widget(true, ui, |ui| {
-                        ui.add(self.reading_to_label(ctx, reading));
-                    });
-                }
-            }
-        }
-
         if self.enable {
-            self.default_interface();
+            if self.show_total_activity || self.show_activity {
+                let (activity, total_activity) = self.network_activity();
 
-            if !self.default_interface.is_empty() {
-                let font_id = ctx
-                    .style()
-                    .text_styles
-                    .get(&TextStyle::Body)
-                    .cloned()
-                    .unwrap_or_else(FontId::default);
-
-                let mut layout_job = LayoutJob::simple(
-                    match self.label_prefix {
-                        LabelPrefix::Icon | LabelPrefix::IconAndText => {
-                            egui_phosphor::regular::WIFI_HIGH.to_string()
-                        }
-                        LabelPrefix::None | LabelPrefix::Text => String::new(),
-                    },
-                    font_id.clone(),
-                    ctx.style().visuals.selection.stroke.color,
-                    100.0,
-                );
-
-                if let LabelPrefix::Text | LabelPrefix::IconAndText = self.label_prefix {
-                    self.default_interface.insert_str(0, "NET: ");
+                if self.show_total_activity {
+                    for reading in total_activity {
+                        config.apply_on_widget(true, ui, |ui| {
+                            ui.add(self.reading_to_label(ctx, reading));
+                        });
+                    }
                 }
 
-                layout_job.append(
-                    &self.default_interface,
-                    10.0,
-                    TextFormat::simple(font_id, ctx.style().visuals.text_color()),
-                );
-
-                config.apply_on_widget(false, ui, |ui| {
-                    if SelectableFrame::new(false)
-                        .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
-                        .clicked()
-                    {
-                        if let Err(error) = Command::new("cmd.exe").args(["/C", "ncpa"]).spawn() {
-                            eprintln!("{}", error)
-                        }
+                if self.show_activity {
+                    for reading in activity {
+                        config.apply_on_widget(true, ui, |ui| {
+                            ui.add(self.reading_to_label(ctx, reading));
+                        });
                     }
-                });
+                }
+            }
+
+            if self.show_default_interface {
+                self.default_interface();
+
+                if !self.default_interface.is_empty() {
+                    let font_id = ctx
+                        .style()
+                        .text_styles
+                        .get(&TextStyle::Body)
+                        .cloned()
+                        .unwrap_or_else(FontId::default);
+
+                    let mut layout_job = LayoutJob::simple(
+                        match self.label_prefix {
+                            LabelPrefix::Icon | LabelPrefix::IconAndText => {
+                                egui_phosphor::regular::WIFI_HIGH.to_string()
+                            }
+                            LabelPrefix::None | LabelPrefix::Text => String::new(),
+                        },
+                        font_id.clone(),
+                        ctx.style().visuals.selection.stroke.color,
+                        100.0,
+                    );
+
+                    if let LabelPrefix::Text | LabelPrefix::IconAndText = self.label_prefix {
+                        self.default_interface.insert_str(0, "NET: ");
+                    }
+
+                    layout_job.append(
+                        &self.default_interface,
+                        10.0,
+                        TextFormat::simple(font_id, ctx.style().visuals.text_color()),
+                    );
+
+                    config.apply_on_widget(false, ui, |ui| {
+                        if SelectableFrame::new(false)
+                            .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
+                            .clicked()
+                        {
+                            if let Err(error) = Command::new("cmd.exe").args(["/C", "ncpa"]).spawn()
+                            {
+                                eprintln!("{}", error)
+                            }
+                        }
+                    });
+                }
             }
         }
     }

--- a/komorebi-bar/src/render.rs
+++ b/komorebi-bar/src/render.rs
@@ -178,11 +178,59 @@ impl RenderConfig {
                 Some(style) => match style {
                     // new styles can be added if needed here
                     GroupingStyle::Default => Shadow::NONE,
-                    GroupingStyle::DefaultWithShadow => Shadow {
+                    GroupingStyle::DefaultWithShadowB4O1S3 => Shadow {
                         blur: 4.0,
                         offset: Vec2::new(1.0, 1.0),
                         spread: 3.0,
                         color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
+                    },
+                    GroupingStyle::DefaultWithShadowB4O0S3 => Shadow {
+                        blur: 4.0,
+                        offset: Vec2::new(0.0, 0.0),
+                        spread: 3.0,
+                        color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
+                    },
+                    GroupingStyle::DefaultWithShadowB0O1S3 => Shadow {
+                        blur: 0.0,
+                        offset: Vec2::new(1.0, 1.0),
+                        spread: 3.0,
+                        color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
+                    },
+                    GroupingStyle::DefaultWithGlowB3O1S2 => Shadow {
+                        blur: 3.0,
+                        offset: Vec2::new(1.0, 1.0),
+                        spread: 2.0,
+                        color: ui
+                            .style()
+                            .visuals
+                            .selection
+                            .stroke
+                            .color
+                            .try_apply_alpha(config.transparency_alpha),
+                    },
+                    GroupingStyle::DefaultWithGlowB3O0S2 => Shadow {
+                        blur: 3.0,
+                        offset: Vec2::new(0.0, 0.0),
+                        spread: 2.0,
+                        color: ui
+                            .style()
+                            .visuals
+                            .selection
+                            .stroke
+                            .color
+                            .try_apply_alpha(config.transparency_alpha),
+                    },
+                    GroupingStyle::DefaultWithGlowB0O1S2 => Shadow {
+                        blur: 0.0,
+                        offset: Vec2::new(1.0, 1.0),
+                        spread: 2.0,
+                        color: ui
+                            .style()
+                            .visuals
+                            .selection
+                            .stroke
+                            .color
+                            .try_apply_alpha(config.transparency_alpha),
                     },
                 },
                 None => Shadow::NONE,
@@ -239,9 +287,20 @@ pub struct GroupingConfig {
 pub enum GroupingStyle {
     #[serde(alias = "CtByte")]
     Default,
-    /// A black shadow is added under the default group
+    /// A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)
     #[serde(alias = "CtByteWithShadow")]
-    DefaultWithShadow,
+    #[serde(alias = "DefaultWithShadow")]
+    DefaultWithShadowB4O1S3,
+    /// A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)
+    DefaultWithShadowB4O0S3,
+    /// A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)
+    DefaultWithShadowB0O1S3,
+    /// A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)
+    DefaultWithGlowB3O1S2,
+    /// A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)
+    DefaultWithGlowB3O0S2,
+    /// A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)
+    DefaultWithGlowB0O1S2,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/komorebi-bar/src/storage.rs
+++ b/komorebi-bar/src/storage.rs
@@ -1,11 +1,11 @@
 use crate::config::LabelPrefix;
 use crate::render::RenderConfig;
+use crate::selected_frame::SelectableFrame;
 use crate::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Context;
 use eframe::egui::FontId;
 use eframe::egui::Label;
-use eframe::egui::Sense;
 use eframe::egui::TextFormat;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
@@ -107,13 +107,9 @@ impl BarWidget for Storage {
                     TextFormat::simple(font_id.clone(), ctx.style().visuals.text_color()),
                 );
 
-                config.apply_on_widget(true, ui, |ui| {
-                    if ui
-                        .add(
-                            Label::new(layout_job)
-                                .selectable(false)
-                                .sense(Sense::click()),
-                        )
+                config.apply_on_widget(false, ui, |ui| {
+                    if SelectableFrame::new(false)
+                        .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                         .clicked()
                     {
                         if let Err(error) = Command::new("cmd.exe")

--- a/komorebi-bar/src/time.rs
+++ b/komorebi-bar/src/time.rs
@@ -1,11 +1,11 @@
 use crate::config::LabelPrefix;
 use crate::render::RenderConfig;
+use crate::selected_frame::SelectableFrame;
 use crate::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Context;
 use eframe::egui::FontId;
 use eframe::egui::Label;
-use eframe::egui::Sense;
 use eframe::egui::TextFormat;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
@@ -110,13 +110,9 @@ impl BarWidget for Time {
                     TextFormat::simple(font_id, ctx.style().visuals.text_color()),
                 );
 
-                config.apply_on_widget(true, ui, |ui| {
-                    if ui
-                        .add(
-                            Label::new(layout_job)
-                                .selectable(false)
-                                .sense(Sense::click()),
-                        )
+                config.apply_on_widget(false, ui, |ui| {
+                    if SelectableFrame::new(false)
+                        .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                         .clicked()
                     {
                         self.format.toggle()

--- a/komorebi-bar/src/widget.rs
+++ b/komorebi-bar/src/widget.rs
@@ -54,4 +54,35 @@ impl WidgetConfig {
             WidgetConfig::Time(config) => Box::new(Time::from(config.clone())),
         }
     }
+
+    pub fn enabled(&self) -> bool {
+        match self {
+            WidgetConfig::Battery(config) => config.enable,
+            WidgetConfig::Cpu(config) => config.enable,
+            WidgetConfig::Date(config) => config.enable,
+            WidgetConfig::Komorebi(config) => {
+                config.workspaces.enable
+                    || (if let Some(layout) = &config.layout {
+                        layout.enable
+                    } else {
+                        false
+                    })
+                    || (if let Some(focused_window) = &config.focused_window {
+                        focused_window.enable
+                    } else {
+                        false
+                    })
+                    || (if let Some(configuration_switcher) = &config.configuration_switcher {
+                        configuration_switcher.enable
+                    } else {
+                        false
+                    })
+            }
+            WidgetConfig::Media(config) => config.enable,
+            WidgetConfig::Memory(config) => config.enable,
+            WidgetConfig::Network(config) => config.enable,
+            WidgetConfig::Storage(config) => config.enable,
+            WidgetConfig::Time(config) => config.enable,
+        }
+    }
 }


### PR DESCRIPTION
This meant to contain a few smaller changes that I think would make the bar even better. I will try to keep this small.

- [fix(bar): only indicate focused window on stack](https://github.com/LGUG2Z/komorebi/commit/6e0b71ce3623ddc7b9f177d75970fe04e23b7944)
- [feat(bar): 5 new grouping styles for shadow and glow](https://github.com/LGUG2Z/komorebi/commit/c982cb069aa8b6e04bbc35dd6c74932304abb8b6)
- [feat(bar): indicate clickable widgets](https://github.com/LGUG2Z/komorebi/pull/1163/commits/9c47c700cc1c39b078df8a09d79520ea4cb62925)
- [feat(bar): network widget - added show_default_interface and use enab…](https://github.com/LGUG2Z/komorebi/pull/1163/commits/b89fd7b94d695260b87ed8d7bff19f88adef7686)
- [feat(bar): only collect enabled widgets](https://github.com/LGUG2Z/komorebi/pull/1163/commits/2453d67a3b24c7dec48671b01aead7f98a68e29b)

---

## Grouping styles with shadows and glow on dark and light themes

DefaultWithShadowB4O1S3 / DefaultWithShadow / CtByteWithShadow
![image](https://github.com/user-attachments/assets/5e404024-3129-4ae0-a767-488a66c04d7c)
![image](https://github.com/user-attachments/assets/300c0ca4-ef09-4ee2-98d7-fc50112a2670)

DefaultWithShadowB4O0S3
![image](https://github.com/user-attachments/assets/b2751aa1-84ab-44fa-b7d9-5cde51b149ae)
![image](https://github.com/user-attachments/assets/740cc689-3feb-4444-a311-229c979dbf41)

DefaultWithShadowB0O1S3
![image](https://github.com/user-attachments/assets/61734064-f9b1-4b1f-953d-b2ddb128ce12)
![image](https://github.com/user-attachments/assets/e7d4ec71-f190-4fdd-be26-ca0857ddcf14)

DefaultWithGlowB3O1S2
![image](https://github.com/user-attachments/assets/8bede338-5f57-4bbf-a9e1-71df7d5c44e4)
![image](https://github.com/user-attachments/assets/7adaaf92-68fa-493b-94ff-510f60c6e407)

DefaultWithGlowB3O0S2
![image](https://github.com/user-attachments/assets/848cca46-7ad2-4c41-bd73-94294f9c7d2f)
![image](https://github.com/user-attachments/assets/dd695778-4f8e-4c9d-8fae-67aa4bd36327)

DefaultWithGlowB0O1S2
![image](https://github.com/user-attachments/assets/ad7f6ed1-7f98-4f04-b707-b43bc0023c2d)
![image](https://github.com/user-attachments/assets/9f909680-228e-45a3-a1f4-47fef05fce1b)
