### PR TITLE
Use Windows API to spawn processes instead of powershell

### DIFF
--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -1482,10 +1482,10 @@ enum SubCommand {
 macro_rules! spawn_and_log {
     ($command:expr) => {
         match $command.spawn() {
-            Err(error) => println!("Error: {error}"),
+            Err(error) => eprintln!("Error: {error}"),
             Ok(_) => match get_command_string(&$command) {
                 Ok(command_str) => println!("{command_str}"),
-                Err(error) => println!("Error: {error}"),
+                Err(error) => eprintln!("Error: {error}"),
             },
         }
     };
@@ -1507,11 +1507,11 @@ macro_rules! spawn_and_log {
 macro_rules! terminate_process {
     ($system:expr, $process_name:expr) => {
         match terminate_matching_processes(&mut $system, &$process_name) {
-            Ok(_) => {
-                println!("{} stopped", &$process_name);
+            Ok(count) => {
+                println!("{} {} processes stopped", count, &$process_name);
             }
             Err(error) => {
-                println!("Error: {}", error);
+                eprintln!("Error: {}", error);
             }
         }
     };
@@ -2407,7 +2407,7 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
                         println!("{script}");
                     }
                     Err(error) => {
-                        println!("Error: {error}");
+                        eprintln!("Error: {error}");
                     }
                 }
             }
@@ -2538,7 +2538,7 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
                         println!("{count} AutoHotkey processes stopped");
                     }
                     Err(error) => {
-                        println!("Error: {error}");
+                        eprintln!("Error: {error}");
                     }
                 }
             }
@@ -2568,7 +2568,7 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
                         }
                     }
                     Err(error) => {
-                        println!("Error: {error}");
+                        eprintln!("Error: {error}");
                     }
                 }
             }
@@ -2593,7 +2593,7 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
                         println!("{count} AutoHotkey processes stopped");
                     }
                     Err(error) => {
-                        println!("Error: {error}");
+                        eprintln!("Error: {error}");
                     }
                 }
             }

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -2527,18 +2527,14 @@ if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
             } else {
                 send_message(&SocketMessage::Stop)?;
             }
-            let mut system = sysinfo::System::new_all();
-            system.refresh_processes(ProcessesToUpdate::All, true);
 
-            if system.processes_by_name("komorebi.exe".as_ref()).count() >= 1 {
+            let komorebi_exe = "komorebi.exe";
+            if system.processes_by_name(komorebi_exe.as_ref()).count() >= 1 {
                 println!("komorebi is still running, attempting to force-quit");
 
-                let script = r"
-Stop-Process -Name:komorebi -ErrorAction SilentlyContinue
-                ";
-                match powershell_script::run(script) {
+                match terminate_matching_processes(&mut system, komorebi_exe) {
                     Ok(_) => {
-                        println!("{script}");
+                        println!("{komorebi_exe} stopped");
 
                         let hwnd_json = DATA_DIR.join("komorebi.hwnd.json");
 

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -113,6 +113,11 @@ lazy_static! {
 
 shadow_rs::shadow!(build);
 
+const KOMOREBI_EXE: &str = "komorebi.exe";
+const KOMOREBI_BAR_EXE: &str = "komorebi-bar.exe";
+const WHKD_EXE: &str = "whkd.exe";
+const MASIR_EXE: &str = "masir.exe";
+
 #[derive(thiserror::Error, Debug, miette::Diagnostic)]
 #[error("{message}")]
 #[diagnostic(code(komorebi::configuration), help("try fixing this syntax error"))]
@@ -2350,45 +2355,48 @@ fn main() -> Result<()> {
                 flags.push("'--clean-state'".to_string());
             }
 
-            let komorebi_exe_path = exec.unwrap_or("komorebi.exe");
+            let komorebi_exe_path = exec.unwrap_or(KOMOREBI_EXE);
             let mut command = detached_command(komorebi_exe_path);
             command.args(&flags);
             spawn_and_log!(command);
 
             let mut system = System::new_all();
             let mut attempts = 0;
-            let mut running = is_running(&mut system, "komorebi.exe");
+            let mut running = is_running(&mut system, KOMOREBI_EXE);
 
             while !running && attempts <= 2 {
                 let mut command = detached_command(komorebi_exe_path);
                 command.args(&flags);
                 spawn_and_log!(command);
 
-                print!("Waiting for komorebi.exe to start...");
+                print!("Waiting for {} to start...", KOMOREBI_EXE);
                 std::thread::sleep(Duration::from_secs(3));
 
                 system.refresh_processes(ProcessesToUpdate::All, true);
 
-                if is_running(&mut system, "komorebi.exe") {
+                if is_running(&mut system, KOMOREBI_EXE) {
                     println!("Started!");
                     running = true;
                 } else {
-                    println!("komorebi.exe did not start... Trying again");
+                    println!("{} did not start... Trying again", KOMOREBI_EXE);
                     attempts += 1;
                 }
             }
 
             if !running {
-                println!("\nRunning komorebi.exe directly for detailed error output\n");
+                println!(
+                    "\nRunning {} directly for detailed error output\n",
+                    KOMOREBI_EXE
+                );
                 if let Some(config) = arg.config {
                     let path = resolve_home_path(config)?;
-                    if let Ok(output) = Command::new("komorebi.exe")
+                    if let Ok(output) = Command::new(KOMOREBI_EXE)
                         .arg(format!("'--config=\"{}\"'", path.display()))
                         .output()
                     {
                         println!("{}", String::from_utf8(output.stderr)?);
                     }
-                } else if let Ok(output) = Command::new("komorebi.exe").output() {
+                } else if let Ok(output) = Command::new(KOMOREBI_EXE).output() {
                     println!("{}", String::from_utf8(output.stderr)?);
                 }
 
@@ -2437,19 +2445,19 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
                     let mut config = StaticConfig::read(config)?;
                     if let Some(display_bar_configurations) = &mut config.bar_configurations {
                         for config_file_path in &mut *display_bar_configurations {
-                            let mut command = detached_command("komorebi-bar.exe");
+                            let mut command = detached_command(KOMOREBI_BAR_EXE);
                             command.arg("--config").arg(&config_file_path);
                             spawn_and_log!(command);
                         }
-                    } else if !is_running(&mut system, "komorebi-bar.exe") {
-                        let mut command = detached_command("komorebi-bar.exe");
+                    } else if !is_running(&mut system, KOMOREBI_BAR_EXE) {
+                        let mut command = detached_command(KOMOREBI_BAR_EXE);
                         spawn_and_log!(command);
                     }
                 }
             }
 
-            if arg.masir && !is_running(&mut system, "masir.exe") {
-                let mut command = detached_command("masir.exe");
+            if arg.masir && !is_running(&mut system, MASIR_EXE) {
+                let mut command = detached_command(MASIR_EXE);
                 spawn_and_log!(command);
             }
 
@@ -2489,7 +2497,7 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
             }
 
             if bar_config.is_some() {
-                let output = Command::new("komorebi-bar.exe").arg("--aliases").output()?;
+                let output = Command::new(KOMOREBI_BAR_EXE).arg("--aliases").output()?;
                 let stdout = String::from_utf8(output.stdout)?;
                 println!("{stdout}");
             }
@@ -2521,15 +2529,15 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
         SubCommand::Stop(arg) => {
             let mut system = System::new_all();
             if arg.whkd {
-                terminate_process!(&mut system, "whkd.exe");
+                terminate_process!(&mut system, WHKD_EXE);
             }
 
             if arg.bar {
-                terminate_process!(&mut system, "komorebi-bar.exe");
+                terminate_process!(&mut system, KOMOREBI_BAR_EXE);
             }
 
             if arg.masir {
-                terminate_process!(&mut system, "masir.exe");
+                terminate_process!(&mut system, MASIR_EXE);
             }
 
             if arg.ahk {
@@ -2549,7 +2557,7 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
                 send_message(&SocketMessage::Stop)?;
             }
 
-            let komorebi_exe = "komorebi.exe";
+            let komorebi_exe = KOMOREBI_EXE;
             if system.processes_by_name(komorebi_exe.as_ref()).count() >= 1 {
                 println!("komorebi is still running, attempting to force-quit");
 
@@ -2576,15 +2584,15 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
         SubCommand::Kill(arg) => {
             let mut system = System::new_all();
             if arg.whkd {
-                terminate_process!(&mut system, "whkd.exe");
+                terminate_process!(&mut system, WHKD_EXE);
             }
 
             if arg.bar {
-                terminate_process!(&mut system, "komorebi-bar.exe");
+                terminate_process!(&mut system, KOMOREBI_BAR_EXE);
             }
 
             if arg.masir {
-                terminate_process!(&mut system, "masir.exe");
+                terminate_process!(&mut system, MASIR_EXE);
             }
 
             if arg.ahk {


### PR DESCRIPTION
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
- Switched to use win api for both process creation and termination for all cases except spawning of `whkd`, as it will spawn a visible console window if we use win api for its process creation. I suspect this can be solved on `whkd` side but I'll leave it as is for now
- Addresses #1174 now that we don't have powershell adding trailing space to the commandline
- Startup time has a very noticeable improvement, on my machine it dropped from about 2s to < 1s
- Modified error printing to print to stderr