### PR TITLE
feat(reaper): rework reaper logic to make it faster

### DIFF
--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -291,7 +291,7 @@ fn main() -> Result<()> {
     transparency_manager::listen_for_notifications(wm.clone());
     workspace_reconciliator::listen_for_notifications(wm.clone());
     monitor_reconciliator::listen_for_notifications(wm.clone())?;
-    reaper::watch_for_orphans(wm.clone());
+    reaper::listen_for_notifications(wm.clone());
     focus_manager::listen_for_notifications(wm.clone());
     theme_manager::listen_for_notifications();
 

--- a/komorebi/src/monitor_reconciliator/mod.rs
+++ b/komorebi/src/monitor_reconciliator/mod.rs
@@ -385,7 +385,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                     }
 
                     // Update known_hwnds
-                    wm.known_hwnds.retain(|i| !windows_to_remove.contains(i));
+                    wm.known_hwnds.retain(|i, _| !windows_to_remove.contains(i));
 
                     if !newly_removed_displays.is_empty() {
                         // After we have cached them, remove them from our state
@@ -481,7 +481,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                                     {
                                         container.windows_mut().retain(|window| {
                                             window.exe().is_ok()
-                                                && !known_hwnds.contains(&window.hwnd)
+                                                && !known_hwnds.contains_key(&window.hwnd)
                                         });
 
                                         if container.windows().is_empty() {
@@ -519,7 +519,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
 
                                     if let Some(window) = workspace.maximized_window() {
                                         if window.exe().is_err()
-                                            || known_hwnds.contains(&window.hwnd)
+                                            || known_hwnds.contains_key(&window.hwnd)
                                         {
                                             workspace.set_maximized_window(None);
                                         } else if is_focused_workspace {
@@ -530,7 +530,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                                     if let Some(container) = workspace.monocle_container_mut() {
                                         container.windows_mut().retain(|window| {
                                             window.exe().is_ok()
-                                                && !known_hwnds.contains(&window.hwnd)
+                                                && !known_hwnds.contains_key(&window.hwnd)
                                         });
 
                                         if container.windows().is_empty() {
@@ -552,7 +552,8 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                                     }
 
                                     workspace.floating_windows_mut().retain(|window| {
-                                        window.exe().is_ok() && !known_hwnds.contains(&window.hwnd)
+                                        window.exe().is_ok()
+                                            && !known_hwnds.contains_key(&window.hwnd)
                                     });
 
                                     if is_focused_workspace {

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1835,6 +1835,9 @@ impl WindowManager {
             | SocketMessage::IdentifyBorderOverflowApplication(_, _) => {}
         };
 
+        // Update list of known_hwnds and their monitor/workspace index pair
+        self.update_known_hwnds();
+
         notify_subscribers(
             Notification {
                 event: NotificationEvent::Socket(message.clone()),

--- a/komorebi/src/reaper.rs
+++ b/komorebi/src/reaper.rs
@@ -1,14 +1,164 @@
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
 use crate::border_manager;
+use crate::notify_subscribers;
+use crate::winevent::WinEvent;
+use crate::NotificationEvent;
+use crate::Window;
 use crate::WindowManager;
+use crate::WindowManagerEvent;
+use crate::DATA_DIR;
+
+use crossbeam_channel::Receiver;
+use crossbeam_channel::Sender;
+use lazy_static::lazy_static;
 use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::fs::OpenOptions;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
-pub fn watch_for_orphans(wm: Arc<Mutex<WindowManager>>) {
+lazy_static! {
+    pub static ref HWNDS_CACHE: Arc<Mutex<HashMap<isize, (usize, usize)>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+}
+
+pub struct ReaperNotification(pub HashMap<isize, (usize, usize)>);
+
+static CHANNEL: OnceLock<(Sender<ReaperNotification>, Receiver<ReaperNotification>)> =
+    OnceLock::new();
+
+pub fn channel() -> &'static (Sender<ReaperNotification>, Receiver<ReaperNotification>) {
+    CHANNEL.get_or_init(|| crossbeam_channel::bounded(50))
+}
+
+fn event_tx() -> Sender<ReaperNotification> {
+    channel().0.clone()
+}
+
+fn event_rx() -> Receiver<ReaperNotification> {
+    channel().1.clone()
+}
+
+pub fn send_notification(hwnds: HashMap<isize, (usize, usize)>) {
+    if event_tx().try_send(ReaperNotification(hwnds)).is_err() {
+        tracing::warn!("channel is full; dropping notification")
+    }
+}
+
+pub fn listen_for_notifications(wm: Arc<Mutex<WindowManager>>) {
+    watch_for_orphans(wm.clone());
+
     std::thread::spawn(move || loop {
-        match find_orphans(wm.clone()) {
+        match handle_notifications(wm.clone()) {
+            Ok(()) => {
+                tracing::warn!("restarting finished thread");
+            }
+            Err(error) => {
+                tracing::warn!("restarting failed thread: {}", error);
+            }
+        }
+    });
+}
+
+fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()> {
+    tracing::info!("listening");
+
+    let receiver = event_rx();
+
+    for notification in receiver {
+        let orphan_hwnds = notification.0;
+        let mut wm = wm.lock();
+        let offset = wm.work_area_offset;
+
+        let mut update_borders = false;
+
+        for (hwnd, (m_idx, w_idx)) in orphan_hwnds.iter() {
+            if let Some(monitor) = wm.monitors_mut().get_mut(*m_idx) {
+                let focused_workspace_idx = monitor.focused_workspace_idx();
+                let work_area = *monitor.work_area_size();
+                let window_based_work_area_offset = (
+                    monitor.window_based_work_area_offset_limit(),
+                    monitor.window_based_work_area_offset(),
+                );
+
+                let offset = if monitor.work_area_offset().is_some() {
+                    monitor.work_area_offset()
+                } else {
+                    offset
+                };
+
+                if let Some(workspace) = monitor.workspaces_mut().get_mut(*w_idx) {
+                    // Remove orphan window
+                    if let Err(error) = workspace.remove_window(*hwnd) {
+                        tracing::warn!(
+                            "error reaping orphan window ({}) on monitor: {}, workspace: {}. Error: {}",
+                            hwnd,
+                            m_idx,
+                            w_idx,
+                            error,
+                        );
+                    }
+
+                    if focused_workspace_idx == *w_idx {
+                        // If this is not a focused workspace there is no need to update the
+                        // workspace or the borders. That will already be done when the user
+                        // changes to this workspace.
+                        workspace.update(&work_area, offset, window_based_work_area_offset)?;
+                        update_borders = true;
+                    }
+                    tracing::info!(
+                        "reaped orphan window ({}) on monitor: {}, workspace: {}",
+                        hwnd,
+                        m_idx,
+                        w_idx,
+                    );
+                }
+            }
+
+            wm.known_hwnds.remove(hwnd);
+
+            let window = Window::from(*hwnd);
+            notify_subscribers(
+                crate::Notification {
+                    event: NotificationEvent::WindowManager(WindowManagerEvent::Destroy(
+                        WinEvent::ObjectDestroy,
+                        window,
+                    )),
+                    state: wm.as_ref().into(),
+                },
+                true,
+            )?;
+        }
+
+        if update_borders {
+            border_manager::send_notification(None);
+        }
+
+        // Save to file
+        let hwnd_json = DATA_DIR.join("komorebi.hwnd.json");
+        let file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(hwnd_json)?;
+
+        serde_json::to_writer_pretty(&file, &wm.known_hwnds.keys().collect::<Vec<_>>())?;
+    }
+
+    Ok(())
+}
+
+fn watch_for_orphans(wm: Arc<Mutex<WindowManager>>) {
+    // Cache current hwnds
+    {
+        let mut cache = HWNDS_CACHE.lock();
+        *cache = wm.lock().known_hwnds.clone();
+    }
+
+    std::thread::spawn(move || loop {
+        match find_orphans() {
             Ok(()) => {
                 tracing::warn!("restarting finished thread");
             }
@@ -23,50 +173,37 @@ pub fn watch_for_orphans(wm: Arc<Mutex<WindowManager>>) {
     });
 }
 
-pub fn find_orphans(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()> {
+fn find_orphans() -> color_eyre::Result<()> {
     tracing::info!("watching");
 
-    let arc = wm.clone();
-
     loop {
-        std::thread::sleep(Duration::from_secs(1));
+        std::thread::sleep(Duration::from_millis(20));
 
-        let mut wm = arc.lock();
-        let offset = wm.work_area_offset;
+        let mut cache = HWNDS_CACHE.lock();
+        let mut orphan_hwnds = HashMap::new();
 
-        let mut update_borders = false;
+        for (hwnd, (m_idx, w_idx)) in cache.iter() {
+            let window = Window::from(*hwnd);
 
-        for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
-            let work_area = *monitor.work_area_size();
-            let window_based_work_area_offset = (
-                monitor.window_based_work_area_offset_limit(),
-                monitor.window_based_work_area_offset(),
-            );
-
-            let offset = if monitor.work_area_offset().is_some() {
-                monitor.work_area_offset()
-            } else {
-                offset
-            };
-
-            for (j, workspace) in monitor.workspaces_mut().iter_mut().enumerate() {
-                let reaped_orphans = workspace.reap_orphans()?;
-                if reaped_orphans.0 > 0 || reaped_orphans.1 > 0 {
-                    workspace.update(&work_area, offset, window_based_work_area_offset)?;
-                    update_borders = true;
-                    tracing::info!(
-                        "reaped {} orphan window(s) and {} orphaned container(s) on monitor: {}, workspace: {}",
-                        reaped_orphans.0,
-                        reaped_orphans.1,
-                        i,
-                        j
-                    );
-                }
+            if !window.is_window()
+                // This one is a hack because WINWORD.EXE is an absolute trainwreck of an app
+                // when multiple docs are open, it keeps open an invisible window, with WS_EX_LAYERED
+                // (A STYLE THAT THE REGULAR WINDOWS NEED IN ORDER TO BE MANAGED!) when one of the
+                // docs is closed
+                //
+                // I hate every single person who worked on Microsoft Office 365, especially Word
+                || !window.is_visible()
+            {
+                orphan_hwnds.insert(window.hwnd, (*m_idx, *w_idx));
             }
         }
 
-        if update_borders {
-            border_manager::send_notification(None);
+        if !orphan_hwnds.is_empty() {
+            // Update reaper cache
+            cache.retain(|h, _| !orphan_hwnds.contains_key(h));
+
+            // Send handles to remove
+            event_tx().send(ReaperNotification(orphan_hwnds))?;
         }
     }
 }

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1208,7 +1208,7 @@ impl StaticConfig {
             pending_move_op: Arc::new(None),
             already_moved_window_handles: Arc::new(Mutex::new(HashSet::new())),
             uncloack_to_ignore: 0,
-            known_hwnds: Vec::new(),
+            known_hwnds: HashMap::new(),
         };
 
         match value.focus_follows_mouse {


### PR DESCRIPTION
This PR changes the way the reaper works.

First it changed the `known_hwnds` held by the `WindowManager` to be a HashMap of window handles (isize) to a pair of monitor_idx, workspace_idx (usize, usize).

Then it changes the reaper to have a cache of hwnds which is updated by the `WindowManager` when they change. The reaper has a thread that is continuously checking this cache to see if there is any window handle that no longer exists. When it finds them, the thread sends a notification to a channel which is then received by the reaper on another thread that actually does the work on the `WindowManager` by removing said windows.

This means that the reaper no longer tries to access and lock the `WindowManager` every second like it used to, but instead it only does it when it actually needs, when a window actually needs to be reaped. This means that we can make the thread that checks for orphan windows run much more frequently since it won't influence the rest of komorebi.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
