### PR TITLE
fix(bar): update widgets background color properly

### DIFF
--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -71,6 +71,7 @@ pub fn apply_theme(
     bg_color_with_alpha: Rc<RefCell<Color32>>,
     transparency_alpha: Option<u8>,
     grouping: Option<Grouping>,
+    render_config: Rc<RefCell<RenderConfig>>,
 ) {
     match theme {
         KomobarTheme::Catppuccin {
@@ -171,6 +172,9 @@ pub fn apply_theme(
             });
         }
     }
+
+    // Update RenderConfig's background_color so that widgets will have the new color
+    render_config.borrow_mut().background_color = *bg_color.borrow();
 }
 
 impl Komobar {
@@ -364,6 +368,7 @@ impl Komobar {
                     self.bg_color_with_alpha.clone(),
                     config.transparency_alpha,
                     config.grouping,
+                    self.render_config.clone(),
                 );
             }
             None => {
@@ -393,6 +398,7 @@ impl Komobar {
                                 self.bg_color_with_alpha.clone(),
                                 bar_transparency_alpha,
                                 bar_grouping,
+                                self.render_config.clone(),
                             );
 
                             let stack_accent = match theme {
@@ -555,6 +561,7 @@ impl eframe::App for Komobar {
                     self.config.transparency_alpha,
                     self.config.grouping,
                     self.config.theme,
+                    self.render_config.clone(),
                 );
         }
 

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -502,6 +502,7 @@ impl KomorebiNotificationState {
         transparency_alpha: Option<u8>,
         grouping: Option<Grouping>,
         default_theme: Option<KomobarTheme>,
+        render_config: Rc<RefCell<RenderConfig>>,
     ) {
         match rx_gui.try_recv() {
             Err(error) => match error {
@@ -526,6 +527,7 @@ impl KomorebiNotificationState {
                                         bg_color_with_alpha.clone(),
                                         transparency_alpha,
                                         grouping,
+                                        render_config,
                                     );
                                     tracing::info!("applied theme from updated komorebi.json");
                                 } else if let Some(default_theme) = default_theme {
@@ -536,6 +538,7 @@ impl KomorebiNotificationState {
                                         bg_color_with_alpha.clone(),
                                         transparency_alpha,
                                         grouping,
+                                        render_config,
                                     );
                                     tracing::info!("removed theme from updated komorebi.json and applied default theme");
                                 } else {
@@ -551,6 +554,7 @@ impl KomorebiNotificationState {
                                 bg_color_with_alpha.clone(),
                                 transparency_alpha,
                                 grouping,
+                                render_config,
                             );
                             tracing::info!("applied theme from komorebi socket message");
                         }


### PR DESCRIPTION
Previously when changing between themes with different backgrounds the widget's background color was not updating because they take the bg color from the `RenderConfig` which was only being updated on `apply_config`, now we also pass the `RenderConfig` to the `apply_theme` function and update it's `background_color` there as well.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
