### PR TITLE
Fix/monitor disconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5926,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "win32-display-data"
 version = "0.1.0"
-source = "git+https://github.com/LGUG2Z/win32-display-data?rev=75286e77c068a89d12adcd6404c9c4874a60acf5#75286e77c068a89d12adcd6404c9c4874a60acf5"
+source = "git+https://github.com/LGUG2Z/win32-display-data?rev=3ff53fb6f53ec3ec4f9941a0409fba5e36decc46#3ff53fb6f53ec3ec4f9941a0409fba5e36decc46"
 dependencies = [
  "itertools",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "jobserver",
  "libc",
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -1528,9 +1528,9 @@ checksum = "66f6ddac3e6ac6fd4c3d48bb8b1943472f8da0f43a4303bcd8a18aa594401c80"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1588,7 +1588,7 @@ dependencies = [
  "bit_field",
  "half",
  "lebe",
- "miniz_oxide 0.8.3",
+ "miniz_oxide 0.8.4",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -1653,7 +1653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.3",
+ "miniz_oxide 0.8.4",
 ]
 
 [[package]]
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2563,9 +2563,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_debug"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ea828c9d6638a5bd3d8b14e37502b4d56cae910ccf8a5b7f51c7a0eb1d0508"
+checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3078,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3716,15 +3716,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if 1.0.0",
@@ -3754,9 +3754,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -3953,7 +3953,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.3",
+ "miniz_oxide 0.8.4",
 ]
 
 [[package]]
@@ -4355,15 +4355,14 @@ checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -4395,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -4677,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d433b5df1e1958a668457ebe4a9c5b7bcfe844f4eb2276ac43cf273baddd54"
+checksum = "6ec14cc798c29f4bf74a6c4299c657c04d4e9fba03875c1f0eec569af03aed89"
 dependencies = [
  "const_format",
  "git2",
@@ -4747,9 +4746,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -4805,12 +4804,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spirv"
@@ -4999,9 +4992,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
@@ -5229,9 +5222,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -5250,9 +5243,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -5394,9 +5387,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "tz-rs"
@@ -5920,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.1"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
  "env_home",
@@ -6464,9 +6457,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winit"
-version = "0.30.8"
+version = "0.30.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d74280aabb958072864bff6cfbcf9025cf8bfacdde5e32b5e12920ef703b0f"
+checksum = "a809eacf18c8eca8b6635091543f02a5a06ddf3dad846398795460e6e0ae3cc0"
 dependencies = [
  "ahash",
  "android-activity",
@@ -6516,9 +6509,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 paste = "1"
 sysinfo = "0.33"
 uds_windows = "1"
-win32-display-data = { git = "https://github.com/LGUG2Z/win32-display-data", rev = "75286e77c068a89d12adcd6404c9c4874a60acf5" }
+win32-display-data = { git = "https://github.com/LGUG2Z/win32-display-data", rev = "3ff53fb6f53ec3ec4f9941a0409fba5e36decc46" }
 windows-implement = { version = "0.58" }
 windows-interface = { version = "0.58" }
 windows-core = { version = "0.58" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ version = "0.58"
 features = [
     "implement",
     "Foundation_Numerics",
+    "Win32_Devices",
     "Win32_System_Com",
     "Win32_UI_Shell_Common", # for IObjectArray
     "Win32_Foundation",
@@ -55,6 +56,7 @@ features = [
     "Win32_Graphics_Direct2D_Common",
     "Win32_Graphics_Dxgi_Common",
     "Win32_System_LibraryLoader",
+    "Win32_System_Power",
     "Win32_System_RemoteDesktop",
     "Win32_System_Threading",
     "Win32_UI_Accessibility",

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ every `WindowManagerEvent` and `SocketMessage` handled by `komorebi` in a Rust c
 Below is a simple example of how to use `komorebi-client` in a basic Rust application.
 
 ```rust
-// komorebi-client = { git = "https://github.com/LGUG2Z/komorebi", tag = "v0.1.33"}
+// komorebi-client = { git = "https://github.com/LGUG2Z/komorebi", tag = "v0.1.34"}
 
 use anyhow::Result;
 use komorebi_client::Notification;

--- a/docs/cli/flip-layout.md
+++ b/docs/cli/flip-layout.md
@@ -1,7 +1,7 @@
 # flip-layout
 
 ```
-Flip the layout on the focused workspace (BSP only)
+Flip the layout on the focused workspace
 
 Usage: komorebic.exe flip-layout <AXIS>
 

--- a/docs/cli/focus-monitor-at-cursor.md
+++ b/docs/cli/focus-monitor-at-cursor.md
@@ -1,0 +1,12 @@
+# focus-monitor-at-cursor
+
+```
+Focus the monitor at the current cursor location
+
+Usage: komorebic.exe focus-monitor-at-cursor
+
+Options:
+  -h, --help
+          Print help
+
+```

--- a/docs/cli/query.md
+++ b/docs/cli/query.md
@@ -7,7 +7,7 @@ Usage: komorebic.exe query <STATE_QUERY>
 
 Arguments:
   <STATE_QUERY>
-          [possible values: focused-monitor-index, focused-workspace-index, focused-container-index, focused-window-index]
+          [possible values: focused-monitor-index, focused-workspace-index, focused-container-index, focused-window-index, focused-workspace-name]
 
 Options:
   -h, --help

--- a/docs/komorebi.bar.example.json
+++ b/docs/komorebi.bar.example.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/LGUG2Z/komorebi/v0.1.33/schema.bar.json",
+  "$schema": "https://raw.githubusercontent.com/LGUG2Z/komorebi/v0.1.34/schema.bar.json",
   "monitor": 0,
   "font_family": "JetBrains Mono",
   "theme": {

--- a/docs/komorebi.example.json
+++ b/docs/komorebi.example.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/LGUG2Z/komorebi/v0.1.33/schema.json",
+  "$schema": "https://raw.githubusercontent.com/LGUG2Z/komorebi/v0.1.34/schema.json",
   "app_specific_configuration_path": "$Env:USERPROFILE/applications.json",
   "window_hiding_behaviour": "Cloak",
   "cross_monitor_move_behaviour": "Insert",

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -61,6 +61,7 @@ use std::sync::Arc;
 pub struct Komobar {
     pub hwnd: Option<isize>,
     pub monitor_index: usize,
+    pub disabled: bool,
     pub config: Arc<KomobarConfig>,
     pub render_config: Rc<RefCell<RenderConfig>>,
     pub komorebi_notification_state: Option<Rc<RefCell<KomorebiNotificationState>>>,
@@ -305,12 +306,22 @@ impl Komobar {
         self.center_widgets = center_widgets;
         self.right_widgets = right_widgets;
 
-        let (monitor_index, config_work_area_offset) = match &config.monitor {
+        let (usr_monitor_index, config_work_area_offset) = match &config.monitor {
             MonitorConfigOrIndex::MonitorConfig(monitor_config) => {
                 (monitor_config.index, monitor_config.work_area_offset)
             }
             MonitorConfigOrIndex::Index(idx) => (*idx, None),
         };
+        let monitor_index = if let Some(state) = &self.komorebi_notification_state {
+            state
+                .borrow()
+                .monitor_usr_idx_map
+                .get(&usr_monitor_index)
+                .map_or(usr_monitor_index, |i| *i)
+        } else {
+            usr_monitor_index
+        };
+
         self.monitor_index = monitor_index;
 
         if let (prev_rect, Some(new_rect)) = (&self.work_area_offset, &config_work_area_offset) {
@@ -515,6 +526,7 @@ impl Komobar {
         let mut komobar = Self {
             hwnd: process_hwnd(),
             monitor_index: 0,
+            disabled: false,
             config: config.clone(),
             render_config: Rc::new(RefCell::new(RenderConfig::new())),
             komorebi_notification_state: None,
@@ -652,6 +664,32 @@ impl eframe::App for Komobar {
                     NotificationEvent::Monitor(MonitorNotification::DisplayConnectionChange)
                 ) {
                     let state = &notification.state;
+                    let usr_monitor_index = match &self.config.monitor {
+                        MonitorConfigOrIndex::MonitorConfig(monitor_config) => monitor_config.index,
+                        MonitorConfigOrIndex::Index(idx) => *idx,
+                    };
+                    let monitor_index = state
+                        .monitor_usr_idx_map
+                        .get(&usr_monitor_index)
+                        .map_or(usr_monitor_index, |i| *i);
+                    self.monitor_index = monitor_index;
+
+                    if self.monitor_index >= state.monitors.elements().len() {
+                        // Monitor for this bar got disconnected lets disable the bar until it
+                        // reconnects
+                        self.disabled = true;
+                        tracing::warn!(
+                            "This bar's monitor got disconnected. The bar will be disabled until it reconnects..."
+                        );
+                        return;
+                    } else {
+                        if self.disabled {
+                            tracing::info!(
+                                "This bar's monitor reconnected. The bar will be enabled again!"
+                            );
+                        }
+                        self.disabled = false;
+                    }
 
                     // Store the monitor coordinates in case they've changed
                     MONITOR_RIGHT.store(
@@ -673,6 +711,10 @@ impl eframe::App for Komobar {
                 } else {
                     false
                 };
+
+                if self.disabled {
+                    return;
+                }
 
                 if let Some(komorebi_notification_state) = &self.komorebi_notification_state {
                     komorebi_notification_state
@@ -717,6 +759,12 @@ impl eframe::App for Komobar {
                     );
                 }
             }
+        }
+
+        if self.disabled {
+            // The check for disabled is performed above, if we get here and the bar is still
+            // disabled then we should return without drawing anything.
+            return;
         }
 
         if !self.applied_theme_on_first_frame {

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -497,7 +497,7 @@ impl KomorebiNotificationState {
     pub fn handle_notification(
         &mut self,
         ctx: &Context,
-        monitor_index: usize,
+        monitor_index: Option<usize>,
         notification: komorebi_client::Notification,
         bg_color: Rc<RefCell<Color32>>,
         bg_color_with_alpha: Rc<RefCell<Color32>>,
@@ -555,14 +555,17 @@ impl KomorebiNotificationState {
             },
         }
 
-        self.monitor_index = monitor_index;
         self.monitor_usr_idx_map = notification.state.monitor_usr_idx_map.clone();
 
-        if monitor_index >= notification.state.monitors.elements().len() {
+        if monitor_index.is_none()
+            || monitor_index.is_some_and(|idx| idx >= notification.state.monitors.elements().len())
+        {
             // The bar's monitor is diconnected, so the bar is disabled no need to check anything
             // any further otherwise we'll get `OutOfBounds` panics.
             return;
         }
+        let monitor_index = monitor_index.expect("should have a monitor index");
+        self.monitor_index = monitor_index;
 
         self.mouse_follows_focus = notification.state.mouse_follows_focus;
 

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -38,6 +38,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
@@ -121,6 +122,7 @@ impl From<&KomorebiConfig> for Komorebi {
                 focused_container_information: KomorebiNotificationStateContainerInformation::EMPTY,
                 stack_accent: None,
                 monitor_index: MONITOR_INDEX.load(Ordering::SeqCst),
+                monitor_usr_idx_map: HashMap::new(),
             })),
             workspaces: value.workspaces,
             layout: value.layout.clone(),
@@ -483,6 +485,7 @@ pub struct KomorebiNotificationState {
     pub work_area_offset: Option<Rect>,
     pub stack_accent: Option<Color32>,
     pub monitor_index: usize,
+    pub monitor_usr_idx_map: HashMap<usize, usize>,
 }
 
 impl KomorebiNotificationState {
@@ -553,6 +556,13 @@ impl KomorebiNotificationState {
         }
 
         self.monitor_index = monitor_index;
+        self.monitor_usr_idx_map = notification.state.monitor_usr_idx_map.clone();
+
+        if monitor_index >= notification.state.monitors.elements().len() {
+            // The bar's monitor is diconnected, so the bar is disabled no need to check anything
+            // any further otherwise we'll get `OutOfBounds` panics.
+            return;
+        }
 
         self.mouse_follows_focus = notification.state.mouse_follows_focus;
 

--- a/komorebi-bar/src/main.rs
+++ b/komorebi-bar/src/main.rs
@@ -238,12 +238,16 @@ fn main() -> color_eyre::Result<()> {
         &SocketMessage::State,
     )?)?;
 
-    let (monitor_index, work_area_offset) = match &config.monitor {
+    let (usr_monitor_index, work_area_offset) = match &config.monitor {
         MonitorConfigOrIndex::MonitorConfig(monitor_config) => {
             (monitor_config.index, monitor_config.work_area_offset)
         }
         MonitorConfigOrIndex::Index(idx) => (*idx, None),
     };
+    let monitor_index = state
+        .monitor_usr_idx_map
+        .get(&usr_monitor_index)
+        .map_or(usr_monitor_index, |i| *i);
 
     MONITOR_RIGHT.store(
         state.monitors.elements()[monitor_index].size().right,

--- a/komorebi-bar/src/main.rs
+++ b/komorebi-bar/src/main.rs
@@ -38,7 +38,6 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -338,7 +337,6 @@ fn main() -> color_eyre::Result<()> {
 
     tracing::info!("watching configuration file for changes");
 
-    let config_arc = Arc::new(config);
     eframe::run_native(
         "komorebi-bar",
         native_options,
@@ -426,7 +424,7 @@ fn main() -> color_eyre::Result<()> {
                 }
             });
 
-            Ok(Box::new(Komobar::new(cc, rx_gui, rx_config, config_arc)))
+            Ok(Box::new(Komobar::new(cc, rx_gui, rx_config, config)))
         }),
     )
     .map_err(|error| color_eyre::eyre::Error::msg(error.to_string()))

--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -65,6 +65,7 @@ pub use komorebi::StaticConfig;
 pub use komorebi::SubscribeOptions;
 pub use komorebi::TabsConfig;
 pub use komorebi::WindowContainerBehaviour;
+pub use komorebi::WindowsApi;
 pub use komorebi::WorkspaceConfig;
 
 use komorebi::DATA_DIR;

--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -268,8 +268,14 @@ fn main() -> Result<()> {
     let dumped_state = temp_dir().join("komorebi.state.json");
 
     if !opts.clean_state && dumped_state.is_file() {
-        let state: State = serde_json::from_str(&std::fs::read_to_string(&dumped_state)?)?;
-        wm.lock().apply_state(state);
+        if let Ok(state) = serde_json::from_str(&std::fs::read_to_string(&dumped_state)?) {
+            wm.lock().apply_state(state);
+        } else {
+            tracing::warn!(
+                "cannot apply state from {}; state struct is not up to date",
+                dumped_state.display()
+            );
+        }
     }
 
     wm.lock().retile_all(false)?;

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -36,31 +36,31 @@ use crate::WindowsApi;
 )]
 pub struct Monitor {
     #[getset(get_copy = "pub", set = "pub")]
-    id: isize,
+    pub id: isize,
     #[getset(get = "pub", set = "pub")]
-    name: String,
+    pub name: String,
     #[getset(get = "pub", set = "pub")]
-    device: String,
+    pub device: String,
     #[getset(get = "pub", set = "pub")]
-    device_id: String,
+    pub device_id: String,
     #[getset(get = "pub", set = "pub")]
-    serial_number_id: Option<String>,
+    pub serial_number_id: Option<String>,
     #[getset(get = "pub", set = "pub")]
-    size: Rect,
+    pub size: Rect,
     #[getset(get = "pub", set = "pub")]
-    work_area_size: Rect,
+    pub work_area_size: Rect,
     #[getset(get_copy = "pub", set = "pub")]
-    work_area_offset: Option<Rect>,
+    pub work_area_offset: Option<Rect>,
     #[getset(get_copy = "pub", set = "pub")]
-    window_based_work_area_offset: Option<Rect>,
+    pub window_based_work_area_offset: Option<Rect>,
     #[getset(get_copy = "pub", set = "pub")]
-    window_based_work_area_offset_limit: isize,
-    workspaces: Ring<Workspace>,
+    pub window_based_work_area_offset_limit: isize,
+    pub workspaces: Ring<Workspace>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get_copy = "pub", set = "pub")]
-    last_focused_workspace: Option<usize>,
+    pub last_focused_workspace: Option<usize>,
     #[getset(get_mut = "pub")]
-    workspace_names: HashMap<usize, String>,
+    pub workspace_names: HashMap<usize, String>,
 }
 
 impl_ring_elements!(Monitor, Workspace);

--- a/komorebi/src/monitor_reconciliator/mod.rs
+++ b/komorebi/src/monitor_reconciliator/mod.rs
@@ -48,7 +48,7 @@ static CHANNEL: OnceLock<(Sender<MonitorNotification>, Receiver<MonitorNotificat
 static MONITOR_CACHE: OnceLock<Mutex<HashMap<String, Monitor>>> = OnceLock::new();
 
 pub fn channel() -> &'static (Sender<MonitorNotification>, Receiver<MonitorNotification>) {
-    CHANNEL.get_or_init(|| crossbeam_channel::bounded(1))
+    CHANNEL.get_or_init(|| crossbeam_channel::bounded(20))
 }
 
 fn event_tx() -> Sender<MonitorNotification> {

--- a/komorebi/src/monitor_reconciliator/mod.rs
+++ b/komorebi/src/monitor_reconciliator/mod.rs
@@ -337,6 +337,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
 
                                 // Put the orphaned containers somewhere visible
                                 for container in orphaned_containers {
+                                    container.restore();
                                     focused_ws.add_container_to_back(container);
                                 }
 

--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -751,6 +751,8 @@ impl WindowManager {
 
         serde_json::to_writer_pretty(&file, &known_hwnds)?;
 
+        self.known_hwnds = known_hwnds;
+
         notify_subscribers(
             Notification {
                 event: NotificationEvent::WindowManager(event),

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -176,6 +176,7 @@ impl From<&Workspace> for WorkspaceConfig {
                 Layout::Custom(_) => {}
             }
         }
+        let layout_rules = (!layout_rules.is_empty()).then_some(layout_rules);
 
         let mut window_container_behaviour_rules = HashMap::new();
         for (threshold, behaviour) in value.window_container_behaviour_rules().iter().flatten() {
@@ -217,7 +218,7 @@ impl From<&Workspace> for WorkspaceConfig {
                 .workspace_config()
                 .as_ref()
                 .and_then(|c| c.custom_layout.clone()),
-            layout_rules: Option::from(layout_rules),
+            layout_rules,
             custom_layout_rules: value
                 .workspace_config()
                 .as_ref()

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -206,7 +206,6 @@ impl From<&Workspace> for WorkspaceConfig {
                 .name()
                 .clone()
                 .unwrap_or_else(|| String::from("unnamed")),
-            custom_layout: None,
             layout: value
                 .tile()
                 .then_some(match value.layout() {
@@ -214,13 +213,25 @@ impl From<&Workspace> for WorkspaceConfig {
                     Layout::Custom(_) => None,
                 })
                 .flatten(),
+            custom_layout: value
+                .workspace_config()
+                .as_ref()
+                .and_then(|c| c.custom_layout.clone()),
             layout_rules: Option::from(layout_rules),
-            // TODO: figure out how we might resolve file references in the future
-            custom_layout_rules: None,
+            custom_layout_rules: value
+                .workspace_config()
+                .as_ref()
+                .and_then(|c| c.custom_layout_rules.clone()),
             container_padding,
             workspace_padding,
-            initial_workspace_rules: None,
-            workspace_rules: None,
+            initial_workspace_rules: value
+                .workspace_config()
+                .as_ref()
+                .and_then(|c| c.initial_workspace_rules.clone()),
+            workspace_rules: value
+                .workspace_config()
+                .as_ref()
+                .and_then(|c| c.workspace_rules.clone()),
             apply_window_based_work_area_offset: Some(value.apply_window_based_work_area_offset()),
             window_container_behaviour: *value.window_container_behaviour(),
             window_container_behaviour_rules: Option::from(window_container_behaviour_rules),

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1207,6 +1207,7 @@ impl StaticConfig {
             pending_move_op: Arc::new(None),
             already_moved_window_handles: Arc::new(Mutex::new(HashSet::new())),
             uncloack_to_ignore: 0,
+            known_hwnds: Vec::new(),
         };
 
         match value.focus_follows_mouse {

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1250,9 +1250,14 @@ impl StaticConfig {
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
                 let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
-                let c_idx = display_index_preferences
-                    .iter()
-                    .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
+                let c_idx = display_index_preferences.iter().find_map(|(c_idx, id)| {
+                    (monitor
+                        .serial_number_id()
+                        .as_ref()
+                        .is_some_and(|sn| sn == id)
+                        || monitor.device_id() == id)
+                        .then_some(*c_idx)
+                });
                 c_idx
             };
             let idx = preferred_config_idx.or({
@@ -1276,10 +1281,11 @@ impl StaticConfig {
                 // Check if this monitor config is the preferred config for this monitor and store
                 // a copy of the config on the monitor cache if it is.
                 if idx == preferred_config_idx {
-                    monitor_reconciliator::insert_in_monitor_cache(
-                        monitor.device_id(),
-                        monitor_config.clone(),
-                    );
+                    let id = monitor
+                        .serial_number_id()
+                        .as_ref()
+                        .map_or(monitor.device_id(), |sn| sn);
+                    monitor_reconciliator::insert_in_monitor_cache(id, monitor_config.clone());
                 }
 
                 if let Some(used_config_idx) = idx {
@@ -1331,24 +1337,21 @@ impl StaticConfig {
         }
 
         // Check for configs that should be tied to a specific display that isn't loaded right now
-        // and cache those configs with the specific `device_id` so that when those devices are
-        // connected later we can use the correct config from the cache.
+        // and cache those configs with the specific `serial_number_id` or `device_id` so that when
+        // those devices are connected later we can use the correct config from the cache.
         if configs_with_preference.len() > configs_used.len() {
             for i in configs_with_preference
                 .iter()
                 .filter(|i| !configs_used.contains(i))
             {
-                let device_id = {
+                let id = {
                     let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
                     display_index_preferences.get(i).cloned()
                 };
-                if let (Some(device_id), Some(monitor_config)) =
-                    (device_id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
+                if let (Some(id), Some(monitor_config)) =
+                    (id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
                 {
-                    monitor_reconciliator::insert_in_monitor_cache(
-                        &device_id,
-                        monitor_config.clone(),
-                    );
+                    monitor_reconciliator::insert_in_monitor_cache(&id, monitor_config.clone());
                 }
             }
         }
@@ -1378,9 +1381,14 @@ impl StaticConfig {
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
                 let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
-                let c_idx = display_index_preferences
-                    .iter()
-                    .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
+                let c_idx = display_index_preferences.iter().find_map(|(c_idx, id)| {
+                    (monitor
+                        .serial_number_id()
+                        .as_ref()
+                        .is_some_and(|sn| sn == id)
+                        || monitor.device_id() == id)
+                        .then_some(*c_idx)
+                });
                 c_idx
             };
             let idx = preferred_config_idx.or({
@@ -1404,10 +1412,11 @@ impl StaticConfig {
                 // Check if this monitor config is the preferred config for this monitor and store
                 // a copy of the config on the monitor cache if it is.
                 if idx == preferred_config_idx {
-                    monitor_reconciliator::insert_in_monitor_cache(
-                        monitor.device_id(),
-                        monitor_config.clone(),
-                    );
+                    let id = monitor
+                        .serial_number_id()
+                        .as_ref()
+                        .map_or(monitor.device_id(), |sn| sn);
+                    monitor_reconciliator::insert_in_monitor_cache(id, monitor_config.clone());
                 }
 
                 if let Some(used_config_idx) = idx {
@@ -1461,24 +1470,21 @@ impl StaticConfig {
         }
 
         // Check for configs that should be tied to a specific display that isn't loaded right now
-        // and cache those configs with the specific `device_id` so that when those devices are
+        // and cache those configs with the specific `serial_number_id` so that when those devices are
         // connected later we can use the correct config from the cache.
         if configs_with_preference.len() > configs_used.len() {
             for i in configs_with_preference
                 .iter()
                 .filter(|i| !configs_used.contains(i))
             {
-                let device_id = {
+                let id = {
                     let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
                     display_index_preferences.get(i).cloned()
                 };
-                if let (Some(device_id), Some(monitor_config)) =
-                    (device_id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
+                if let (Some(id), Some(monitor_config)) =
+                    (id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
                 {
-                    monitor_reconciliator::insert_in_monitor_cache(
-                        &device_id,
-                        monitor_config.clone(),
-                    );
+                    monitor_reconciliator::insert_in_monitor_cache(&id, monitor_config.clone());
                 }
             }
         }

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -206,12 +206,14 @@ impl From<&Workspace> for WorkspaceConfig {
                 .name()
                 .clone()
                 .unwrap_or_else(|| String::from("unnamed")),
-            layout: match value.layout() {
-                Layout::Default(layout) => Option::from(*layout),
-                // TODO: figure out how we might resolve file references in the future
-                Layout::Custom(_) => None,
-            },
             custom_layout: None,
+            layout: value
+                .tile()
+                .then_some(match value.layout() {
+                    Layout::Default(layout) => Option::from(*layout),
+                    Layout::Custom(_) => None,
+                })
+                .flatten(),
             layout_rules: Option::from(layout_rules),
             // TODO: figure out how we might resolve file references in the future
             custom_layout_rules: None,

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1253,7 +1253,6 @@ impl StaticConfig {
                 let c_idx = display_index_preferences
                     .iter()
                     .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
-                drop(display_index_preferences);
                 c_idx
             };
             let idx = preferred_config_idx.or({
@@ -1382,7 +1381,6 @@ impl StaticConfig {
                 let c_idx = display_index_preferences
                     .iter()
                     .find_map(|(c_idx, m_id)| (monitor.device_id() == m_id).then_some(*c_idx));
-                drop(display_index_preferences);
                 c_idx
             };
             let idx = preferred_config_idx.or({

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1247,7 +1247,7 @@ impl StaticConfig {
         drop(workspace_matching_rules);
 
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
-            let config_idx = {
+            let preferred_config_idx = {
                 let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
                 let c_idx = display_index_preferences
                     .iter()
@@ -1255,7 +1255,7 @@ impl StaticConfig {
                 drop(display_index_preferences);
                 c_idx
             };
-            let idx = config_idx.or({
+            let idx = preferred_config_idx.or({
                 // Monitor without preferred config idx.
                 // Get index of first config that is not a preferred config of some other monitor
                 // and that has not been used yet. This might return `None` as well, in that case
@@ -1275,7 +1275,7 @@ impl StaticConfig {
             {
                 // Check if this monitor config is the preferred config for this monitor and store
                 // a copy of the config on the monitor cache if it is.
-                if idx == config_idx {
+                if idx == preferred_config_idx {
                     monitor_reconciliator::insert_in_monitor_cache(
                         monitor.device_id(),
                         monitor_config.clone(),
@@ -1330,6 +1330,29 @@ impl StaticConfig {
             }
         }
 
+        // Check for configs that should be tied to a specific display that isn't loaded right now
+        // and cache those configs with the specific `device_id` so that when those devices are
+        // connected later we can use the correct config from the cache.
+        if configs_with_preference.len() > configs_used.len() {
+            for i in configs_with_preference
+                .iter()
+                .filter(|i| !configs_used.contains(i))
+            {
+                let device_id = {
+                    let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                    display_index_preferences.get(i).cloned()
+                };
+                if let (Some(device_id), Some(monitor_config)) =
+                    (device_id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
+                {
+                    monitor_reconciliator::insert_in_monitor_cache(
+                        &device_id,
+                        monitor_config.clone(),
+                    );
+                }
+            }
+        }
+
         wm.enforce_workspace_rules()?;
 
         if value.border == Some(true) {
@@ -1353,7 +1376,7 @@ impl StaticConfig {
         drop(workspace_matching_rules);
 
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
-            let config_idx = {
+            let preferred_config_idx = {
                 let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
                 let c_idx = display_index_preferences
                     .iter()
@@ -1361,7 +1384,7 @@ impl StaticConfig {
                 drop(display_index_preferences);
                 c_idx
             };
-            let idx = config_idx.or({
+            let idx = preferred_config_idx.or({
                 // Monitor without preferred config idx.
                 // Get index of first config that is not a preferred config of some other monitor
                 // and that has not been used yet. This might return `None` as well, in that case
@@ -1381,7 +1404,7 @@ impl StaticConfig {
             {
                 // Check if this monitor config is the preferred config for this monitor and store
                 // a copy of the config on the monitor cache if it is.
-                if idx == config_idx {
+                if idx == preferred_config_idx {
                     monitor_reconciliator::insert_in_monitor_cache(
                         monitor.device_id(),
                         monitor_config.clone(),
@@ -1434,6 +1457,29 @@ impl StaticConfig {
                             });
                         }
                     }
+                }
+            }
+        }
+
+        // Check for configs that should be tied to a specific display that isn't loaded right now
+        // and cache those configs with the specific `device_id` so that when those devices are
+        // connected later we can use the correct config from the cache.
+        if configs_with_preference.len() > configs_used.len() {
+            for i in configs_with_preference
+                .iter()
+                .filter(|i| !configs_used.contains(i))
+            {
+                let device_id = {
+                    let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                    display_index_preferences.get(i).cloned()
+                };
+                if let (Some(device_id), Some(monitor_config)) =
+                    (device_id, value.monitors.as_ref().and_then(|ms| ms.get(*i)))
+                {
+                    monitor_reconciliator::insert_in_monitor_cache(
+                        &device_id,
+                        monitor_config.clone(),
+                    );
                 }
             }
         }

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1178,6 +1178,7 @@ impl StaticConfig {
 
         let mut wm = WindowManager {
             monitors: Ring::default(),
+            monitor_usr_idx_map: HashMap::new(),
             incoming_events: incoming,
             command_listener: listener,
             is_paused: false,

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -117,6 +117,7 @@ pub struct WindowManager {
     pub pending_move_op: Arc<Option<(usize, usize, isize)>>,
     pub already_moved_window_handles: Arc<Mutex<HashSet<isize>>>,
     pub uncloack_to_ignore: usize,
+    pub known_hwnds: Vec<isize>,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -364,6 +365,7 @@ impl WindowManager {
             pending_move_op: Arc::new(None),
             already_moved_window_handles: Arc::new(Mutex::new(HashSet::new())),
             uncloack_to_ignore: 0,
+            known_hwnds: Vec::new(),
         })
     }
 

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -348,7 +348,7 @@ impl WindowsApi {
             .len()
             .max(monitor_usr_idx_map.keys().max().map_or(0, |v| *v));
 
-        let available_usr_idxs = (0..max_usr_idx)
+        let mut available_usr_idxs = (0..max_usr_idx)
             .filter(|i| !monitor_usr_idx_map.contains_key(i))
             .collect::<Vec<_>>();
 
@@ -359,6 +359,7 @@ impl WindowsApi {
         for i in not_added_monitor_idxs {
             if let Some(next_usr_idx) = available_usr_idxs.first() {
                 monitor_usr_idx_map.insert(*next_usr_idx, i);
+                available_usr_idxs.remove(0);
             } else if let Some(idx) = monitor_usr_idx_map.keys().max() {
                 monitor_usr_idx_map.insert(*idx, i);
             }

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -296,7 +296,8 @@ impl WindowsApi {
 
             let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
             for (index, id) in &*display_index_preferences {
-                if id.eq(m.device_id()) {
+                if m.serial_number_id().as_ref().is_some_and(|sn| sn == id) || id.eq(m.device_id())
+                {
                     index_preference = Option::from(index);
                 }
             }

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -49,6 +49,8 @@ use windows::Win32::Graphics::Gdi::MONITORENUMPROC;
 use windows::Win32::Graphics::Gdi::MONITORINFOEXW;
 use windows::Win32::Graphics::Gdi::MONITOR_DEFAULTTONEAREST;
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows::Win32::System::Power::RegisterPowerSettingNotification;
+use windows::Win32::System::Power::HPOWERNOTIFY;
 use windows::Win32::System::RemoteDesktop::ProcessIdToSessionId;
 use windows::Win32::System::RemoteDesktop::WTSRegisterSessionNotification;
 use windows::Win32::System::Threading::GetCurrentProcessId;
@@ -93,6 +95,7 @@ use windows::Win32::UI::WindowsAndMessaging::MoveWindow;
 use windows::Win32::UI::WindowsAndMessaging::PostMessageW;
 use windows::Win32::UI::WindowsAndMessaging::RealGetWindowClassW;
 use windows::Win32::UI::WindowsAndMessaging::RegisterClassW;
+use windows::Win32::UI::WindowsAndMessaging::RegisterDeviceNotificationW;
 use windows::Win32::UI::WindowsAndMessaging::SetCursorPos;
 use windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
 use windows::Win32::UI::WindowsAndMessaging::SetLayeredWindowAttributes;
@@ -102,11 +105,14 @@ use windows::Win32::UI::WindowsAndMessaging::ShowWindow;
 use windows::Win32::UI::WindowsAndMessaging::SystemParametersInfoW;
 use windows::Win32::UI::WindowsAndMessaging::WindowFromPoint;
 use windows::Win32::UI::WindowsAndMessaging::CW_USEDEFAULT;
+use windows::Win32::UI::WindowsAndMessaging::DEV_BROADCAST_DEVICEINTERFACE_W;
 use windows::Win32::UI::WindowsAndMessaging::GWL_EXSTYLE;
 use windows::Win32::UI::WindowsAndMessaging::GWL_STYLE;
 use windows::Win32::UI::WindowsAndMessaging::GW_HWNDNEXT;
+use windows::Win32::UI::WindowsAndMessaging::HDEVNOTIFY;
 use windows::Win32::UI::WindowsAndMessaging::HWND_TOP;
 use windows::Win32::UI::WindowsAndMessaging::LWA_ALPHA;
+use windows::Win32::UI::WindowsAndMessaging::REGISTER_NOTIFICATION_FLAGS;
 use windows::Win32::UI::WindowsAndMessaging::SET_WINDOW_POS_FLAGS;
 use windows::Win32::UI::WindowsAndMessaging::SHOW_WINDOW_CMD;
 use windows::Win32::UI::WindowsAndMessaging::SPIF_SENDCHANGE;
@@ -1208,6 +1214,26 @@ impl WindowsApi {
             )?
         }
         .process()
+    }
+
+    pub fn register_power_setting_notification(
+        hwnd: isize,
+        guid: &windows_core::GUID,
+        flags: REGISTER_NOTIFICATION_FLAGS,
+    ) -> WindowsCrateResult<HPOWERNOTIFY> {
+        unsafe { RegisterPowerSettingNotification(HWND(as_ptr!(hwnd)), guid, flags) }
+    }
+
+    pub fn register_device_notification(
+        hwnd: isize,
+        mut filter: DEV_BROADCAST_DEVICEINTERFACE_W,
+        flags: REGISTER_NOTIFICATION_FLAGS,
+    ) -> WindowsCrateResult<HDEVNOTIFY> {
+        unsafe {
+            let state_ptr: *const core::ffi::c_void =
+                &mut filter as *mut _ as *const core::ffi::c_void;
+            RegisterDeviceNotificationW(HWND(as_ptr!(hwnd)), state_ptr, flags)
+        }
     }
 
     pub fn invalidate_rect(hwnd: isize, rect: Option<&Rect>, erase: bool) -> bool {

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -92,6 +92,8 @@ pub struct Workspace {
     window_container_behaviour_rules: Option<Vec<(usize, WindowContainerBehaviour)>>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     float_override: Option<bool>,
+    #[getset(get = "pub", set = "pub")]
+    workspace_config: Option<WorkspaceConfig>,
 }
 
 impl_ring_elements!(Workspace, Container);
@@ -118,6 +120,7 @@ impl Default for Workspace {
             window_container_behaviour: None,
             window_container_behaviour_rules: None,
             float_override: None,
+            workspace_config: None,
         }
     }
 }
@@ -208,6 +211,8 @@ impl Workspace {
 
         self.set_float_override(config.float_override);
         self.set_layout_flip(config.layout_flip);
+
+        self.set_workspace_config(Some(config.clone()));
 
         Ok(())
     }

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -92,6 +92,7 @@ pub struct Workspace {
     window_container_behaviour_rules: Option<Vec<(usize, WindowContainerBehaviour)>>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     float_override: Option<bool>,
+    #[serde(skip)]
     #[getset(get = "pub", set = "pub")]
     workspace_config: Option<WorkspaceConfig>,
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - cli/send-to-monitor-workspace.md
       - cli/move-to-monitor-workspace.md
       - cli/focus-monitor.md
+      - cli/focus-monitor-at-cursor.md
       - cli/focus-last-workspace.md
       - cli/focus-workspace.md
       - cli/focus-workspaces.md


### PR DESCRIPTION
## This PR tries to properly handle monitors disconnecting and reconnecting

This PR reworks the way the `postload` and the `reload` functions apply the monitor configs to the monitors. Previously it was looping through the monitor configs and applying them to the monitor with the index corresponding to the config's index. 

However this isn't correct, since the user might set the preferred indices for 3 monitors (like monitor A, B and C), with the preferred index set to 0 for A, 1 for B and 2 for C, but if only monitors A and C are connected then komorebi would apply config 0 to A and config 1 to C, which is wrong it should be 2 for C.

This PR changes the way the configs are applied on those functions.
Now it loops through the existing monitors (already in order), then checks if the monitor has a preferred config index, if it does it uses that one, if it doesn't then it uses the first monitor config that isn't a preferred index for some other monitor and that hasn't been used yet.

For the situation above it means that it would still apply config 2 to monitor C. And in case there aren't any display_index_preferences set it will still apply the configs in order.

It also changes the way the layout is stored from the current monitor, by making sure to set it to `None` if the workspace is not tiling. Previously any floating workspace would be restored from cache with a tiling BSP layout.

Related to [this discussion](https://discord.com/channels/898554690126630914/1329508394205184104/1329518859383865456) on Discord

However this entire code is based on the premise that the `device_id` is always the same for the same devices. However there have been [comments](https://discord.com/channels/898554690126630914/898554690608967786/1330587647462084609) on discord stating that this isn't true, however I've not been able to confirm this and the users have not given any proof of this happening (they might simply be confusing it since it's a weird string similar between monitors...)

I think the changes from this PR should fix most issues that people have been having with multiple monitors (specially with 3 or more monitors). But it's probably better to not merge this until we can get some users to test it.


This PR changes the monitor cache from caching a config to caching the actual state of the monitor itself.

With this PR when a monitor disconnects instead of "throwing" all windows to the main monitor, right now it does nothing and keeps your other monitors as is and simply stores the disconnected monitor state.
If then you reconnect (or wake up) the monitor again, then you'll get back to the same monitor with all the windows like you had before!

If while the monitor is disconnected you need to access some window that was on the disconnected monitor, you can simply `alt + tab` to it or press the taskbar icon and the window will show on the focused workspace of the focused monitor and it becomes handled by this monitor/workspace. When the previously disconnected monitor reconnects it will see that this specific window is already handled by another workspace so it ignores it.


This PR also introduces a few changes to the bar so that it can handle the monitor disconnect/reconnect properly and so that it can map the bar config to the correct monitor.

Previously if you had 3 monitor configs setup on `komorebi.json` with the `display_index_preferences` set like this:
```json
"display_index_preferences": [
    "0": "MONITOR_A",
    "1": "MONITOR_B",
    "2": "MONITOR_C",
]
```
But if you only had connected monitors A and C you would have to manually change the bar configurations monitor index because now monitor A would have index 0, but monitor C would have index 1 instead of 2.
Now with this PR this is no longer needed. Now the monitor index setup on the bar configuration **NEEDS TO BE** the index you've used on `display_index_preferences` for that monitor. So in the case above you would setup the bar configurations using the indices 0, 1 and 2 for monitors A, B and C respectively.

If the monitor B is disconnected, komorebi will know that now the monitor with index 1 is monitor C so the bar will also be aware of this and automatically change it's internal index to 1 (the user doesn't have to do anything!). Meaning that the bar will still show on the correct monitor with the correct coordinates. After the monitor reconnects the bar will update it's internal index again automatically and continue to show on the correct monitor. This means that even if you connect other monitors that are not mentioned on the `display_index_preferences` the bar should still point to the correct monitor.

It would be great if some users could test this PR since it introduces quite a few changes to make sure there are no regressions!
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
