### PR TITLE
feat(bar): added icon_scale to the config

### DIFF
--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -245,8 +245,11 @@ impl Komobar {
             Self::set_font_size(ctx, *font_size);
         }
 
-        self.render_config
-            .replace(config.new_renderconfig(ctx, *self.bg_color.borrow()));
+        self.render_config.replace(config.new_renderconfig(
+            ctx,
+            *self.bg_color.borrow(),
+            config.icon_scale,
+        ));
 
         let mut komorebi_notification_state = previous_notification_state;
         let mut komorebi_widgets = Vec::new();

--- a/komorebi-bar/src/config.rs
+++ b/komorebi-bar/src/config.rs
@@ -25,6 +25,8 @@ pub struct KomobarConfig {
     pub font_family: Option<String>,
     /// Font size (default: 12.5)
     pub font_size: Option<f32>,
+    /// Scale of the icons relative to the font_size [[1.0-2.0]]. (default: 1.4)
+    pub icon_scale: Option<f32>,
     /// Max label width before text truncation (default: 400.0)
     pub max_label_width: Option<f32>,
     /// Theme

--- a/komorebi-bar/src/render.rs
+++ b/komorebi-bar/src/render.rs
@@ -56,11 +56,21 @@ pub struct RenderConfig {
 }
 
 pub trait RenderExt {
-    fn new_renderconfig(&self, ctx: &Context, background_color: Color32) -> RenderConfig;
+    fn new_renderconfig(
+        &self,
+        ctx: &Context,
+        background_color: Color32,
+        icon_scale: Option<f32>,
+    ) -> RenderConfig;
 }
 
 impl RenderExt for &KomobarConfig {
-    fn new_renderconfig(&self, ctx: &Context, background_color: Color32) -> RenderConfig {
+    fn new_renderconfig(
+        &self,
+        ctx: &Context,
+        background_color: Color32,
+        icon_scale: Option<f32>,
+    ) -> RenderConfig {
         let text_font_id = ctx
             .style()
             .text_styles
@@ -69,7 +79,7 @@ impl RenderExt for &KomobarConfig {
             .unwrap_or_else(FontId::default);
 
         let mut icon_font_id = text_font_id.clone();
-        icon_font_id.size *= 1.4;
+        icon_font_id.size *= icon_scale.unwrap_or(1.4).clamp(1.0, 2.0);
 
         RenderConfig {
             monitor_idx: self.monitor.index,


### PR DESCRIPTION
This commit adds `icon_scale` setting to the config that allows to set the icon scaling relative to the font size. This custom value is limited between 1.0 and 2.0 and has a default value of 1.4.
