### PR TITLE
fix(wm): stop wrongfully removing layout-flip

### DIFF
--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -333,10 +333,6 @@ impl Workspace {
             }
 
             if let Some(updated_layout) = updated_layout {
-                if !matches!(updated_layout, Layout::Default(DefaultLayout::BSP)) {
-                    self.set_layout_flip(None);
-                }
-
                 self.set_layout(updated_layout);
             }
         }

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -1175,7 +1175,7 @@ enum SubCommand {
     #[clap(hide = true)]
     #[clap(arg_required_else_help = true)]
     LoadCustomLayout(LoadCustomLayout),
-    /// Flip the layout on the focused workspace (BSP only)
+    /// Flip the layout on the focused workspace
     #[clap(arg_required_else_help = true)]
     FlipLayout(FlipLayout),
     /// Promote the focused window to the top of the tree


### PR DESCRIPTION
This commit removes the code on the workspace `update` on `layout-rules` where it was setting the `layout-flip` to `None` if the layout was different from `BSP`. This appears to be some old code when the layout-flip would only apply to the `BSP` layout. However now it appears to apply to all layouts so this code shouldn't exist. This commit also changes the docs from the `FlipLayout` command to remove the statement that only applied to `BSP` since it is no longer true.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
