### PR TITLE
Feature(wm)/stop ignore restore

### DIFF
--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -105,6 +105,7 @@ pub enum SocketMessage {
     NewWorkspace,
     ToggleTiling,
     Stop,
+    StopIgnoreRestore,
     TogglePause,
     Retile,
     RetileWithResizeDimensions,

--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -307,7 +307,7 @@ fn main() -> Result<()> {
 
     ANIMATION_ENABLED_PER_ANIMATION.lock().clear();
     ANIMATION_ENABLED_GLOBAL.store(false, Ordering::SeqCst);
-    wm.lock().restore_all_windows()?;
+    wm.lock().restore_all_windows(false)?;
     AnimationEngine::wait_for_all_animations();
 
     if WindowsApi::focus_follows_mouse()? {

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
-use std::env::temp_dir;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::io::Read;
-use std::net::Shutdown;
 use std::net::TcpListener;
 use std::net::TcpStream;
 use std::num::NonZeroUsize;
@@ -23,7 +21,6 @@ use schemars::gen::SchemaSettings;
 use schemars::schema_for;
 use uds_windows::UnixStream;
 
-use crate::animation::AnimationEngine;
 use crate::animation::ANIMATION_DURATION_PER_ANIMATION;
 use crate::animation::ANIMATION_ENABLED_PER_ANIMATION;
 use crate::animation::ANIMATION_STYLE_PER_ANIMATION;
@@ -913,36 +910,10 @@ impl WindowManager {
                 }
             }
             SocketMessage::Stop => {
-                tracing::info!(
-                    "received stop command, restoring all hidden windows and terminating process"
-                );
-
-                let state = &window_manager::State::from(&*self);
-                std::fs::write(
-                    temp_dir().join("komorebi.state.json"),
-                    serde_json::to_string_pretty(&state)?,
-                )?;
-
-                ANIMATION_ENABLED_PER_ANIMATION.lock().clear();
-                ANIMATION_ENABLED_GLOBAL.store(false, Ordering::SeqCst);
-                self.restore_all_windows()?;
-                AnimationEngine::wait_for_all_animations();
-
-                if WindowsApi::focus_follows_mouse()? {
-                    WindowsApi::disable_focus_follows_mouse()?;
-                }
-
-                let sockets = SUBSCRIPTION_SOCKETS.lock();
-                for path in (*sockets).values() {
-                    if let Ok(stream) = UnixStream::connect(path) {
-                        stream.shutdown(Shutdown::Both)?;
-                    }
-                }
-
-                let socket = DATA_DIR.join("komorebi.sock");
-                let _ = std::fs::remove_file(socket);
-
-                std::process::exit(0)
+                self.stop(false)?;
+            }
+            SocketMessage::StopIgnoreRestore => {
+                self.stop(true)?;
             }
             SocketMessage::MonitorIndexPreference(index_preference, left, top, right, bottom) => {
                 let mut monitor_index_preferences = MONITOR_INDEX_PREFERENCES.lock();
@@ -1257,7 +1228,7 @@ impl WindowManager {
                     // Pause so that restored windows come to the foreground from all workspaces
                     self.is_paused = true;
                     // Bring all windows to the foreground
-                    self.restore_all_windows()?;
+                    self.restore_all_windows(false)?;
 
                     // Create a new wm from the config path
                     let mut wm = StaticConfig::preload(

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -801,6 +801,9 @@ struct Stop {
     /// Stop masir if it is running as a background process
     #[clap(long)]
     masir: bool,
+    /// Do not restore windows after stopping komorebi
+    #[clap(long, hide = true)]
+    ignore_restore: bool,
 }
 
 #[derive(Parser)]
@@ -2300,7 +2303,11 @@ if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
                 }
             }
 
-            send_message(&SocketMessage::Stop)?;
+            if arg.ignore_restore {
+                send_message(&SocketMessage::StopIgnoreRestore)?;
+            } else {
+                send_message(&SocketMessage::Stop)?;
+            }
             let mut system = sysinfo::System::new_all();
             system.refresh_processes(ProcessesToUpdate::All);
 


### PR DESCRIPTION
This PR creates a new `SocketMessage` called `StopIgnoreRestore` which makes komorebi stop without calling `window.restore()` on all windows. This way every maximized window will stay maximized once you start komorebi again and it is able to use the previous `State`.

If it fails to restore the previous state you might have to call `komorebic restore-windows` in case you had hidden windows, for example when when using the `window_hiding_behaviour` as `Hide`, or you can simply unminimize them if you were using `Cloak` or `Minimize`.

This PR is built on top #1185 so it needs to be merged after that one.

@LGUG2Z I've made this just a draft PR so you can give me your feedback and tell me if you think it's fine to add or if you rather not add it to not increase complexity just to appease the needs of one person (that one person being me 😄). I don't think users can use this to shoot themselves on the foot because even if they are using `window_hiding_behaviour` as `Hide` they can always call `komorebic restore-windows` afterwards if for some reason komorebi fails to load their previous `State`.
Also this command is mostly intended for developers that are making changes to komorebi code and need to be restarting it a lot of times.
However I totally understand if you think it's better not to add it. In that case I might keep rebasing this commit on top of master just for me... 😄 
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
