### PR TITLE
Fix the default hiding behaviour not matching the documentation

### DIFF
--- a/komorebi/src/lib.rs
+++ b/komorebi/src/lib.rs
@@ -182,7 +182,7 @@ lazy_static! {
     static ref TCP_CONNECTIONS: Arc<Mutex<HashMap<String, TcpStream>>> =
         Arc::new(Mutex::new(HashMap::new()));
     static ref HIDING_BEHAVIOUR: Arc<Mutex<HidingBehaviour>> =
-        Arc::new(Mutex::new(HidingBehaviour::Minimize));
+        Arc::new(Mutex::new(HidingBehaviour::Cloak));
     pub static ref HOME_DIR: PathBuf = {
         std::env::var("KOMOREBI_CONFIG_HOME").map_or_else(|_| dirs::home_dir().expect("there is no home directory"), |home_path| {
             let home = PathBuf::from(&home_path);


### PR DESCRIPTION
[The Configuration Reference](https://komorebi.lgug2z.com/schema#window_hiding_behaviour) and [Rust Doc](https://github.com/LGUG2Z/komorebi/blob/2d2b6e5c1552b046b783517f4875647a88a3e00b/komorebi/src/static_config.rs#L346) both state that the default hiding behaviour is `Cloak`, however, the default was actually set to `Minimize`.

While this technically changes the behaviour for anyone who doesn't have this option explicitly set, I feel it's more important to match the documentation, especially considering the other options were soft deprecated almost a year ago in cc7dbde0497ac9186d1325e3514c4d037f5af6b5 and the obvious issues `Minimize` causes when switching workspaces.

I noticed this after removing the config option since I thought it was redundant, which caused the workspace switching issues mentioned in the docs for `Minimize`.