### PR TITLE
Fix: prevent bar from changing `mff`

### DIFF
--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -220,53 +220,45 @@ impl BarWidget for Komorebi {
                         .clicked()
                         {
                             update = Some(ws.to_string());
-                            let mut proceed = true;
 
-                            if komorebi_client::send_message(&SocketMessage::MouseFollowsFocus(
-                                false,
-                            ))
-                            .is_err()
-                            {
-                                tracing::error!(
-                                    "could not send message to komorebi: MouseFollowsFocus"
-                                );
-                                proceed = false;
-                            }
-
-                            if proceed
-                                && komorebi_client::send_message(
-                                    &SocketMessage::FocusMonitorWorkspaceNumber(
+                            if komorebi_notification_state.mouse_follows_focus {
+                                if komorebi_client::send_batch([
+                                    SocketMessage::MouseFollowsFocus(false),
+                                    SocketMessage::FocusMonitorWorkspaceNumber(
                                         komorebi_notification_state.monitor_index,
                                         i,
                                     ),
-                                )
+                                    SocketMessage::RetileWithResizeDimensions,
+                                    SocketMessage::MouseFollowsFocus(true),
+                                ])
                                 .is_err()
+                                {
+                                    tracing::error!(
+                                        "could not send the following batch of messages to komorebi:\n
+                                        MouseFollowsFocus(false)\n
+                                        FocusMonitorWorkspaceNumber({}, {})\n
+                                        RetileWithResizeDimensions
+                                        MouseFollowsFocus(true)\n",
+                                        komorebi_notification_state.monitor_index,
+                                        i,
+                                    );
+                                }
+                            } else if komorebi_client::send_batch([
+                                SocketMessage::FocusMonitorWorkspaceNumber(
+                                    komorebi_notification_state.monitor_index,
+                                    i,
+                                ),
+                                SocketMessage::RetileWithResizeDimensions,
+                            ])
+                            .is_err()
                             {
                                 tracing::error!(
-                                    "could not send message to komorebi: FocusWorkspaceNumber"
+                                    "could not send the following batch of messages to komorebi:\n
+                                    FocusMonitorWorkspaceNumber({}, {})\n
+                                    RetileWithResizeDimensions",
+                                    komorebi_notification_state.monitor_index,
+                                    i,
                                 );
-                                proceed = false;
-                            }
-
-                            if proceed
-                                && komorebi_client::send_message(&SocketMessage::MouseFollowsFocus(
-                                    komorebi_notification_state.mouse_follows_focus,
-                                ))
-                                .is_err()
-                            {
-                                tracing::error!(
-                                    "could not send message to komorebi: MouseFollowsFocus"
-                                );
-                                proceed = false;
-                            }
-
-                            if proceed
-                                && komorebi_client::send_message(
-                                    &SocketMessage::RetileWithResizeDimensions,
-                                )
-                                .is_err()
-                            {
-                                tracing::error!("could not send message to komorebi: Retile");
                             }
                         }
                     }
@@ -426,33 +418,25 @@ impl BarWidget for Komorebi {
                                     return;
                                 }
 
-                                if komorebi_client::send_message(&SocketMessage::MouseFollowsFocus(
-                                    false,
-                                ))
-                                .is_err()
-                                {
-                                    tracing::error!(
-                                        "could not send message to komorebi: MouseFollowsFocus"
-                                    );
-                                }
-
-                                if komorebi_client::send_message(&SocketMessage::FocusStackWindow(
-                                    i,
-                                ))
-                                .is_err()
-                                {
+                                if komorebi_notification_state.mouse_follows_focus {
+                                    if komorebi_client::send_batch([
+                                        SocketMessage::MouseFollowsFocus(false),
+                                        SocketMessage::FocusStackWindow(i),
+                                        SocketMessage::MouseFollowsFocus(true),
+                                    ]).is_err() {
+                                        tracing::error!(
+                                            "could not send the following batch of messages to komorebi:\n
+                                            MouseFollowsFocus(false)\n
+                                            FocusStackWindow({})\n
+                                            MouseFollowsFocus(true)\n",
+                                            i,
+                                        );
+                                    }
+                                } else if komorebi_client::send_message(
+                                    &SocketMessage::FocusStackWindow(i)
+                                ).is_err() {
                                     tracing::error!(
                                         "could not send message to komorebi: FocusStackWindow"
-                                    );
-                                }
-
-                                if komorebi_client::send_message(&SocketMessage::MouseFollowsFocus(
-                                    komorebi_notification_state.mouse_follows_focus,
-                                ))
-                                .is_err()
-                                {
-                                    tracing::error!(
-                                        "could not send message to komorebi: MouseFollowsFocus"
                                     );
                                 }
                             }

--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -68,6 +68,20 @@ pub fn send_message(message: &SocketMessage) -> std::io::Result<()> {
     stream.write_all(serde_json::to_string(message)?.as_bytes())
 }
 
+pub fn send_batch(messages: impl IntoIterator<Item = SocketMessage>) -> std::io::Result<()> {
+    let socket = DATA_DIR.join(KOMOREBI);
+    let mut stream = UnixStream::connect(socket)?;
+    stream.set_write_timeout(Some(Duration::from_secs(1)))?;
+    let msgs = messages.into_iter().fold(String::new(), |mut s, m| {
+        if let Ok(m_str) = serde_json::to_string(&m) {
+            s.push_str(&m_str);
+            s.push('\n');
+        }
+        s
+    });
+    stream.write_all(msgs.as_bytes())
+}
+
 pub fn send_query(message: &SocketMessage) -> std::io::Result<String> {
     let socket = DATA_DIR.join(KOMOREBI);
 


### PR DESCRIPTION
This PR adds a helper function `send_batch` to komorebi-client that allows sending multiple messages in a batch. 3rd party users of this library could already do this themselves but it is nice to have this helper to simplify it.

Then, on komorebi-bar it makes use of the new `send_batch` function to batch all the messages in one go when pressing the button to move between workspaces or when moving between stacked windows.
Since we are creating this messages in one go we won't be mistakenly changing the value of `mff` for the user.
It also only batches the `mff` messages when the `mff` value it's true, if it is already false there is no need to be sending those extra messages.
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
