### PR TITLE
fix(bar): normalize areas of widgets

### DIFF
--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -361,6 +361,8 @@ impl Komobar {
         tracing::info!("widget configuration options applied");
 
         self.komorebi_notification_state = komorebi_notification_state;
+
+        self.config = config.clone().into();
     }
 
     pub fn new(

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -57,6 +57,7 @@ pub struct Komobar {
     pub rx_gui: Receiver<komorebi_client::Notification>,
     pub rx_config: Receiver<KomobarConfig>,
     pub bg_color: Rc<RefCell<Color32>>,
+    pub bg_color_with_alpha: Rc<RefCell<Color32>>,
     pub scale_factor: f32,
 }
 
@@ -64,6 +65,7 @@ pub fn apply_theme(
     ctx: &Context,
     theme: KomobarTheme,
     bg_color: Rc<RefCell<Color32>>,
+    bg_color_with_alpha: Rc<RefCell<Color32>>,
     transparency_alpha: Option<u8>,
     grouping: Option<Grouping>,
 ) {
@@ -150,7 +152,7 @@ pub fn apply_theme(
     // Apply transparency_alpha
     let theme_color = *bg_color.borrow();
 
-    bg_color.replace(theme_color.try_apply_alpha(transparency_alpha));
+    bg_color_with_alpha.replace(theme_color.try_apply_alpha(transparency_alpha));
 
     // apply rounding to the widgets
     if let Some(Grouping::Bar(config) | Grouping::Alignment(config) | Grouping::Widget(config)) =
@@ -236,6 +238,7 @@ impl Komobar {
                     ctx,
                     theme,
                     self.bg_color.clone(),
+                    self.bg_color_with_alpha.clone(),
                     config.transparency_alpha,
                     config.grouping,
                 );
@@ -264,6 +267,7 @@ impl Komobar {
                                 ctx,
                                 KomobarTheme::from(theme),
                                 self.bg_color.clone(),
+                                self.bg_color_with_alpha.clone(),
                                 bar_transparency_alpha,
                                 bar_grouping,
                             );
@@ -290,7 +294,9 @@ impl Komobar {
 
                         // apply rounding to the widgets since we didn't call `apply_theme`
                         if let Some(
-                            Grouping::Bar(config) | Grouping::Alignment(config) | Grouping::Widget(config),
+                            Grouping::Bar(config)
+                            | Grouping::Alignment(config)
+                            | Grouping::Widget(config),
                         ) = &bar_grouping
                         {
                             if let Some(rounding) = config.rounding {
@@ -440,6 +446,7 @@ impl Komobar {
             rx_gui,
             rx_config,
             bg_color: Rc::new(RefCell::new(Style::default().visuals.panel_fill)),
+            bg_color_with_alpha: Rc::new(RefCell::new(Style::default().visuals.panel_fill)),
             scale_factor: cc.egui_ctx.native_pixels_per_point().unwrap_or(1.0),
         };
 
@@ -535,6 +542,7 @@ impl eframe::App for Komobar {
                     self.config.monitor.index,
                     self.rx_gui.clone(),
                     self.bg_color.clone(),
+                    self.bg_color_with_alpha.clone(),
                     self.config.transparency_alpha,
                     self.config.grouping,
                     self.config.theme,
@@ -547,9 +555,9 @@ impl eframe::App for Komobar {
                     frame.inner_margin.x,
                     frame.inner_margin.y,
                 ))
-                .fill(*self.bg_color.borrow())
+                .fill(*self.bg_color_with_alpha.borrow())
         } else {
-            Frame::none().fill(*self.bg_color.borrow())
+            Frame::none().fill(*self.bg_color_with_alpha.borrow())
         };
 
         let mut render_config = self.render_config.borrow_mut();

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -17,6 +17,7 @@ use crate::MONITOR_LEFT;
 use crate::MONITOR_RIGHT;
 use crate::MONITOR_TOP;
 use crossbeam_channel::Receiver;
+use eframe::egui::Align;
 use eframe::egui::Align2;
 use eframe::egui::Area;
 use eframe::egui::CentralPanel;
@@ -28,6 +29,7 @@ use eframe::egui::FontFamily;
 use eframe::egui::FontId;
 use eframe::egui::Frame;
 use eframe::egui::Id;
+use eframe::egui::Layout;
 use eframe::egui::Margin;
 use eframe::egui::Rgba;
 use eframe::egui::Style;
@@ -397,6 +399,8 @@ impl Komobar {
                 });
         }
 
+        right_widgets.reverse();
+
         self.left_widgets = left_widgets;
         self.center_widgets = center_widgets;
         self.right_widgets = right_widgets;
@@ -582,7 +586,7 @@ impl eframe::App for Komobar {
                             left_area_frame.inner_margin.left = frame.inner_margin.x;
                         }
                         left_area_frame.show(ui, |ui| {
-                            ui.horizontal_centered(|ui| {
+                            ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
                                 let mut render_conf = render_config.clone();
                                 render_conf.alignment = Some(Alignment::Left);
 
@@ -606,7 +610,7 @@ impl eframe::App for Komobar {
                             right_area_frame.inner_margin.right = frame.inner_margin.x;
                         }
                         right_area_frame.show(ui, |ui| {
-                            ui.horizontal_centered(|ui| {
+                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                                 let mut render_conf = render_config.clone();
                                 render_conf.alignment = Some(Alignment::Right);
 
@@ -627,7 +631,7 @@ impl eframe::App for Komobar {
                     .show(ctx, |ui| {
                         let center_area_frame = area_frame;
                         center_area_frame.show(ui, |ui| {
-                            ui.horizontal_centered(|ui| {
+                            ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
                                 let mut render_conf = render_config.clone();
                                 render_conf.alignment = Some(Alignment::Center);
 

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -231,6 +231,7 @@ impl Komobar {
                     },
                 );
 
+                let bar_transparency_alpha = config.transparency_alpha;
                 let config = home_dir.join("komorebi.json");
                 match komorebi_client::StaticConfig::read(&config) {
                     Ok(config) => {
@@ -239,7 +240,7 @@ impl Komobar {
                                 ctx,
                                 KomobarTheme::from(theme),
                                 self.bg_color.clone(),
-                                config.transparency_alpha,
+                                bar_transparency_alpha,
                             );
 
                             let stack_accent = match theme {

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -213,6 +213,7 @@ impl Komobar {
             }
         }
 
+        let background_color_before_transparency = *self.bg_color.borrow();
         match config.theme {
             Some(theme) => {
                 apply_theme(ctx, theme, self.bg_color.clone(), config.transparency_alpha);
@@ -289,7 +290,7 @@ impl Komobar {
         }
 
         self.render_config
-            .replace(config.new_renderconfig(ctx, *self.bg_color.borrow()));
+            .replace(config.new_renderconfig(ctx, background_color_before_transparency));
 
         let mut komorebi_notification_state = previous_notification_state;
         let mut komorebi_widgets = Vec::new();

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -496,15 +496,22 @@ impl eframe::App for Komobar {
 
         CentralPanel::default().frame(frame).show(ctx, |_| {
             // Apply grouping logic for the bar as a whole
+            let area_frame = if let Some(frame) = &self.config.frame {
+                Frame::none().inner_margin(Margin::symmetric(0.0, frame.inner_margin.y))
+            } else {
+                Frame::none()
+            };
+
             if !self.left_widgets.is_empty() {
                 // Left-aligned widgets layout
                 Area::new(Id::new("left_panel"))
-                    .anchor(
-                        Align2::LEFT_CENTER,
-                        [self.config.widget_spacing.unwrap_or(10.0), 0.0],
-                    ) // Align in the left center of the window
+                    .anchor(Align2::LEFT_CENTER, [0.0, 0.0]) // Align in the left center of the window
                     .show(ctx, |ui| {
-                        Frame::none().show(ui, |ui| {
+                        let mut left_area_frame = area_frame;
+                        if let Some(frame) = &self.config.frame {
+                            left_area_frame.inner_margin.left = frame.inner_margin.x;
+                        }
+                        left_area_frame.show(ui, |ui| {
                             ui.horizontal_centered(|ui| {
                                 let mut render_conf = render_config.clone();
                                 render_conf.alignment = Some(Alignment::Left);
@@ -522,12 +529,13 @@ impl eframe::App for Komobar {
             if !self.right_widgets.is_empty() {
                 // Right-aligned widgets layout
                 Area::new(Id::new("right_panel"))
-                    .anchor(
-                        Align2::RIGHT_CENTER,
-                        [-self.config.widget_spacing.unwrap_or(10.0), 0.0],
-                    ) // Align in the right center of the window
+                    .anchor(Align2::RIGHT_CENTER, [0.0, 0.0]) // Align in the right center of the window
                     .show(ctx, |ui| {
-                        Frame::none().show(ui, |ui| {
+                        let mut right_area_frame = area_frame;
+                        if let Some(frame) = &self.config.frame {
+                            right_area_frame.inner_margin.right = frame.inner_margin.x;
+                        }
+                        right_area_frame.show(ui, |ui| {
                             ui.horizontal_centered(|ui| {
                                 let mut render_conf = render_config.clone();
                                 render_conf.alignment = Some(Alignment::Right);
@@ -547,7 +555,8 @@ impl eframe::App for Komobar {
                 Area::new(Id::new("center_panel"))
                     .anchor(Align2::CENTER_CENTER, [0.0, 0.0]) // Align in the center of the window
                     .show(ctx, |ui| {
-                        Frame::none().show(ui, |ui| {
+                        let center_area_frame = area_frame;
+                        center_area_frame.show(ui, |ui| {
                             ui.horizontal_centered(|ui| {
                                 let mut render_conf = render_config.clone();
                                 render_conf.alignment = Some(Alignment::Center);

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -2,6 +2,7 @@ use crate::bar::apply_theme;
 use crate::config::DisplayFormat;
 use crate::config::KomobarTheme;
 use crate::komorebi_layout::KomorebiLayout;
+use crate::render::Grouping;
 use crate::render::RenderConfig;
 use crate::selected_frame::SelectableFrame;
 use crate::ui::CustomUi;
@@ -497,6 +498,7 @@ impl KomorebiNotificationState {
         rx_gui: Receiver<komorebi_client::Notification>,
         bg_color: Rc<RefCell<Color32>>,
         transparency_alpha: Option<u8>,
+        grouping: Option<Grouping>,
         default_theme: Option<KomobarTheme>,
     ) {
         match rx_gui.try_recv() {
@@ -520,6 +522,7 @@ impl KomorebiNotificationState {
                                         KomobarTheme::from(theme),
                                         bg_color.clone(),
                                         transparency_alpha,
+                                        grouping,
                                     );
                                     tracing::info!("applied theme from updated komorebi.json");
                                 } else if let Some(default_theme) = default_theme {
@@ -528,6 +531,7 @@ impl KomorebiNotificationState {
                                         default_theme,
                                         bg_color.clone(),
                                         transparency_alpha,
+                                        grouping,
                                     );
                                     tracing::info!("removed theme from updated komorebi.json and applied default theme");
                                 } else {
@@ -541,6 +545,7 @@ impl KomorebiNotificationState {
                                 KomobarTheme::from(theme),
                                 bg_color,
                                 transparency_alpha,
+                                grouping,
                             );
                             tracing::info!("applied theme from komorebi socket message");
                         }

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -491,12 +491,14 @@ impl KomorebiNotificationState {
         self.hide_empty_workspaces = config.hide_empty_workspaces;
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn handle_notification(
         &mut self,
         ctx: &Context,
         monitor_index: usize,
         rx_gui: Receiver<komorebi_client::Notification>,
         bg_color: Rc<RefCell<Color32>>,
+        bg_color_with_alpha: Rc<RefCell<Color32>>,
         transparency_alpha: Option<u8>,
         grouping: Option<Grouping>,
         default_theme: Option<KomobarTheme>,
@@ -521,6 +523,7 @@ impl KomorebiNotificationState {
                                         ctx,
                                         KomobarTheme::from(theme),
                                         bg_color.clone(),
+                                        bg_color_with_alpha.clone(),
                                         transparency_alpha,
                                         grouping,
                                     );
@@ -530,6 +533,7 @@ impl KomorebiNotificationState {
                                         ctx,
                                         default_theme,
                                         bg_color.clone(),
+                                        bg_color_with_alpha.clone(),
                                         transparency_alpha,
                                         grouping,
                                     );
@@ -544,6 +548,7 @@ impl KomorebiNotificationState {
                                 ctx,
                                 KomobarTheme::from(theme),
                                 bg_color,
+                                bg_color_with_alpha.clone(),
                                 transparency_alpha,
                                 grouping,
                             );


### PR DESCRIPTION
This commit changes the way each of the 3 parts of potential widgets (left, center and right) is created so that they are all done on the same way and look the same. It is using `Area` with different anchors for each part which makes the widgets actually center vertically properly.

This created an issue with the `Bar` grouping. To fix it we've made the `Bar` grouping change the outer panel frame instead of creating an actual group. This has the side effect (or maybe feature!) of losing the background of the outer frame. Meaning this outer frame will now have the look of the `Bar` grouping only. Currently it is using a fixed outer margin but this can be changed in the future to a config option.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
