### PR TITLE
fix(borders): properly handle borders ZOrder

### DIFF
--- a/komorebi/src/border_manager/border.rs
+++ b/komorebi/src/border_manager/border.rs
@@ -425,6 +425,18 @@ impl Border {
                             return LRESULT(0);
                         }
 
+                        let reference_hwnd = (*border_pointer).tracking_hwnd;
+
+                        // Update position to update the ZOrder
+                        let border_window_rect = (*border_pointer).window_rect;
+
+                        tracing::trace!("updating border position");
+                        if let Err(error) =
+                            (*border_pointer).set_position(&border_window_rect, reference_hwnd)
+                        {
+                            tracing::error!("failed to update border position {error}");
+                        }
+
                         if let Some(render_target) = (*border_pointer).render_target.get() {
                             (*border_pointer).width = BORDER_WIDTH.load(Ordering::Relaxed);
                             (*border_pointer).offset = BORDER_OFFSET.load(Ordering::Relaxed);


### PR DESCRIPTION
This commit makes it so a floating window only has the floating border when it is focused, if not it has the `Unfocused` border. It also makes the 'focused_container' have the `Unfocused` border when it is not the foreground window, for example when we have a floating window focused instead.

This commit also changes the border's `window_kind` so that the stored borders actually have that value so we can check it later (This value wasn't being updated).

This commit also makes it so we properly invalidate the borders in the situations discussed above (for example when changing focus to/from a floating window we need the floating window border to update its ZOrder as well as the previously focused window).

Lastly this commit, changes the `WM_PAINT` code part of the border so that it now sets the position of border so that the border's ZOrder updates to it's tracking window ZOrder.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
