### PR TITLE
feat(wm): add padding per monitor

### DIFF
--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -48,6 +48,7 @@ pub use komorebi::ring::Ring;
 pub use komorebi::window::Window;
 pub use komorebi::window_manager_event::WindowManagerEvent;
 pub use komorebi::workspace::Workspace;
+pub use komorebi::workspace::WorkspaceGlobals;
 pub use komorebi::workspace::WorkspaceLayer;
 pub use komorebi::AnimationsConfig;
 pub use komorebi::AspectRatio;

--- a/komorebi/src/reaper.rs
+++ b/komorebi/src/reaper.rs
@@ -70,24 +70,12 @@ fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()>
     for notification in receiver {
         let orphan_hwnds = notification.0;
         let mut wm = wm.lock();
-        let offset = wm.work_area_offset;
 
         let mut update_borders = false;
 
         for (hwnd, (m_idx, w_idx)) in orphan_hwnds.iter() {
             if let Some(monitor) = wm.monitors_mut().get_mut(*m_idx) {
                 let focused_workspace_idx = monitor.focused_workspace_idx();
-                let work_area = *monitor.work_area_size();
-                let window_based_work_area_offset = (
-                    monitor.window_based_work_area_offset_limit(),
-                    monitor.window_based_work_area_offset(),
-                );
-
-                let offset = if monitor.work_area_offset().is_some() {
-                    monitor.work_area_offset()
-                } else {
-                    offset
-                };
 
                 if let Some(workspace) = monitor.workspaces_mut().get_mut(*w_idx) {
                     // Remove orphan window
@@ -105,7 +93,7 @@ fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()>
                         // If this is not a focused workspace there is no need to update the
                         // workspace or the borders. That will already be done when the user
                         // changes to this workspace.
-                        workspace.update(&work_area, offset, window_based_work_area_offset)?;
+                        workspace.update()?;
                         update_borders = true;
                     }
                     tracing::info!(

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -140,7 +140,7 @@ pub struct WorkspaceConfig {
     /// Container padding (default: global)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_padding: Option<i32>,
-    /// Container padding (default: global)
+    /// Workspace padding (default: global)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_padding: Option<i32>,
     /// Initial workspace application rules
@@ -259,7 +259,7 @@ pub struct MonitorConfig {
     /// Container padding (default: global)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container_padding: Option<i32>,
-    /// Container padding (default: global)
+    /// Workspace padding (default: global)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_padding: Option<i32>,
 }

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -256,6 +256,12 @@ pub struct MonitorConfig {
     /// Open window limit after which the window based work area offset will no longer be applied (default: 1)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub window_based_work_area_offset_limit: Option<isize>,
+    /// Container padding (default: global)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_padding: Option<i32>,
+    /// Container padding (default: global)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_padding: Option<i32>,
 }
 
 impl From<&Monitor> for MonitorConfig {
@@ -265,11 +271,32 @@ impl From<&Monitor> for MonitorConfig {
             workspaces.push(WorkspaceConfig::from(w));
         }
 
+        let default_container_padding = DEFAULT_CONTAINER_PADDING.load(Ordering::SeqCst);
+        let default_workspace_padding = DEFAULT_WORKSPACE_PADDING.load(Ordering::SeqCst);
+
+        let container_padding = value.container_padding().and_then(|container_padding| {
+            if container_padding == default_container_padding {
+                None
+            } else {
+                Option::from(container_padding)
+            }
+        });
+
+        let workspace_padding = value.workspace_padding().and_then(|workspace_padding| {
+            if workspace_padding == default_workspace_padding {
+                None
+            } else {
+                Option::from(workspace_padding)
+            }
+        });
+
         Self {
             workspaces,
             work_area_offset: value.work_area_offset(),
             window_based_work_area_offset: value.window_based_work_area_offset(),
             window_based_work_area_offset_limit: Some(value.window_based_work_area_offset_limit()),
+            container_padding,
+            workspace_padding,
         }
     }
 }
@@ -1250,6 +1277,7 @@ impl StaticConfig {
         workspace_matching_rules.clear();
         drop(workspace_matching_rules);
 
+        let offset = wm.work_area_offset;
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
                 let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
@@ -1295,7 +1323,10 @@ impl StaticConfig {
                         .window_based_work_area_offset_limit
                         .unwrap_or(1),
                 );
+                monitor.set_container_padding(monitor_config.container_padding);
+                monitor.set_workspace_padding(monitor_config.workspace_padding);
 
+                monitor.update_workspaces_globals(offset);
                 for (j, ws) in monitor.workspaces_mut().iter_mut().enumerate() {
                     if let Some(workspace_config) = monitor_config.workspaces.get(j) {
                         ws.load_static_config(workspace_config)?;
@@ -1377,6 +1408,10 @@ impl StaticConfig {
                             .window_based_work_area_offset_limit
                             .unwrap_or(1),
                     );
+                    m.set_container_padding(monitor_config.container_padding);
+                    m.set_workspace_padding(monitor_config.workspace_padding);
+
+                    m.update_workspaces_globals(offset);
 
                     for (j, ws) in m.workspaces_mut().iter_mut().enumerate() {
                         if let Some(workspace_config) = monitor_config.workspaces.get(j) {
@@ -1411,6 +1446,7 @@ impl StaticConfig {
         workspace_matching_rules.clear();
         drop(workspace_matching_rules);
 
+        let offset = wm.work_area_offset;
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
                 let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
@@ -1458,6 +1494,10 @@ impl StaticConfig {
                         .window_based_work_area_offset_limit
                         .unwrap_or(1),
                 );
+                monitor.set_container_padding(monitor_config.container_padding);
+                monitor.set_workspace_padding(monitor_config.workspace_padding);
+
+                monitor.update_workspaces_globals(offset);
 
                 for (j, ws) in monitor.workspaces_mut().iter_mut().enumerate() {
                     if let Some(workspace_config) = monitor_config.workspaces.get(j) {
@@ -1540,6 +1580,10 @@ impl StaticConfig {
                             .window_based_work_area_offset_limit
                             .unwrap_or(1),
                     );
+                    m.set_container_padding(monitor_config.container_padding);
+                    m.set_workspace_padding(monitor_config.workspace_padding);
+
+                    m.update_workspaces_globals(offset);
 
                     for (j, ws) in m.workspaces_mut().iter_mut().enumerate() {
                         if let Some(workspace_config) = monitor_config.workspaces.get(j) {

--- a/schema.json
+++ b/schema.json
@@ -1075,6 +1075,11 @@
           "workspaces"
         ],
         "properties": {
+          "container_padding": {
+            "description": "Container padding (default: global)",
+            "type": "integer",
+            "format": "int32"
+          },
           "window_based_work_area_offset": {
             "description": "Window based work area offset (default: None)",
             "type": "object",
@@ -1143,6 +1148,11 @@
                 "format": "int32"
               }
             }
+          },
+          "workspace_padding": {
+            "description": "Workspace padding (default: global)",
+            "type": "integer",
+            "format": "int32"
           },
           "workspaces": {
             "description": "Workspace configurations",
@@ -1346,7 +1356,7 @@
                   }
                 },
                 "workspace_padding": {
-                  "description": "Container padding (default: global)",
+                  "description": "Workspace padding (default: global)",
                   "type": "integer",
                   "format": "int32"
                 },


### PR DESCRIPTION
This commit adds the ability to set a container and workspace padding per monitor. To do so and to simplify any future need of changing some value per monitor and have it pass through to each workspace a new field was added to the `Workspace` called `globals` which has a new struct called `WorkspaceGlobals` which includes any global values that might be needed by the workspace.

This field is updated by the monitor for all its workspaces whenever the config is loaded or reloaded. It is also updated on `RetileAll` and on the function `update_focused_workspace`. This should make sure that every time a workspace needs to use it's `update` function it has all the `globals` up to date!

This also means that now the `update` function from workspaces doesn't take any argument at all, reducing all the need to get all the `work_area`, `work_area_offset`, `window_based_work_area_offset` or `window_based_work_area_offset_limit` simplifying the callers of this function quite a bit.

Lastly this commit has also (sort of accidentaly) fixed an existing bug with the `move_workspace_to_monitor` function which was removing the workspace from a monitor but wasn't changing it's `focused_workspace_idx` meaning that komorebi would get all messed up after that command, like the `border_manager` would get stuck and the komorebi-bar would crash. Now the `remove_focused_workspace` function also focus the previous workspace (which in turn will create a new workspace in case the removed one was the last workspace).

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
