### PR TITLE
feat(bar): added option to show all icons on the komorebi workspace

### DIFF
--- a/komorebi-bar/src/config.rs
+++ b/komorebi-bar/src/config.rs
@@ -125,6 +125,15 @@ impl KomobarConfig {
             }
         }
     }
+
+    pub fn show_all_icons_on_komorebi_workspace(widgets: &[WidgetConfig]) -> bool {
+        widgets
+            .iter()
+            .any(|w| matches!(w, WidgetConfig::Komorebi(config) if config.workspaces.is_some_and(|w| w.enable && w.display.is_some_and(|s| matches!(s,
+            WorkspacesDisplayFormat::AllIcons
+            | WorkspacesDisplayFormat::AllIconsAndText
+            | WorkspacesDisplayFormat::AllIconsAndTextOnSelected)))))
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/komorebi-bar/src/render.rs
+++ b/komorebi-bar/src/render.rs
@@ -54,6 +54,8 @@ pub struct RenderConfig {
     pub text_font_id: FontId,
     /// FontId for icon (based on scaling the text font id)
     pub icon_font_id: FontId,
+    /// Show all icons on the workspace section of the Komorebi widget
+    pub show_all_icons: bool,
 }
 
 pub trait RenderExt {
@@ -87,6 +89,15 @@ impl RenderExt for &KomobarConfig {
             MonitorConfigOrIndex::Index(idx) => *idx,
         };
 
+        // check if any of the alignments have a komorebi widget with the workspace set to show all icons
+        let show_all_icons =
+            KomobarConfig::show_all_icons_on_komorebi_workspace(&self.left_widgets)
+                || self
+                    .center_widgets
+                    .as_ref()
+                    .is_some_and(|list| KomobarConfig::show_all_icons_on_komorebi_workspace(list))
+                || KomobarConfig::show_all_icons_on_komorebi_workspace(&self.right_widgets);
+
         RenderConfig {
             monitor_idx,
             spacing: self.widget_spacing.unwrap_or(10.0),
@@ -97,6 +108,7 @@ impl RenderExt for &KomobarConfig {
             applied_on_widget: false,
             text_font_id,
             icon_font_id,
+            show_all_icons,
         }
     }
 }
@@ -121,6 +133,7 @@ impl RenderConfig {
             applied_on_widget: false,
             text_font_id: FontId::default(),
             icon_font_id: FontId::default(),
+            show_all_icons: false,
         }
     }
 

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -529,39 +529,73 @@
                         "description": "Display format of the workspace",
                         "oneOf": [
                           {
-                            "description": "Show only icon",
+                            "description": "Show all icons only",
                             "type": "string",
                             "enum": [
-                              "Icon"
+                              "AllIcons"
                             ]
                           },
                           {
-                            "description": "Show only text",
+                            "description": "Show both all icons and text",
                             "type": "string",
                             "enum": [
-                              "Text"
+                              "AllIconsAndText"
                             ]
                           },
                           {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "description": "Show all icons and text for the selected element, and all icons on the rest",
                             "type": "string",
                             "enum": [
-                              "TextAndIconOnSelected"
+                              "AllIconsAndTextOnSelected"
                             ]
                           },
                           {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
+                            "type": "object",
+                            "required": [
+                              "Existing"
+                            ],
+                            "properties": {
+                              "Existing": {
+                                "oneOf": [
+                                  {
+                                    "description": "Show only icon",
+                                    "type": "string",
+                                    "enum": [
+                                      "Icon"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show only text",
+                                    "type": "string",
+                                    "enum": [
+                                      "Text"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and text on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "TextAndIconOnSelected"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show both icon and text",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndText"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and icons on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndTextOnSelected"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
                           }
                         ]
                       },
@@ -1849,39 +1883,73 @@
                         "description": "Display format of the workspace",
                         "oneOf": [
                           {
-                            "description": "Show only icon",
+                            "description": "Show all icons only",
                             "type": "string",
                             "enum": [
-                              "Icon"
+                              "AllIcons"
                             ]
                           },
                           {
-                            "description": "Show only text",
+                            "description": "Show both all icons and text",
                             "type": "string",
                             "enum": [
-                              "Text"
+                              "AllIconsAndText"
                             ]
                           },
                           {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "description": "Show all icons and text for the selected element, and all icons on the rest",
                             "type": "string",
                             "enum": [
-                              "TextAndIconOnSelected"
+                              "AllIconsAndTextOnSelected"
                             ]
                           },
                           {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
+                            "type": "object",
+                            "required": [
+                              "Existing"
+                            ],
+                            "properties": {
+                              "Existing": {
+                                "oneOf": [
+                                  {
+                                    "description": "Show only icon",
+                                    "type": "string",
+                                    "enum": [
+                                      "Icon"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show only text",
+                                    "type": "string",
+                                    "enum": [
+                                      "Text"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and text on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "TextAndIconOnSelected"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show both icon and text",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndText"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and icons on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndTextOnSelected"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
                           }
                         ]
                       },
@@ -3102,39 +3170,73 @@
                         "description": "Display format of the workspace",
                         "oneOf": [
                           {
-                            "description": "Show only icon",
+                            "description": "Show all icons only",
                             "type": "string",
                             "enum": [
-                              "Icon"
+                              "AllIcons"
                             ]
                           },
                           {
-                            "description": "Show only text",
+                            "description": "Show both all icons and text",
                             "type": "string",
                             "enum": [
-                              "Text"
+                              "AllIconsAndText"
                             ]
                           },
                           {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "description": "Show all icons and text for the selected element, and all icons on the rest",
                             "type": "string",
                             "enum": [
-                              "TextAndIconOnSelected"
+                              "AllIconsAndTextOnSelected"
                             ]
                           },
                           {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
+                            "type": "object",
+                            "required": [
+                              "Existing"
+                            ],
+                            "properties": {
+                              "Existing": {
+                                "oneOf": [
+                                  {
+                                    "description": "Show only icon",
+                                    "type": "string",
+                                    "enum": [
+                                      "Icon"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show only text",
+                                    "type": "string",
+                                    "enum": [
+                                      "Text"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and text on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "TextAndIconOnSelected"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show both icon and text",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndText"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and icons on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndTextOnSelected"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
                           }
                         ]
                       },


### PR DESCRIPTION
Fixes #1013

Added a new option to show all the icons on the komorebi workspace widget. 
In order to distinguish between focused and non-focused windows, the icon(s) of focused window(s) on a workspace are scaled, while the non-focused icons are text sized.

https://github.com/user-attachments/assets/e5647e93-db69-4d6a-8915-1a2e0cebe8d6

---

I am open to change the name of the setting or even consider always loading all the icons from the state, instead of checking the config in the render.rs.

My idea was to optimize for performance, so the icons would only be loaded for all the containers if needed. If it gives little to no advantage, the code would be cleaner when all the icons are loaded regardless of the setting.

Please let me know what you prefer
