### PR TITLE
fix: Jetbrains Client not getting managed

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -277,6 +277,7 @@ impl WindowManager {
             }
             WindowManagerEvent::Show(_, window)
             | WindowManagerEvent::Manage(window)
+            | WindowManagerEvent::TitleUpdate(_, window)
             | WindowManagerEvent::Uncloak(_, window) => {
                 if matches!(event, WindowManagerEvent::Uncloak(_, _))
                     && self.uncloack_to_ignore >= 1
@@ -692,8 +693,7 @@ impl WindowManager {
                 }
             }
             WindowManagerEvent::MouseCapture(..)
-            | WindowManagerEvent::Cloak(..)
-            | WindowManagerEvent::TitleUpdate(..) => {}
+            | WindowManagerEvent::Cloak(..) => {}
         };
 
         // If we unmanaged a window, it shouldn't be immediately hidden behind managed windows


### PR DESCRIPTION
The Jetbrains Client is what is used by Remote Development. You can access this in any Jetbrains IDE when you go to File -> Remote Development...
For some reason the JBC doesn't fire an Show event though it does fire a TitleUpdate event. 

EDIT: not sure whether there are other applications that also have this issue so i didn't add any specific checks for whether the window is actually the JBC though i can add one if you want