### PR TITLE
fix(bar): removed unneeded separator character on network widget

### DIFF
--- a/komorebi-bar/src/network.rs
+++ b/komorebi-bar/src/network.rs
@@ -148,7 +148,7 @@ impl Network {
             LabelPrefix::None | LabelPrefix::Icon => match reading.format {
                 NetworkReadingFormat::Speed => (
                     format!(
-                        "{: >width$}/s | ",
+                        "{: >width$}/s ",
                         reading.received_text,
                         width = self.network_activity_fill_characters
                     ),
@@ -159,14 +159,14 @@ impl Network {
                     ),
                 ),
                 NetworkReadingFormat::Total => (
-                    format!("{} | ", reading.received_text),
+                    format!("{} ", reading.received_text),
                     reading.transmitted_text,
                 ),
             },
             LabelPrefix::Text | LabelPrefix::IconAndText => match reading.format {
                 NetworkReadingFormat::Speed => (
                     format!(
-                        "DOWN: {: >width$}/s | ",
+                        "DOWN: {: >width$}/s ",
                         reading.received_text,
                         width = self.network_activity_fill_characters
                     ),
@@ -177,7 +177,7 @@ impl Network {
                     ),
                 ),
                 NetworkReadingFormat::Total => (
-                    format!("\u{2211}DOWN: {}/s | ", reading.received_text),
+                    format!("\u{2211}DOWN: {}/s ", reading.received_text),
                     format!("\u{2211}UP: {}/s", reading.transmitted_text),
                 ),
             },


### PR DESCRIPTION
I realized that the `|` is not really necessary, so it is now removed.

before:
![image](https://github.com/user-attachments/assets/ade7599c-84da-46ba-b426-ad40ea6b5f3e)

after:
![image](https://github.com/user-attachments/assets/7304b507-f3ed-4f04-962d-5764d6f9049f)
