### PR TITLE
perf(komorebi): dont pull redundant info from sysinfo::System

### DIFF
--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -176,7 +176,7 @@ fn main() -> Result<()> {
     let session_id = WindowsApi::process_id_to_session_id()?;
     SESSION_ID.store(session_id, Ordering::SeqCst);
 
-    let mut system = sysinfo::System::new_all();
+    let mut system = sysinfo::System::new();
     system.refresh_processes(ProcessesToUpdate::All, true);
 
     let matched_procs: Vec<&Process> = system.processes_by_name("komorebi.exe".as_ref()).collect();


### PR DESCRIPTION
System::new_all() pulls all information (processes, cpu, mem, etc) but we only need process information. In addition currently it is being polled twice. System::new() creates an uninitialized struct, then we poll specifically for process info.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
