### PR TITLE
feat(bar): add thai font fallback

### DIFF
--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -571,6 +571,7 @@ impl Komobar {
 
         fallbacks.insert("Microsoft YaHei", "C:\\Windows\\Fonts\\msyh.ttc"); // chinese
         fallbacks.insert("Malgun Gothic", "C:\\Windows\\Fonts\\malgun.ttf"); // korean
+        fallbacks.insert("Leelawadee UI", "C:\\Windows\\Fonts\\LeelawUI.ttf"); // thai
 
         for (name, path) in fallbacks {
             if let Ok(bytes) = std::fs::read(path) {


### PR DESCRIPTION
This commit adds Thai font fallback to Leelawadee UI. This will be looked up at runtime on the user's system, and only loaded if the files exist in the default Windows font installation location.