### PR TITLE
Fix reaper deadlock

### DIFF
--- a/komorebi/src/reaper.rs
+++ b/komorebi/src/reaper.rs
@@ -47,8 +47,11 @@ pub fn send_notification(hwnds: HashMap<isize, (usize, usize)>) {
     }
 }
 
-pub fn listen_for_notifications(wm: Arc<Mutex<WindowManager>>) {
-    watch_for_orphans(wm.clone());
+pub fn listen_for_notifications(
+    wm: Arc<Mutex<WindowManager>>,
+    known_hwnds: HashMap<isize, (usize, usize)>,
+) {
+    watch_for_orphans(known_hwnds);
 
     std::thread::spawn(move || loop {
         match handle_notifications(wm.clone()) {
@@ -138,11 +141,11 @@ fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()>
     Ok(())
 }
 
-fn watch_for_orphans(wm: Arc<Mutex<WindowManager>>) {
+fn watch_for_orphans(known_hwnds: HashMap<isize, (usize, usize)>) {
     // Cache current hwnds
     {
         let mut cache = HWNDS_CACHE.lock();
-        *cache = wm.lock().known_hwnds.clone();
+        *cache = known_hwnds;
     }
 
     std::thread::spawn(move || loop {


### PR DESCRIPTION
Previously the reaper at startup would lock it's own `HWNDS_CACHE` and then try to lock the WM to get its `known_hwnds`, however if there was an event in the mean time, the process_event would lock the WM first and then it would try to lock the reaper's `HWNDS_CACHE` to update it but it would deadlock since that would be locked by the reaper waiting for the WM to be released.
    
This PR now makes it so we pass the `known_hwnds` to the reaper as an argument at startup and it also rearranges the order of loading the listeners. Now it first loads all the manager type listeners and only after it does it load the commands and events listeners. After some testing this seems to be the best order that doesn't cause any issues at all! There were some other issues that I've noticed before when starting komorebi while having other 3rd parties trying to subscribe to it (like komorebi-bar and YASB) which would make those subscribers lock the `process_command` thread. This doesn't seem to be happening on my tests anymore with this new order.
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
