### PR TITLE
fix(border): stop removing borders on wrong monitors

### DIFF
--- a/komorebi/src/border_manager/mod.rs
+++ b/komorebi/src/border_manager/mod.rs
@@ -369,9 +369,11 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                             continue 'monitors;
                         }
 
-                        let is_maximized = WindowsApi::is_zoomed(
-                            WindowsApi::foreground_window().unwrap_or_default(),
-                        );
+                        let foreground_hwnd = WindowsApi::foreground_window().unwrap_or_default();
+                        let foreground_monitor_id =
+                            WindowsApi::monitor_from_window(foreground_hwnd);
+                        let is_maximized = foreground_monitor_id == m.id()
+                            && WindowsApi::is_zoomed(foreground_hwnd);
 
                         if is_maximized {
                             let mut to_remove = vec![];


### PR DESCRIPTION
There is a bug where the border manager is checking if the foreground window is maximized to remove all the borders on that monitor. However this check for `is_maximized` didn't check if the foreground window in question was on the current monitor being iterated through. So when the foreground (focused) window was maximized, every borders on all monitors were being removed.

This fix makes sure we check if the foreground window is on the monitor being iterated through and only remove the borders on that specific monitor.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
