### PR TITLE
fix(wm): hide/restore floating windows on monocle toggle

### DIFF
--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -2845,6 +2845,10 @@ impl WindowManager {
             container.hide(None);
         }
 
+        for window in workspace.floating_windows_mut() {
+            window.hide();
+        }
+
         Ok(())
     }
 
@@ -2856,6 +2860,10 @@ impl WindowManager {
 
         for container in workspace.containers_mut() {
             container.restore();
+        }
+
+        for window in workspace.floating_windows_mut() {
+            window.restore();
         }
 
         workspace.reintegrate_monocle_container()


### PR DESCRIPTION
When toggling monocle mode it hides all the other containers but it wasn't hiding the floating windows. Now it hides and restores them as well.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
