### PR TITLE
fix(bar): resolve env vars in the configuration switcher

### DIFF
--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -28,6 +28,7 @@ use eframe::egui::Vec2;
 use image::RgbaImage;
 use komorebi_client::Container;
 use komorebi_client::NotificationEvent;
+use komorebi_client::PathExt;
 use komorebi_client::Rect;
 use komorebi_client::SocketMessage;
 use komorebi_client::Window;
@@ -97,7 +98,7 @@ impl From<&KomorebiConfig> for Komorebi {
             if let Some(configuration_switcher) = &value.configuration_switcher {
                 let mut configuration_switcher = configuration_switcher.clone();
                 for (_, location) in configuration_switcher.configurations.iter_mut() {
-                    *location = dunce::simplified(&PathBuf::from(location.clone()))
+                    *location = dunce::simplified(&PathBuf::from(location.clone()).replace_env())
                         .to_string_lossy()
                         .to_string();
                 }

--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -25,6 +25,7 @@ pub use komorebi::core::Layout;
 pub use komorebi::core::MoveBehaviour;
 pub use komorebi::core::OperationBehaviour;
 pub use komorebi::core::OperationDirection;
+pub use komorebi::core::PathExt;
 pub use komorebi::core::Rect;
 pub use komorebi::core::Sizing;
 pub use komorebi::core::SocketMessage;

--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -25,6 +25,7 @@ pub use default_layout::DefaultLayout;
 pub use direction::Direction;
 pub use layout::Layout;
 pub use operation_direction::OperationDirection;
+pub use pathext::PathExt;
 pub use rect::Rect;
 
 pub mod animation;
@@ -37,6 +38,7 @@ pub mod default_layout;
 pub mod direction;
 pub mod layout;
 pub mod operation_direction;
+pub mod pathext;
 pub mod rect;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Display, JsonSchema)]

--- a/komorebi/src/core/pathext.rs
+++ b/komorebi/src/core/pathext.rs
@@ -1,0 +1,48 @@
+use std::env;
+use std::path::Component;
+use std::path::PathBuf;
+
+pub trait PathExt {
+    fn replace_env(&self) -> PathBuf;
+}
+
+impl PathExt for PathBuf {
+    fn replace_env(&self) -> PathBuf {
+        let mut result = PathBuf::new();
+
+        for component in self.components() {
+            match component {
+                Component::Normal(segment) => {
+                    // Check if it starts with `$` or `$Env:`
+                    if let Some(stripped_segment) = segment.to_string_lossy().strip_prefix('$') {
+                        let var_name = if let Some(env_name) = stripped_segment.strip_prefix("Env:")
+                        {
+                            // Extract the variable name after `$Env:`
+                            env_name
+                        } else if stripped_segment == "HOME" {
+                            // Special case for `$HOME`
+                            "USERPROFILE"
+                        } else {
+                            // Extract the variable name after `$`
+                            stripped_segment
+                        };
+
+                        if let Ok(value) = env::var(var_name) {
+                            result.push(&value); // Replace with the value
+                        } else {
+                            result.push(segment); // Keep as-is if variable is not found
+                        }
+                    } else {
+                        result.push(segment); // Keep as-is if not an environment variable
+                    }
+                }
+                _ => {
+                    // Add other components (e.g., root, parent) as-is
+                    result.push(component.as_os_str());
+                }
+            }
+        }
+
+        result
+    }
+}


### PR DESCRIPTION
Environment variables were not supported in the location of the configuration switcher section as described in #1131.

I've decided to make an extension called `PathExt` (name debatable) that replaces _any_ environment variable in a PathBuf.

It supports the following:

```json
        "configuration_switcher": {
          "enable": true,
          "configurations": {
            "home": "$HOME/komorebi.json",
            "work": "$Env:USERPROFILE/komorebi.work.json"
          }
        }
```

My proposal is to use this extension other places as well in order to support any env vars in paths. Could it perhaps be used [here](https://github.com/LGUG2Z/komorebi/blob/a575b28422b45ca4dc3cabef55009fed59fcf3be/komorebi/src/core/mod.rs#L496)?