### PR TITLE
fix(wm): take layer into account on ws restore

### DIFF
--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -303,7 +303,7 @@ impl Workspace {
         // Maximised windows and floating windows should always be drawn at the top of the Z order
         // when switching to a workspace
         if let Some(window) = to_focus {
-            if self.maximized_window().is_none() && self.floating_windows().is_empty() {
+            if self.maximized_window().is_none() && matches!(self.layer, WorkspaceLayer::Tiling) {
                 window.focus(mouse_follows_focus)?;
             } else if let Some(maximized_window) = self.maximized_window() {
                 maximized_window.focus(mouse_follows_focus)?;


### PR DESCRIPTION
Previously if a workspace had any floating windows it would always focus the first one when restoring. Now it only focus the floating window if the workspace layer is `Floating`.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
