### PR TITLE
fix(bar): prevent komorebi connection from staling

### DIFF
--- a/komorebi-bar/src/main.rs
+++ b/komorebi-bar/src/main.rs
@@ -351,6 +351,10 @@ fn main() -> color_eyre::Result<()> {
                 for client in listener.incoming() {
                     match client {
                         Ok(subscription) => {
+                            match subscription.set_read_timeout(Some(Duration::from_secs(1))) {
+                                Ok(()) => {}
+                                Err(error) => tracing::error!("{}", error),
+                            }
                             let mut buffer = Vec::new();
                             let mut reader = BufReader::new(subscription);
 


### PR DESCRIPTION
Sometimes the bar would randomly stop receiving notifications from komorebi and would stop updating the `Komorebi` widget. This feels to me that the reason is the same one that used to happen on the `process_commands` from `komorebi` where the socket would get stuck reading an empty connection. This commit adds a read timeout to the socket to prevent that from happening and hopefully it should stop those situations where the bar would stop receiving notifications.

There were some users reporting on Discord that the bar would sometime stop updating the workspaces widget and I have faced that as well! Hopefully this should fix that. I looked if there was an opened issue on github related to this but couldn't find any, so maybe it was just reported on Discord.


<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
