### PR TITLE
fix(wm): sort layout and behaviour rules

### DIFF
--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -167,6 +167,7 @@ impl Workspace {
                 all_layout_rules.push((*count, Layout::Default(*rule)));
             }
 
+            all_layout_rules.sort_by_key(|(i, _)| *i);
             self.tile = true;
         }
 
@@ -178,6 +179,7 @@ impl Workspace {
                 all_layout_rules.push((*count, Layout::Custom(rule)));
             }
 
+            all_layout_rules.sort_by_key(|(i, _)| *i);
             self.tile = true;
             self.set_layout_rules(all_layout_rules);
         }
@@ -197,11 +199,11 @@ impl Workspace {
                     all_rules.push((*count, *behaviour));
                 }
 
+                all_rules.sort_by_key(|(i, _)| *i);
                 self.set_window_container_behaviour_rules(Some(all_rules));
             }
         } else {
             self.set_window_container_behaviour_rules(None);
-            self.set_window_container_behaviour(None);
         }
 
         self.set_float_override(config.float_override);


### PR DESCRIPTION
This commit makes sure the `layout-rules` and `window_container_behaviour_rules` are sorted when setting them from the config. So that the behaviour on workspace update is correct.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
