### PR TITLE
chore(deps): bump eframe to 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,11 +285,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
 dependencies = [
  "clipboard-win",
+ "core-graphics 0.23.2",
+ "image",
  "log",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "parking_lot",
+ "windows-sys 0.48.0",
  "x11rb",
 ]
 
@@ -553,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e335041290c43101ca215eed6f43ec437eb5a42125573f600fc3fa42b9bddd62"
+checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
 dependencies = [
  "arrayvec",
 ]
@@ -587,13 +590,13 @@ dependencies = [
 [[package]]
 name = "base16-egui-themes"
 version = "0.1.0"
-source = "git+https://github.com/LGUG2Z/base16-egui-themes?rev=911079d#911079d1ee7d60bbebf1f8e05d0e5a6bc596ad79"
+source = "git+https://github.com/LGUG2Z/base16-egui-themes?rev=96f26c88d83781f234d42222293ec73d23a39ad8#96f26c88d83781f234d42222293ec73d23a39ad8"
 dependencies = [
  "egui",
  "schemars",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -781,7 +784,7 @@ dependencies = [
 [[package]]
 name = "catppuccin-egui"
 version = "5.3.1"
-source = "git+https://github.com/LGUG2Z/catppuccin-egui?rev=f85cc3c#f85cc3ce187bab308bec7d50ca974d66578a5590"
+source = "git+https://github.com/LGUG2Z/catppuccin-egui?rev=bdaff30959512c4f7ee7304117076a48633d777f#bdaff30959512c4f7ee7304117076a48633d777f"
 dependencies = [
  "egui",
 ]
@@ -827,12 +830,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -848,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -858,14 +855,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -873,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -987,12 +984,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
 
 [[package]]
 name = "const_format"
@@ -1285,9 +1276,9 @@ checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "ecolor"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d72e9c39f6e11a2e922d04a34ec5e7ef522ea3f5a1acfca7a19d16ad5fe50f5"
+checksum = "878e9005799dd739e5d5d89ff7480491c12d0af571d44399bcaefa1ee172dd76"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1295,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f2d9e7ea2d11ec9e98a8683b6eb99f9d7d0448394ef6e0d6d91bd4eb817220"
+checksum = "eba4c50d905804fe9ec4e159fde06b9d38f9440228617ab64a03d7a2091ece63"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1306,7 +1297,7 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow 0.16.0",
+ "glow",
  "glutin",
  "glutin-winit",
  "image",
@@ -1331,12 +1322,13 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252d52224d35be1535d7fd1d6139ce071fb42c9097773e79f7665604f5596b5e"
+checksum = "7d2768eaa6d5c80a6e2a008da1f0e062dff3c83eb2b28605ea2d0732d46e74d6"
 dependencies = [
  "accesskit",
  "ahash",
+ "bitflags 2.8.0",
  "emath",
  "epaint",
  "log",
@@ -1346,18 +1338,18 @@ dependencies = [
 
 [[package]]
 name = "egui-phosphor"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe75c81cd796bfb6718df8a5339c47695bfb33e400fae03a77200305519f2c2"
+checksum = "171d57331491e92f0a7c73fad1088716e3200984309f4f8684731b750cee1378"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c1e821d2d8921ef6ce98b258c7e24d9d6aab2ca1f9cdf374eca997e7f67f59"
+checksum = "6d8151704bcef6271bec1806c51544d70e79ef20e8616e5eac01facfd9c8c54a"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1375,13 +1367,14 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e84c2919cd9f3a38a91e8f84ac6a245c19251fd95226ed9fae61d5ea564fce3"
+checksum = "ace791b367c1f63e6044aef2f3834904509d1d1a6912fd23ebf3f6a9af92cd84"
 dependencies = [
  "accesskit_winit",
  "ahash",
  "arboard",
+ "bytemuck",
  "egui",
  "log",
  "profiling",
@@ -1394,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7a8198c088b1007108cb2d403bc99a5e370999b200db4f14559610d7330126"
+checksum = "b5b5cf69510eb3d19211fc0c062fb90524f43fe8e2c012967dcf0e2d81cb040f"
 dependencies = [
  "ahash",
  "egui",
@@ -1408,14 +1401,14 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf6264cc7608e3e69a7d57a6175f438275f1b3889c1a551b418277721c95e6"
+checksum = "9a53e2374a964c3c793cb0b8ead81bca631f24974bc0b747d1a5622f4e39fdd0"
 dependencies = [
  "ahash",
  "bytemuck",
  "egui",
- "glow 0.16.0",
+ "glow",
  "log",
  "memoffset",
  "profiling",
@@ -1426,15 +1419,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "emath"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe73c1207b864ee40aa0b0c038d6092af1030744678c60188a05c28553515d"
+checksum = "55b7b6be5ad1d247f11738b0e4699d9c20005ed366f2c29f5ec1f8e1de180bc2"
 dependencies = [
  "bytemuck",
 ]
@@ -1504,9 +1497,9 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "epaint"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5666f8d25236293c966fbb3635eac18b04ad1914e3bab55bc7d44b9980cafcac"
+checksum = "275b665a7b9611d8317485187e5458750850f9e64604d3c58434bb3fc1d22915"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1522,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f6ddac3e6ac6fd4c3d48bb8b1943472f8da0f43a4303bcd8a18aa594401c80"
+checksum = "9343d356d7cac894dacafc161b4654e0881301097bdf32a122ed503d97cb94b6"
 
 [[package]]
 name = "equivalent"
@@ -1648,9 +1641,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.5",
@@ -1908,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded738faa0e88d3abc9d1a13cb11adc2073c400969eeb8793cf7132589959fc"
+checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1960,18 +1953,6 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
@@ -1989,7 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03642b8b0cce622392deb0ee3e88511f75df2daac806102597905c3ea1974848"
 dependencies = [
  "bitflags 2.8.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "cgl",
  "core-foundation 0.9.4",
  "dispatch",
@@ -2013,7 +1994,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -2691,7 +2672,7 @@ dependencies = [
  "serde_json_lenient",
  "serde_yaml",
  "shadow-rs",
- "strum",
+ "strum 0.27.1",
  "sysinfo",
  "tracing",
  "tracing-appender",
@@ -2775,7 +2756,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_variant",
- "strum",
+ "strum 0.27.1",
 ]
 
 [[package]]
@@ -2848,9 +2829,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2915,9 +2896,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litrs"
@@ -3013,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
  "bitflags 2.8.0",
  "block",
@@ -3036,7 +3017,7 @@ dependencies = [
  "backtrace-ext",
  "cfg-if 1.0.0",
  "miette-derive",
- "owo-colors 4.1.0",
+ "owo-colors 4.2.0",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
@@ -3132,22 +3113,23 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "23.1.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.8.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
  "log",
  "rustc-hash",
  "spirv",
+ "strum 0.26.3",
  "termcolor",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "unicode-xid",
 ]
 
@@ -3307,7 +3289,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if 1.0.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -3792,6 +3774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,9 +3826,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "owo-colors"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "parking"
@@ -4367,9 +4358,9 @@ checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "ring"
-version = "0.17.10"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34b5020fcdea098ef7d95e9f89ec15952123a4a039badd09fabebe9e963e839"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
@@ -4475,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -4487,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4688,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209d2a96c110f23f27b5944408d36027a2ce2c9159ca2efee3a7f333e548427e"
+checksum = "3672eb035a31ac62bf171765d04e3f1f01659920847384d08ac979ca6bb56763"
 dependencies = [
  "const_format",
  "git2",
@@ -4874,7 +4865,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -4882,6 +4882,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5405,18 +5418,15 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "tz-rs"
-version = "0.6.14"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
+checksum = "e1450bf2b99397e72070e7935c89facaa80092ac812502200375f1f7d33c71a1"
 
 [[package]]
 name = "tzdb"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
+checksum = "0be2ea5956f295449f47c0b825c5e109022ff1a6a53bb4f77682a87c2341fbf5"
 dependencies = [
  "iana-time-zone",
  "tz-rs",
@@ -5425,9 +5435,9 @@ dependencies = [
 
 [[package]]
 name = "tzdb_data"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4471adcfcbd3052e8c5b5890a04a559837444b3be26b9cbbd622063171cec9d"
+checksum = "0604b35c1f390a774fdb138cac75a99981078895d24bcab175987440bbff803b"
 dependencies = [
  "tz-rs",
 ]
@@ -5825,12 +5835,13 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "23.0.1"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
+checksum = "47f55718f85c2fa756edffa0e7f0e0a60aba463d1362b57e23123c58f035e4b6"
 dependencies = [
  "arrayvec",
- "cfg_aliases 0.1.1",
+ "bitflags 2.8.0",
+ "cfg_aliases",
  "document-features",
  "js-sys",
  "log",
@@ -5849,14 +5860,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "23.0.1"
+version = "24.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
+checksum = "671c25545d479b47d3f0a8e373aceb2060b67c6eb841b24ac8c32348151c7a0c"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.8.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "document-features",
  "indexmap",
  "log",
@@ -5867,25 +5878,25 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "23.0.1"
+version = "24.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
+checksum = "4317a17171dc20e6577bf606796794580accae0716a69edbc7388c86a3ec9f23"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bitflags 2.8.0",
  "bytemuck",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "core-graphics-types",
- "glow 0.14.2",
+ "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-descriptor",
@@ -5899,13 +5910,14 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
+ "ordered-float",
  "parking_lot",
  "profiling",
  "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -5914,12 +5926,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f6ff27778148c31093f3b03abc4840f9636d58d597ca2f5977433acfe0068"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
 dependencies = [
  "bitflags 2.8.0",
  "js-sys",
+ "log",
  "web-sys",
 ]
 
@@ -6455,7 +6468,7 @@ dependencies = [
  "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
@@ -6783,18 +6796,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ chrono = "0.4"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"
 color-eyre = "0.6"
-eframe = "0.30"
-egui_extras = "0.30"
+eframe = "0.31"
+egui_extras = "0.31"
 dirs = "6"
 dunce = "1"
 hotwatch = "0.5"
@@ -27,6 +27,7 @@ lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { package = "serde_json_lenient", version = "0.2" }
 serde_yaml = "0.9"
+strum = { version = "0.27", features = ["derive"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/komorebi-bar/Cargo.toml
+++ b/komorebi-bar/Cargo.toml
@@ -16,7 +16,7 @@ crossbeam-channel = { workspace = true }
 dirs = { workspace = true }
 dunce = { workspace = true }
 eframe = { workspace = true }
-egui-phosphor = "0.8"
+egui-phosphor = "0.9"
 font-loader = "0.11"
 hotwatch = { workspace = true }
 image = "0.25"

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -178,11 +178,11 @@ pub fn apply_theme(
     {
         if let Some(rounding) = config.rounding {
             ctx.style_mut(|style| {
-                style.visuals.widgets.noninteractive.rounding = rounding.into();
-                style.visuals.widgets.inactive.rounding = rounding.into();
-                style.visuals.widgets.hovered.rounding = rounding.into();
-                style.visuals.widgets.active.rounding = rounding.into();
-                style.visuals.widgets.open.rounding = rounding.into();
+                style.visuals.widgets.noninteractive.corner_radius = rounding.into();
+                style.visuals.widgets.inactive.corner_radius = rounding.into();
+                style.visuals.widgets.hovered.corner_radius = rounding.into();
+                style.visuals.widgets.active.corner_radius = rounding.into();
+                style.visuals.widgets.open.corner_radius = rounding.into();
             });
         }
     }
@@ -502,11 +502,12 @@ impl Komobar {
                         {
                             if let Some(rounding) = config.rounding {
                                 ctx.style_mut(|style| {
-                                    style.visuals.widgets.noninteractive.rounding = rounding.into();
-                                    style.visuals.widgets.inactive.rounding = rounding.into();
-                                    style.visuals.widgets.hovered.rounding = rounding.into();
-                                    style.visuals.widgets.active.rounding = rounding.into();
-                                    style.visuals.widgets.open.rounding = rounding.into();
+                                    style.visuals.widgets.noninteractive.corner_radius =
+                                        rounding.into();
+                                    style.visuals.widgets.inactive.corner_radius = rounding.into();
+                                    style.visuals.widgets.hovered.corner_radius = rounding.into();
+                                    style.visuals.widgets.active.corner_radius = rounding.into();
+                                    style.visuals.widgets.open.corner_radius = rounding.into();
                                 });
                             }
                         }
@@ -839,26 +840,26 @@ impl eframe::App for Komobar {
         let frame = match &self.config.padding {
             None => {
                 if let Some(frame) = &self.config.frame {
-                    Frame::none()
+                    Frame::NONE
                         .inner_margin(Margin::symmetric(
-                            frame.inner_margin.x,
-                            frame.inner_margin.y,
+                            frame.inner_margin.x as i8,
+                            frame.inner_margin.y as i8,
                         ))
                         .fill(*self.bg_color_with_alpha.borrow())
                 } else {
-                    Frame::none()
-                        .inner_margin(Margin::same(0.0))
+                    Frame::NONE
+                        .inner_margin(Margin::same(0))
                         .fill(*self.bg_color_with_alpha.borrow())
                 }
             }
             Some(padding) => {
                 let padding = padding.to_individual(DEFAULT_PADDING);
-                Frame::none()
+                Frame::NONE
                     .inner_margin(Margin {
-                        top: padding.top,
-                        bottom: padding.bottom,
-                        left: padding.left,
-                        right: padding.right,
+                        top: padding.top as i8,
+                        bottom: padding.bottom as i8,
+                        left: padding.left as i8,
+                        right: padding.right as i8,
                     })
                     .fill(*self.bg_color_with_alpha.borrow())
             }
@@ -871,13 +872,13 @@ impl eframe::App for Komobar {
         CentralPanel::default().frame(frame).show(ctx, |ui| {
             // Apply grouping logic for the bar as a whole
             let area_frame = if let Some(frame) = &self.config.frame {
-                Frame::none()
-                    .inner_margin(Margin::symmetric(0.0, frame.inner_margin.y))
-                    .outer_margin(Margin::same(0.0))
+                Frame::NONE
+                    .inner_margin(Margin::symmetric(0, frame.inner_margin.y as i8))
+                    .outer_margin(Margin::same(0))
             } else {
-                Frame::none()
-                    .inner_margin(Margin::same(0.0))
-                    .outer_margin(Margin::same(0.0))
+                Frame::NONE
+                    .inner_margin(Margin::same(0))
+                    .outer_margin(Margin::same(0))
             };
 
             let available_height = ui.max_rect().max.y;
@@ -897,13 +898,13 @@ impl eframe::App for Komobar {
                             .as_ref()
                             .map(|s| s.to_individual(DEFAULT_PADDING))
                         {
-                            left_area_frame.inner_margin.left = padding.left;
-                            left_area_frame.inner_margin.top = padding.top;
-                            left_area_frame.inner_margin.bottom = padding.bottom;
+                            left_area_frame.inner_margin.left = padding.left as i8;
+                            left_area_frame.inner_margin.top = padding.top as i8;
+                            left_area_frame.inner_margin.bottom = padding.bottom as i8;
                         } else if let Some(frame) = &self.config.frame {
-                            left_area_frame.inner_margin.left = frame.inner_margin.x;
-                            left_area_frame.inner_margin.top = frame.inner_margin.y;
-                            left_area_frame.inner_margin.bottom = frame.inner_margin.y;
+                            left_area_frame.inner_margin.left = frame.inner_margin.x as i8;
+                            left_area_frame.inner_margin.top = frame.inner_margin.y as i8;
+                            left_area_frame.inner_margin.bottom = frame.inner_margin.y as i8;
                         }
 
                         left_area_frame.show(ui, |ui| {
@@ -933,13 +934,13 @@ impl eframe::App for Komobar {
                             .as_ref()
                             .map(|s| s.to_individual(DEFAULT_PADDING))
                         {
-                            right_area_frame.inner_margin.right = padding.right;
-                            right_area_frame.inner_margin.top = padding.top;
-                            right_area_frame.inner_margin.bottom = padding.bottom;
+                            right_area_frame.inner_margin.right = padding.right as i8;
+                            right_area_frame.inner_margin.top = padding.top as i8;
+                            right_area_frame.inner_margin.bottom = padding.bottom as i8;
                         } else if let Some(frame) = &self.config.frame {
-                            right_area_frame.inner_margin.right = frame.inner_margin.x;
-                            right_area_frame.inner_margin.top = frame.inner_margin.y;
-                            right_area_frame.inner_margin.bottom = frame.inner_margin.y;
+                            right_area_frame.inner_margin.right = frame.inner_margin.x as i8;
+                            right_area_frame.inner_margin.top = frame.inner_margin.y as i8;
+                            right_area_frame.inner_margin.bottom = frame.inner_margin.y as i8;
                         }
 
                         right_area_frame.show(ui, |ui| {
@@ -977,11 +978,11 @@ impl eframe::App for Komobar {
                             .as_ref()
                             .map(|s| s.to_individual(DEFAULT_PADDING))
                         {
-                            center_area_frame.inner_margin.top = padding.top;
-                            center_area_frame.inner_margin.bottom = padding.bottom;
+                            center_area_frame.inner_margin.top = padding.top as i8;
+                            center_area_frame.inner_margin.bottom = padding.bottom as i8;
                         } else if let Some(frame) = &self.config.frame {
-                            center_area_frame.inner_margin.top = frame.inner_margin.y;
-                            center_area_frame.inner_margin.bottom = frame.inner_margin.y;
+                            center_area_frame.inner_margin.top = frame.inner_margin.y as i8;
+                            center_area_frame.inner_margin.bottom = frame.inner_margin.y as i8;
                         }
 
                         center_area_frame.show(ui, |ui| {

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -15,14 +15,15 @@ use eframe::egui::vec2;
 use eframe::egui::Color32;
 use eframe::egui::ColorImage;
 use eframe::egui::Context;
+use eframe::egui::CornerRadius;
 use eframe::egui::Frame;
 use eframe::egui::Image;
 use eframe::egui::Label;
 use eframe::egui::Margin;
 use eframe::egui::RichText;
-use eframe::egui::Rounding;
 use eframe::egui::Sense;
 use eframe::egui::Stroke;
+use eframe::egui::StrokeKind;
 use eframe::egui::TextureHandle;
 use eframe::egui::TextureOptions;
 use eframe::egui::Ui;
@@ -192,9 +193,9 @@ impl BarWidget for Komorebi {
                                     });
 
                                     if has_icon {
-                                        Frame::none()
+                                        Frame::NONE
                                             .inner_margin(Margin::same(
-                                                ui.style().spacing.button_padding.y,
+                                                ui.style().spacing.button_padding.y as i8,
                                             ))
                                             .show(ui, |ui| {
                                                 for (is_focused, container) in containers {
@@ -220,11 +221,11 @@ impl BarWidget for Komorebi {
                                         if is_selected { ctx.style().visuals.selection.stroke.color} else { ui.style().visuals.text_color() },
                                     );
                                     let mut rect = response.rect;
-                                    let rounding = Rounding::same(rect.width() * 0.1);
+                                    let rounding = CornerRadius::same((rect.width() * 0.1) as u8);
                                     rect = rect.shrink(stroke.width);
                                     let c = rect.center();
                                     let r = rect.width() / 2.0;
-                                    painter.rect_stroke(rect, rounding, stroke);
+                                    painter.rect_stroke(rect, rounding, stroke, StrokeKind::Outside);
                                     painter.line_segment([c - vec2(r, r), c + vec2(r, r)], stroke);
 
                                     response.on_hover_text(ws.to_string())
@@ -453,9 +454,9 @@ impl BarWidget for Komorebi {
                                             && i == focused_window_idx)
                                     {
                                         if let Some(img) = icon {
-                                            Frame::none()
+                                            Frame::NONE
                                                 .inner_margin(Margin::same(
-                                                    ui.style().spacing.button_padding.y,
+                                                    ui.style().spacing.button_padding.y as i8,
                                                 ))
                                                 .show(ui, |ui| {
                                                     let response = ui.add(

--- a/komorebi-bar/src/komorebi_layout.rs
+++ b/komorebi-bar/src/komorebi_layout.rs
@@ -4,12 +4,13 @@ use crate::render::RenderConfig;
 use crate::selected_frame::SelectableFrame;
 use eframe::egui::vec2;
 use eframe::egui::Context;
+use eframe::egui::CornerRadius;
 use eframe::egui::FontId;
 use eframe::egui::Frame;
 use eframe::egui::Label;
-use eframe::egui::Rounding;
 use eframe::egui::Sense;
 use eframe::egui::Stroke;
+use eframe::egui::StrokeKind;
 use eframe::egui::Ui;
 use eframe::egui::Vec2;
 use komorebi_client::SocketMessage;
@@ -133,11 +134,11 @@ impl KomorebiLayout {
         };
         let stroke = Stroke::new(1.0, color);
         let mut rect = response.rect;
-        let rounding = Rounding::same(rect.width() * 0.1);
+        let rounding = CornerRadius::same((rect.width() * 0.1) as u8);
         rect = rect.shrink(stroke.width);
         let c = rect.center();
         let r = rect.width() / 2.0;
-        painter.rect_stroke(rect, rounding, stroke);
+        painter.rect_stroke(rect, rounding, stroke, StrokeKind::Outside);
 
         match self {
             KomorebiLayout::Default(layout) => match layout {
@@ -193,7 +194,7 @@ impl KomorebiLayout {
                     rect.width() * 0.35 + stroke.width,
                 ));
                 painter.rect_filled(rect_left, rounding, color);
-                painter.rect_stroke(rect_right, rounding, stroke);
+                painter.rect_stroke(rect_right, rounding, stroke, StrokeKind::Outside);
             }
             KomorebiLayout::Paused => {
                 let mut rect_left = response.rect;
@@ -255,7 +256,7 @@ impl KomorebiLayout {
 
             if show_options {
                 if let Some(workspace_idx) = workspace_idx {
-                    Frame::none().show(ui, |ui| {
+                    Frame::NONE.show(ui, |ui| {
                         ui.add(
                             Label::new(egui_phosphor::regular::ARROW_FAT_LINES_RIGHT.to_string())
                                 .selectable(false),

--- a/komorebi-bar/src/render.rs
+++ b/komorebi-bar/src/render.rs
@@ -3,15 +3,14 @@ use crate::config::KomobarConfig;
 use crate::config::MonitorConfigOrIndex;
 use eframe::egui::Color32;
 use eframe::egui::Context;
+use eframe::egui::CornerRadius;
 use eframe::egui::FontId;
 use eframe::egui::Frame;
 use eframe::egui::InnerResponse;
 use eframe::egui::Margin;
-use eframe::egui::Rounding;
 use eframe::egui::Shadow;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
-use eframe::egui::Vec2;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -148,10 +147,10 @@ impl RenderConfig {
             return self.define_group_frame(
                 //TODO: this outer margin can be a config
                 Some(Margin {
-                    left: 10.0,
-                    right: 10.0,
-                    top: 6.0,
-                    bottom: 6.0,
+                    left: 10,
+                    right: 10,
+                    top: 6,
+                    bottom: 6,
                 }),
                 config,
                 ui_style,
@@ -204,11 +203,11 @@ impl RenderConfig {
         ui: &mut Ui,
         add_contents: impl FnOnce(&mut Ui) -> R,
     ) -> InnerResponse<R> {
-        Frame::none()
+        Frame::NONE
             .outer_margin(outer_margin.unwrap_or(Margin::ZERO))
             .inner_margin(match self.more_inner_margin {
-                true => Margin::symmetric(5.0, 0.0),
-                false => Margin::same(0.0),
+                true => Margin::symmetric(5, 0),
+                false => Margin::same(0),
             })
             .show(ui, add_contents)
     }
@@ -233,13 +232,13 @@ impl RenderConfig {
         Frame::group(ui_style)
             .outer_margin(outer_margin.unwrap_or(Margin::ZERO))
             .inner_margin(match self.more_inner_margin {
-                true => Margin::symmetric(6.0, 1.0),
-                false => Margin::symmetric(1.0, 1.0),
+                true => Margin::symmetric(6, 1),
+                false => Margin::symmetric(1, 1),
             })
             .stroke(ui_style.visuals.widgets.noninteractive.bg_stroke)
-            .rounding(match config.rounding {
+            .corner_radius(match config.rounding {
                 Some(rounding) => rounding.into(),
-                None => ui_style.visuals.widgets.noninteractive.rounding,
+                None => ui_style.visuals.widgets.noninteractive.corner_radius,
             })
             .fill(
                 self.background_color
@@ -250,27 +249,27 @@ impl RenderConfig {
                     // new styles can be added if needed here
                     GroupingStyle::Default => Shadow::NONE,
                     GroupingStyle::DefaultWithShadowB4O1S3 => Shadow {
-                        blur: 4.0,
-                        offset: Vec2::new(1.0, 1.0),
-                        spread: 3.0,
+                        blur: 4,
+                        offset: [1, 1],
+                        spread: 3,
                         color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithShadowB4O0S3 => Shadow {
-                        blur: 4.0,
-                        offset: Vec2::new(0.0, 0.0),
-                        spread: 3.0,
+                        blur: 4,
+                        offset: [0, 0],
+                        spread: 3,
                         color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithShadowB0O1S3 => Shadow {
-                        blur: 0.0,
-                        offset: Vec2::new(1.0, 1.0),
-                        spread: 3.0,
+                        blur: 0,
+                        offset: [1, 1],
+                        spread: 3,
                         color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithGlowB3O1S2 => Shadow {
-                        blur: 3.0,
-                        offset: Vec2::new(1.0, 1.0),
-                        spread: 2.0,
+                        blur: 3,
+                        offset: [1, 1],
+                        spread: 2,
                         color: ui_style
                             .visuals
                             .selection
@@ -279,9 +278,9 @@ impl RenderConfig {
                             .try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithGlowB3O0S2 => Shadow {
-                        blur: 3.0,
-                        offset: Vec2::new(0.0, 0.0),
-                        spread: 2.0,
+                        blur: 3,
+                        offset: [0, 0],
+                        spread: 2,
                         color: ui_style
                             .visuals
                             .selection
@@ -290,9 +289,9 @@ impl RenderConfig {
                             .try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithGlowB0O1S2 => Shadow {
-                        blur: 0.0,
-                        offset: Vec2::new(1.0, 1.0),
-                        spread: 2.0,
+                        blur: 0,
+                        offset: [1, 1],
+                        spread: 2,
                         color: ui_style
                             .visuals
                             .selection
@@ -308,9 +307,9 @@ impl RenderConfig {
     fn widget_outer_margin(&mut self, ui: &mut Ui) -> Margin {
         let spacing = if self.applied_on_widget {
             // Remove the default item spacing from the margin
-            self.spacing - ui.spacing().item_spacing.x
+            (self.spacing - ui.spacing().item_spacing.x) as i8
         } else {
-            0.0
+            0
         };
 
         if !self.applied_on_widget {
@@ -322,20 +321,20 @@ impl RenderConfig {
                 Some(align) => match align {
                     Alignment::Left => spacing,
                     Alignment::Center => spacing,
-                    Alignment::Right => 0.0,
+                    Alignment::Right => 0,
                 },
-                None => 0.0,
+                None => 0,
             },
             right: match self.alignment {
                 Some(align) => match align {
-                    Alignment::Left => 0.0,
-                    Alignment::Center => 0.0,
+                    Alignment::Left => 0,
+                    Alignment::Center => 0,
                     Alignment::Right => spacing,
                 },
-                None => 0.0,
+                None => 0,
             },
-            top: 0.0,
-            bottom: 0.0,
+            top: 0,
+            bottom: 0,
         }
     }
 }
@@ -379,16 +378,19 @@ pub enum RoundingConfig {
     Individual([f32; 4]),
 }
 
-impl From<RoundingConfig> for Rounding {
+impl From<RoundingConfig> for CornerRadius {
     fn from(value: RoundingConfig) -> Self {
         match value {
-            RoundingConfig::Same(value) => Rounding::same(value),
-            RoundingConfig::Individual(values) => Self {
-                nw: values[0],
-                ne: values[1],
-                sw: values[2],
-                se: values[3],
-            },
+            RoundingConfig::Same(value) => Self::same(value as u8),
+            RoundingConfig::Individual(values) => {
+                let values = values.map(|f| f as u8);
+                Self {
+                    nw: values[0],
+                    ne: values[1],
+                    sw: values[2],
+                    se: values[3],
+                }
+            }
         }
     }
 }

--- a/komorebi-bar/src/selected_frame.rs
+++ b/komorebi-bar/src/selected_frame.rs
@@ -18,14 +18,14 @@ impl SelectableFrame {
     pub fn show<R>(self, ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> Response {
         let Self { selected } = self;
 
-        Frame::none()
+        Frame::NONE
             .show(ui, |ui| {
                 let response = ui.interact(ui.max_rect(), ui.unique_id(), Sense::click());
 
                 if ui.is_rect_visible(response.rect) {
                     let inner_margin = Margin::symmetric(
-                        ui.style().spacing.button_padding.x,
-                        ui.style().spacing.button_padding.y,
+                        ui.style().spacing.button_padding.x as i8,
+                        ui.style().spacing.button_padding.y as i8,
                     );
 
                     if selected
@@ -35,14 +35,14 @@ impl SelectableFrame {
                     {
                         let visuals = ui.style().interact_selectable(&response, selected);
 
-                        Frame::none()
+                        Frame::NONE
                             .stroke(visuals.bg_stroke)
-                            .rounding(visuals.rounding)
+                            .corner_radius(visuals.corner_radius)
                             .fill(visuals.bg_fill)
                             .inner_margin(inner_margin)
                             .show(ui, add_contents);
                     } else {
-                        Frame::none()
+                        Frame::NONE
                             .inner_margin(inner_margin)
                             .show(ui, add_contents);
                     }

--- a/komorebi-bar/src/time.rs
+++ b/komorebi-bar/src/time.rs
@@ -6,13 +6,14 @@ use crate::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Align;
 use eframe::egui::Context;
+use eframe::egui::CornerRadius;
 use eframe::egui::Label;
-use eframe::egui::Rounding;
 use eframe::egui::Sense;
 use eframe::egui::Stroke;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
 use eframe::egui::Vec2;
+use eframe::epaint::StrokeKind;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -158,14 +159,14 @@ impl Time {
         let color = ctx.style().visuals.text_color();
         let stroke = Stroke::new(1.0, color);
 
-        let round_all = Rounding::same(response.rect.width() * 0.1);
-        let round_top = Rounding {
+        let round_all = CornerRadius::same((response.rect.width() * 0.1) as u8);
+        let round_top = CornerRadius {
             nw: round_all.nw,
             ne: round_all.ne,
             ..Default::default()
         };
-        let round_none = Rounding::ZERO;
-        let round_bottom = Rounding {
+        let round_none = CornerRadius::ZERO;
+        let round_bottom = CornerRadius {
             sw: round_all.nw,
             se: round_all.ne,
             ..Default::default()
@@ -175,14 +176,19 @@ impl Time {
             let mut rect = response.rect.shrink(stroke.width);
             rect.set_height(rect.height() - height * 2.0);
             rect = rect.translate(Vec2::new(0.0, height * 2.0));
-            painter.rect_stroke(rect, round_all, stroke);
+            painter.rect_stroke(rect, round_all, stroke, StrokeKind::Outside);
         } else if max_power == 3 {
             let mut rect = response.rect.shrink(stroke.width);
             rect.set_height(rect.height() - height);
             rect = rect.translate(Vec2::new(0.0, height));
-            painter.rect_stroke(rect, round_all, stroke);
+            painter.rect_stroke(rect, round_all, stroke, StrokeKind::Outside);
         } else {
-            painter.rect_stroke(response.rect.shrink(stroke.width), round_all, stroke);
+            painter.rect_stroke(
+                response.rect.shrink(stroke.width),
+                round_all,
+                stroke,
+                StrokeKind::Outside,
+            );
         }
 
         let mut rect_bin = response.rect;

--- a/komorebi-themes/Cargo.toml
+++ b/komorebi-themes/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.35"
 edition = "2021"
 
 [dependencies]
-base16-egui-themes = { git = "https://github.com/LGUG2Z/base16-egui-themes", rev = "911079d" }
-catppuccin-egui = { git = "https://github.com/LGUG2Z/catppuccin-egui", rev = "f85cc3c", default-features = false, features = ["egui30"] }
+base16-egui-themes = { git = "https://github.com/LGUG2Z/base16-egui-themes", rev = "96f26c88d83781f234d42222293ec73d23a39ad8" }
+catppuccin-egui = { git = "https://github.com/LGUG2Z/catppuccin-egui", rev = "bdaff30959512c4f7ee7304117076a48633d777f", default-features = false, features = ["egui31"] }
 #catppuccin-egui = { version = "5", default-features = false, features = ["egui30"] }
 eframe = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_variant = "0.1"
-strum = "0.26"
+strum = { workspace = true }

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -34,7 +34,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 shadow-rs = { workspace = true }
-strum = { version = "0.26", features = ["derive"] }
+strum = { workspace = true }
 sysinfo = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }


### PR DESCRIPTION
A whole bunch of deprecations and breaking changes in this egui/eframe release - @CtByte can you take a look?

I'm not sure what we should default to for this new enum: https://docs.rs/egui/0.31.0/egui/enum.StrokeKind.html