### PR TITLE
Fix monitor preferences

### DIFF
--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -38,6 +38,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
@@ -121,6 +122,7 @@ impl From<&KomorebiConfig> for Komorebi {
                 focused_container_information: KomorebiNotificationStateContainerInformation::EMPTY,
                 stack_accent: None,
                 monitor_index: MONITOR_INDEX.load(Ordering::SeqCst),
+                monitor_usr_idx_map: HashMap::new(),
             })),
             workspaces: value.workspaces,
             layout: value.layout.clone(),
@@ -483,6 +485,7 @@ pub struct KomorebiNotificationState {
     pub work_area_offset: Option<Rect>,
     pub stack_accent: Option<Color32>,
     pub monitor_index: usize,
+    pub monitor_usr_idx_map: HashMap<usize, usize>,
 }
 
 impl KomorebiNotificationState {
@@ -553,6 +556,13 @@ impl KomorebiNotificationState {
         }
 
         self.monitor_index = monitor_index;
+        self.monitor_usr_idx_map = notification.state.monitor_usr_idx_map.clone();
+
+        if monitor_index >= notification.state.monitors.elements().len() {
+            // The bar's monitor is diconnected, so the bar is disabled no need to check anything
+            // any further otherwise we'll get `OutOfBounds` panics.
+            return;
+        }
 
         self.mouse_follows_focus = notification.state.mouse_follows_focus;
 

--- a/komorebi-bar/src/main.rs
+++ b/komorebi-bar/src/main.rs
@@ -237,12 +237,16 @@ fn main() -> color_eyre::Result<()> {
         &SocketMessage::State,
     )?)?;
 
-    let (monitor_index, work_area_offset) = match &config.monitor {
+    let (usr_monitor_index, work_area_offset) = match &config.monitor {
         MonitorConfigOrIndex::MonitorConfig(monitor_config) => {
             (monitor_config.index, monitor_config.work_area_offset)
         }
         MonitorConfigOrIndex::Index(idx) => (*idx, None),
     };
+    let monitor_index = state
+        .monitor_usr_idx_map
+        .get(&usr_monitor_index)
+        .map_or(usr_monitor_index, |i| *i);
 
     MONITOR_RIGHT.store(
         state.monitors.elements()[monitor_index].size().right,

--- a/komorebi/src/monitor_reconciliator/mod.rs
+++ b/komorebi/src/monitor_reconciliator/mod.rs
@@ -337,6 +337,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
 
                                 // Put the orphaned containers somewhere visible
                                 for container in orphaned_containers {
+                                    container.restore();
                                     focused_ws.add_container_to_back(container);
                                 }
 

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -171,6 +171,7 @@ impl From<&Workspace> for WorkspaceConfig {
                 Layout::Custom(_) => {}
             }
         }
+        let layout_rules = (!layout_rules.is_empty()).then_some(layout_rules);
 
         let mut window_container_behaviour_rules = HashMap::new();
         for (threshold, behaviour) in value.window_container_behaviour_rules().iter().flatten() {
@@ -212,7 +213,7 @@ impl From<&Workspace> for WorkspaceConfig {
                 .workspace_config()
                 .as_ref()
                 .and_then(|c| c.custom_layout.clone()),
-            layout_rules: Option::from(layout_rules),
+            layout_rules,
             custom_layout_rules: value
                 .workspace_config()
                 .as_ref()

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1213,9 +1213,14 @@ impl StaticConfig {
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
                 let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
-                let c_idx = display_index_preferences
-                    .iter()
-                    .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
+                let c_idx = display_index_preferences.iter().find_map(|(c_idx, id)| {
+                    (monitor
+                        .serial_number_id()
+                        .as_ref()
+                        .is_some_and(|sn| sn == id)
+                        || monitor.device_id() == id)
+                        .then_some(*c_idx)
+                });
                 c_idx
             };
             let idx = preferred_config_idx.or({
@@ -1239,10 +1244,11 @@ impl StaticConfig {
                 // Check if this monitor config is the preferred config for this monitor and store
                 // a copy of the config on the monitor cache if it is.
                 if idx == preferred_config_idx {
-                    monitor_reconciliator::insert_in_monitor_cache(
-                        monitor.device_id(),
-                        monitor_config.clone(),
-                    );
+                    let id = monitor
+                        .serial_number_id()
+                        .as_ref()
+                        .map_or(monitor.device_id(), |sn| sn);
+                    monitor_reconciliator::insert_in_monitor_cache(id, monitor_config.clone());
                 }
 
                 if let Some(used_config_idx) = idx {
@@ -1294,24 +1300,21 @@ impl StaticConfig {
         }
 
         // Check for configs that should be tied to a specific display that isn't loaded right now
-        // and cache those configs with the specific `device_id` so that when those devices are
-        // connected later we can use the correct config from the cache.
+        // and cache those configs with the specific `serial_number_id` or `device_id` so that when
+        // those devices are connected later we can use the correct config from the cache.
         if configs_with_preference.len() > configs_used.len() {
             for i in configs_with_preference
                 .iter()
                 .filter(|i| !configs_used.contains(i))
             {
-                let device_id = {
+                let id = {
                     let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
                     display_index_preferences.get(i).cloned()
                 };
-                if let (Some(device_id), Some(monitor_config)) =
-                    (device_id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
+                if let (Some(id), Some(monitor_config)) =
+                    (id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
                 {
-                    monitor_reconciliator::insert_in_monitor_cache(
-                        &device_id,
-                        monitor_config.clone(),
-                    );
+                    monitor_reconciliator::insert_in_monitor_cache(&id, monitor_config.clone());
                 }
             }
         }
@@ -1341,9 +1344,14 @@ impl StaticConfig {
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
                 let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
-                let c_idx = display_index_preferences
-                    .iter()
-                    .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
+                let c_idx = display_index_preferences.iter().find_map(|(c_idx, id)| {
+                    (monitor
+                        .serial_number_id()
+                        .as_ref()
+                        .is_some_and(|sn| sn == id)
+                        || monitor.device_id() == id)
+                        .then_some(*c_idx)
+                });
                 c_idx
             };
             let idx = preferred_config_idx.or({
@@ -1367,10 +1375,11 @@ impl StaticConfig {
                 // Check if this monitor config is the preferred config for this monitor and store
                 // a copy of the config on the monitor cache if it is.
                 if idx == preferred_config_idx {
-                    monitor_reconciliator::insert_in_monitor_cache(
-                        monitor.device_id(),
-                        monitor_config.clone(),
-                    );
+                    let id = monitor
+                        .serial_number_id()
+                        .as_ref()
+                        .map_or(monitor.device_id(), |sn| sn);
+                    monitor_reconciliator::insert_in_monitor_cache(id, monitor_config.clone());
                 }
 
                 if let Some(used_config_idx) = idx {
@@ -1424,24 +1433,21 @@ impl StaticConfig {
         }
 
         // Check for configs that should be tied to a specific display that isn't loaded right now
-        // and cache those configs with the specific `device_id` so that when those devices are
+        // and cache those configs with the specific `serial_number_id` so that when those devices are
         // connected later we can use the correct config from the cache.
         if configs_with_preference.len() > configs_used.len() {
             for i in configs_with_preference
                 .iter()
                 .filter(|i| !configs_used.contains(i))
             {
-                let device_id = {
+                let id = {
                     let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
                     display_index_preferences.get(i).cloned()
                 };
-                if let (Some(device_id), Some(monitor_config)) =
-                    (device_id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
+                if let (Some(id), Some(monitor_config)) =
+                    (id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
                 {
-                    monitor_reconciliator::insert_in_monitor_cache(
-                        &device_id,
-                        monitor_config.clone(),
-                    );
+                    monitor_reconciliator::insert_in_monitor_cache(&id, monitor_config.clone());
                 }
             }
         }

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -115,7 +115,7 @@ pub struct BorderColours {
     pub unfocused: Option<Colour>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct WorkspaceConfig {
     /// Name
     pub name: String,
@@ -201,7 +201,6 @@ impl From<&Workspace> for WorkspaceConfig {
                 .name()
                 .clone()
                 .unwrap_or_else(|| String::from("unnamed")),
-            custom_layout: None,
             layout: value
                 .tile()
                 .then_some(match value.layout() {
@@ -209,13 +208,25 @@ impl From<&Workspace> for WorkspaceConfig {
                     Layout::Custom(_) => None,
                 })
                 .flatten(),
+            custom_layout: value
+                .workspace_config()
+                .as_ref()
+                .and_then(|c| c.custom_layout.clone()),
             layout_rules: Option::from(layout_rules),
-            // TODO: figure out how we might resolve file references in the future
-            custom_layout_rules: None,
+            custom_layout_rules: value
+                .workspace_config()
+                .as_ref()
+                .and_then(|c| c.custom_layout_rules.clone()),
             container_padding,
             workspace_padding,
-            initial_workspace_rules: None,
-            workspace_rules: None,
+            initial_workspace_rules: value
+                .workspace_config()
+                .as_ref()
+                .and_then(|c| c.initial_workspace_rules.clone()),
+            workspace_rules: value
+                .workspace_config()
+                .as_ref()
+                .and_then(|c| c.workspace_rules.clone()),
             apply_window_based_work_area_offset: Some(value.apply_window_based_work_area_offset()),
             window_container_behaviour: *value.window_container_behaviour(),
             window_container_behaviour_rules: Option::from(window_container_behaviour_rules),

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1216,7 +1216,6 @@ impl StaticConfig {
                 let c_idx = display_index_preferences
                     .iter()
                     .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
-                drop(display_index_preferences);
                 c_idx
             };
             let idx = preferred_config_idx.or({
@@ -1345,7 +1344,6 @@ impl StaticConfig {
                 let c_idx = display_index_preferences
                     .iter()
                     .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
-                drop(display_index_preferences);
                 c_idx
             };
             let idx = preferred_config_idx.or({

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1141,6 +1141,7 @@ impl StaticConfig {
 
         let mut wm = WindowManager {
             monitors: Ring::default(),
+            monitor_usr_idx_map: HashMap::new(),
             incoming_events: incoming,
             command_listener: listener,
             is_paused: false,

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1201,32 +1201,73 @@ impl StaticConfig {
         let value = Self::read(path)?;
         let mut wm = wm.lock();
 
-        if let Some(monitors) = value.monitors {
-            for (i, monitor) in monitors.iter().enumerate() {
-                {
-                    let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
-                    if let Some(device_id) = display_index_preferences.get(&i) {
-                        monitor_reconciliator::insert_in_monitor_cache(device_id, monitor.clone());
-                    }
+        let configs_with_preference: Vec<_> =
+            DISPLAY_INDEX_PREFERENCES.lock().keys().copied().collect();
+        let mut configs_used = Vec::new();
+
+        let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
+        workspace_matching_rules.clear();
+        drop(workspace_matching_rules);
+
+        for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
+            let config_idx = {
+                let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                let c_idx = display_index_preferences
+                    .iter()
+                    .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
+                drop(display_index_preferences);
+                c_idx
+            };
+            let idx = config_idx.or({
+                // Monitor without preferred config idx.
+                // Get index of first config that is not a preferred config of some other monitor
+                // and that has not been used yet. This might return `None` as well, in that case
+                // this monitor won't have a config tied to it and will use the default values.
+                let m_config_count = value
+                    .monitors
+                    .as_ref()
+                    .map(|ms| ms.len())
+                    .unwrap_or_default();
+                (0..m_config_count)
+                    .find(|i| !configs_with_preference.contains(i) && !configs_used.contains(i))
+            });
+            if let Some(monitor_config) = value
+                .monitors
+                .as_ref()
+                .and_then(|ms| idx.and_then(|i| ms.get(i)))
+            {
+                // Check if this monitor config is the preferred config for this monitor and store
+                // a copy of the config on the monitor cache if it is.
+                if idx == config_idx {
+                    monitor_reconciliator::insert_in_monitor_cache(
+                        monitor.device_id(),
+                        monitor_config.clone(),
+                    );
                 }
 
-                if let Some(m) = wm.monitors_mut().get_mut(i) {
-                    m.ensure_workspace_count(monitor.workspaces.len());
-                    m.set_work_area_offset(monitor.work_area_offset);
-                    m.set_window_based_work_area_offset(monitor.window_based_work_area_offset);
-                    m.set_window_based_work_area_offset_limit(
-                        monitor.window_based_work_area_offset_limit.unwrap_or(1),
-                    );
+                if let Some(used_config_idx) = idx {
+                    configs_used.push(used_config_idx);
+                }
 
-                    for (j, ws) in m.workspaces_mut().iter_mut().enumerate() {
-                        if let Some(workspace_config) = monitor.workspaces.get(j) {
-                            ws.load_static_config(workspace_config)?;
-                        }
+                monitor.ensure_workspace_count(monitor_config.workspaces.len());
+                monitor.set_work_area_offset(monitor_config.work_area_offset);
+                monitor.set_window_based_work_area_offset(
+                    monitor_config.window_based_work_area_offset,
+                );
+                monitor.set_window_based_work_area_offset_limit(
+                    monitor_config
+                        .window_based_work_area_offset_limit
+                        .unwrap_or(1),
+                );
+
+                for (j, ws) in monitor.workspaces_mut().iter_mut().enumerate() {
+                    if let Some(workspace_config) = monitor_config.workspaces.get(j) {
+                        ws.load_static_config(workspace_config)?;
                     }
                 }
 
                 let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
-                for (j, ws) in monitor.workspaces.iter().enumerate() {
+                for (j, ws) in monitor_config.workspaces.iter().enumerate() {
                     if let Some(rules) = &ws.workspace_rules {
                         for r in rules {
                             workspace_matching_rules.push(WorkspaceMatchingRule {
@@ -1266,29 +1307,75 @@ impl StaticConfig {
 
         value.apply_globals()?;
 
-        if let Some(monitors) = value.monitors {
-            let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
-            workspace_matching_rules.clear();
+        let configs_with_preference: Vec<_> =
+            DISPLAY_INDEX_PREFERENCES.lock().keys().copied().collect();
+        let mut configs_used = Vec::new();
 
-            for (i, monitor) in monitors.iter().enumerate() {
-                if let Some(m) = wm.monitors_mut().get_mut(i) {
-                    m.ensure_workspace_count(monitor.workspaces.len());
-                    if m.work_area_offset().is_none() {
-                        m.set_work_area_offset(monitor.work_area_offset);
-                    }
-                    m.set_window_based_work_area_offset(monitor.window_based_work_area_offset);
-                    m.set_window_based_work_area_offset_limit(
-                        monitor.window_based_work_area_offset_limit.unwrap_or(1),
+        let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
+        workspace_matching_rules.clear();
+        drop(workspace_matching_rules);
+
+        for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
+            let config_idx = {
+                let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                let c_idx = display_index_preferences
+                    .iter()
+                    .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
+                drop(display_index_preferences);
+                c_idx
+            };
+            let idx = config_idx.or({
+                // Monitor without preferred config idx.
+                // Get index of first config that is not a preferred config of some other monitor
+                // and that has not been used yet. This might return `None` as well, in that case
+                // this monitor won't have a config tied to it and will use the default values.
+                let m_config_count = value
+                    .monitors
+                    .as_ref()
+                    .map(|ms| ms.len())
+                    .unwrap_or_default();
+                (0..m_config_count)
+                    .find(|i| !configs_with_preference.contains(i) && !configs_used.contains(i))
+            });
+            if let Some(monitor_config) = value
+                .monitors
+                .as_ref()
+                .and_then(|ms| idx.and_then(|i| ms.get(i)))
+            {
+                // Check if this monitor config is the preferred config for this monitor and store
+                // a copy of the config on the monitor cache if it is.
+                if idx == config_idx {
+                    monitor_reconciliator::insert_in_monitor_cache(
+                        monitor.device_id(),
+                        monitor_config.clone(),
                     );
+                }
 
-                    for (j, ws) in m.workspaces_mut().iter_mut().enumerate() {
-                        if let Some(workspace_config) = monitor.workspaces.get(j) {
-                            ws.load_static_config(workspace_config)?;
-                        }
+                if let Some(used_config_idx) = idx {
+                    configs_used.push(used_config_idx);
+                }
+
+                monitor.ensure_workspace_count(monitor_config.workspaces.len());
+                if monitor.work_area_offset().is_none() {
+                    monitor.set_work_area_offset(monitor_config.work_area_offset);
+                }
+                monitor.set_window_based_work_area_offset(
+                    monitor_config.window_based_work_area_offset,
+                );
+                monitor.set_window_based_work_area_offset_limit(
+                    monitor_config
+                        .window_based_work_area_offset_limit
+                        .unwrap_or(1),
+                );
+
+                for (j, ws) in monitor.workspaces_mut().iter_mut().enumerate() {
+                    if let Some(workspace_config) = monitor_config.workspaces.get(j) {
+                        ws.load_static_config(workspace_config)?;
                     }
                 }
 
-                for (j, ws) in monitor.workspaces.iter().enumerate() {
+                let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
+                for (j, ws) in monitor_config.workspaces.iter().enumerate() {
                     if let Some(rules) = &ws.workspace_rules {
                         for r in rules {
                             workspace_matching_rules.push(WorkspaceMatchingRule {

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -201,12 +201,14 @@ impl From<&Workspace> for WorkspaceConfig {
                 .name()
                 .clone()
                 .unwrap_or_else(|| String::from("unnamed")),
-            layout: match value.layout() {
-                Layout::Default(layout) => Option::from(*layout),
-                // TODO: figure out how we might resolve file references in the future
-                Layout::Custom(_) => None,
-            },
             custom_layout: None,
+            layout: value
+                .tile()
+                .then_some(match value.layout() {
+                    Layout::Default(layout) => Option::from(*layout),
+                    Layout::Custom(_) => None,
+                })
+                .flatten(),
             layout_rules: Option::from(layout_rules),
             // TODO: figure out how we might resolve file references in the future
             custom_layout_rules: None,

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -296,7 +296,8 @@ impl WindowsApi {
 
             let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
             for (index, id) in &*display_index_preferences {
-                if id.eq(m.device_id()) {
+                if m.serial_number_id().as_ref().is_some_and(|sn| sn == id) || id.eq(m.device_id())
+                {
                     index_preference = Option::from(index);
                 }
             }

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -92,6 +92,8 @@ pub struct Workspace {
     window_container_behaviour_rules: Option<Vec<(usize, WindowContainerBehaviour)>>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     float_override: Option<bool>,
+    #[getset(get = "pub", set = "pub")]
+    workspace_config: Option<WorkspaceConfig>,
 }
 
 impl_ring_elements!(Workspace, Container);
@@ -118,6 +120,7 @@ impl Default for Workspace {
             window_container_behaviour: None,
             window_container_behaviour_rules: None,
             float_override: None,
+            workspace_config: None,
         }
     }
 }
@@ -208,6 +211,8 @@ impl Workspace {
 
         self.set_float_override(config.float_override);
         self.set_layout_flip(config.layout_flip);
+
+        self.set_workspace_config(Some(config.clone()));
 
         Ok(())
     }

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -92,6 +92,7 @@ pub struct Workspace {
     window_container_behaviour_rules: Option<Vec<(usize, WindowContainerBehaviour)>>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     float_override: Option<bool>,
+    #[serde(skip)]
     #[getset(get = "pub", set = "pub")]
     workspace_config: Option<WorkspaceConfig>,
 }


### PR DESCRIPTION
This PR reworks the way the `postload` and the `reload` functions apply the monitor configs to the monitors. Previously it was looping through the monitor configs and applying them to the monitor with the index corresponding to the config's index. 

However this isn't correct, since the user might set the preferred indices for 3 monitors (like monitor A, B and C), with the preferred index set to 0 for A, 1 for B and 2 for C, but if only monitors A and C are connected then komorebi would apply config 0 to A and config 1 to C, which is wrong it should be 2 for C.

This PR changes the way the configs are applied on those functions.
Now it loops through the existing monitors (already in order), then checks if the monitor has a preferred config index, if it does it uses that one, if it doesn't then it uses the first monitor config that isn't a preferred index for some other monitor and that hasn't been used yet.

For the situation above it means that it would still apply config 2 to monitor C. And in case there aren't any display_index_preferences set it will still apply the configs in order.

It also changes the way the layout is stored from the current monitor, by making sure to set it to `None` if the workspace is not tiling. Previously any floating workspace would be restored from cache with a tiling BSP layout.


Related to [this discussion](https://discord.com/channels/898554690126630914/1329508394205184104/1329518859383865456) on Discord

However this entire code is based on the premise that the `device_id` is always the same for the same devices. However there have been [comments](https://discord.com/channels/898554690126630914/898554690608967786/1330587647462084609) on discord stating that this isn't true, however I've not been able to confirm this and the users have not given any proof of this happening (they might simply be confusing it since it's a weird string similar between monitors...)

I think the changes from this PR should fix most issues that people have been having with multiple monitors (specially with 3 or more monitors). But it's probably better to not merge this until we can get some users to test it.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
