### PR TITLE
Notify monitor events to subscribers

### DIFF
--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -504,6 +504,7 @@ impl KomorebiNotificationState {
     ) {
         match notification.event {
             NotificationEvent::WindowManager(_) => {}
+            NotificationEvent::Monitor(_) => {}
             NotificationEvent::Socket(message) => match message {
                 SocketMessage::ReloadStaticConfiguration(path) => {
                     if let Ok(config) = komorebi_client::StaticConfig::read(&path) {

--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -33,6 +33,7 @@ pub use komorebi::core::StackbarMode;
 pub use komorebi::core::StateQuery;
 pub use komorebi::core::WindowKind;
 pub use komorebi::monitor::Monitor;
+pub use komorebi::monitor_reconciliator::MonitorNotification;
 pub use komorebi::ring::Ring;
 pub use komorebi::window::Window;
 pub use komorebi::window_manager_event::WindowManagerEvent;

--- a/komorebi/src/lib.rs
+++ b/komorebi/src/lib.rs
@@ -32,6 +32,7 @@ pub mod workspace;
 pub mod workspace_reconciliator;
 
 use lazy_static::lazy_static;
+use monitor_reconciliator::MonitorNotification;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::fs::File;
@@ -283,6 +284,7 @@ pub fn current_virtual_desktop() -> Option<Vec<u8>> {
 pub enum NotificationEvent {
     WindowManager(WindowManagerEvent),
     Socket(SocketMessage),
+    Monitor(MonitorNotification),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/komorebi/src/monitor_reconciliator/hidden.rs
+++ b/komorebi/src/monitor_reconciliator/hidden.rs
@@ -114,7 +114,7 @@ impl Hidden {
                                 "WM_POWERBROADCAST event received - resume from suspend"
                             );
                             monitor_reconciliator::send_notification(
-                                monitor_reconciliator::Notification::ResumingFromSuspendedState,
+                                monitor_reconciliator::MonitorNotification::ResumingFromSuspendedState,
                             );
                             LRESULT(0)
                         }
@@ -124,7 +124,7 @@ impl Hidden {
                                 "WM_POWERBROADCAST event received - entering suspended state"
                             );
                             monitor_reconciliator::send_notification(
-                                monitor_reconciliator::Notification::EnteringSuspendedState,
+                                monitor_reconciliator::MonitorNotification::EnteringSuspendedState,
                             );
                             LRESULT(0)
                         }
@@ -137,14 +137,14 @@ impl Hidden {
                             tracing::debug!("WM_WTSSESSION_CHANGE event received with WTS_SESSION_LOCK - screen locked");
 
                             monitor_reconciliator::send_notification(
-                                monitor_reconciliator::Notification::SessionLocked,
+                                monitor_reconciliator::MonitorNotification::SessionLocked,
                             );
                         }
                         WTS_SESSION_UNLOCK => {
                             tracing::debug!("WM_WTSSESSION_CHANGE event received with WTS_SESSION_UNLOCK - screen unlocked");
 
                             monitor_reconciliator::send_notification(
-                                monitor_reconciliator::Notification::SessionUnlocked,
+                                monitor_reconciliator::MonitorNotification::SessionUnlocked,
                             );
                         }
                         _ => {}
@@ -165,7 +165,7 @@ impl Hidden {
                     );
 
                     monitor_reconciliator::send_notification(
-                        monitor_reconciliator::Notification::ResolutionScalingChanged,
+                        monitor_reconciliator::MonitorNotification::ResolutionScalingChanged,
                     );
                     LRESULT(0)
                 }
@@ -179,7 +179,7 @@ impl Hidden {
                             );
 
                         monitor_reconciliator::send_notification(
-                            monitor_reconciliator::Notification::WorkAreaChanged,
+                            monitor_reconciliator::MonitorNotification::WorkAreaChanged,
                         );
                     }
                     LRESULT(0)
@@ -193,7 +193,7 @@ impl Hidden {
                                 "WM_DEVICECHANGE event received with DBT_DEVNODES_CHANGED - display added or removed"
                             );
                         monitor_reconciliator::send_notification(
-                            monitor_reconciliator::Notification::DisplayConnectionChange,
+                            monitor_reconciliator::MonitorNotification::DisplayConnectionChange,
                         );
                     }
 


### PR DESCRIPTION
This PR allows notifying the subscribers of any monitor events like display connection change or work area change. It also makes use of these new monitor notifications on the komorebi-bar to update the bar when the displays connections changes.
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
