### PR TITLE
feature: toggle layer moves all windows

### DIFF
--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -736,6 +736,30 @@ impl Window {
         self.update_style(&style)
     }
 
+    /// Raise the window to the top of the Z order, but do not activate or focus
+    /// it. Use raise_and_focus_window to activate and focus a window.
+    /// It also checks if there is a border attached to this window and if it is
+    /// it raises it as well.
+    pub fn raise(self) -> Result<()> {
+        WindowsApi::raise_window(self.hwnd)?;
+        if let Some(border) = crate::border_manager::window_border(self.hwnd) {
+            WindowsApi::raise_window(border.hwnd)?;
+        }
+        Ok(())
+    }
+
+    /// Lower the window to the bottom of the Z order, but do not activate or focus
+    /// it.
+    /// It also checks if there is a border attached to this window and if it is
+    /// it lowers it as well.
+    pub fn lower(self) -> Result<()> {
+        WindowsApi::lower_window(self.hwnd)?;
+        if let Some(border) = crate::border_manager::window_border(self.hwnd) {
+            WindowsApi::lower_window(border.hwnd)?;
+        }
+        Ok(())
+    }
+
     #[tracing::instrument(fields(exe, title), skip(debug))]
     pub fn should_manage(
         self,

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -109,6 +109,7 @@ use windows::Win32::UI::WindowsAndMessaging::GWL_EXSTYLE;
 use windows::Win32::UI::WindowsAndMessaging::GWL_STYLE;
 use windows::Win32::UI::WindowsAndMessaging::GW_HWNDNEXT;
 use windows::Win32::UI::WindowsAndMessaging::HDEVNOTIFY;
+use windows::Win32::UI::WindowsAndMessaging::HWND_BOTTOM;
 use windows::Win32::UI::WindowsAndMessaging::HWND_TOP;
 use windows::Win32::UI::WindowsAndMessaging::LWA_ALPHA;
 use windows::Win32::UI::WindowsAndMessaging::REGISTER_NOTIFICATION_FLAGS;
@@ -477,12 +478,32 @@ impl WindowsApi {
         unsafe { BringWindowToTop(HWND(as_ptr!(hwnd))) }.process()
     }
 
-    // Raise the window to the top of the Z order, but do not activate or focus
-    // it. Use raise_and_focus_window to activate and focus a window.
+    /// Raise the window to the top of the Z order, but do not activate or focus
+    /// it. Use raise_and_focus_window to activate and focus a window.
     pub fn raise_window(hwnd: isize) -> Result<()> {
-        let flags = SetWindowPosition::NO_MOVE | SetWindowPosition::NO_ACTIVATE;
+        let flags = SetWindowPosition::NO_MOVE
+            | SetWindowPosition::NO_SIZE
+            | SetWindowPosition::NO_ACTIVATE
+            | SetWindowPosition::SHOW_WINDOW;
 
         let position = HWND_TOP;
+        Self::set_window_pos(
+            HWND(as_ptr!(hwnd)),
+            &Rect::default(),
+            position,
+            flags.bits(),
+        )
+    }
+
+    /// Lower the window to the bottom of the Z order, but do not activate or focus
+    /// it.
+    pub fn lower_window(hwnd: isize) -> Result<()> {
+        let flags = SetWindowPosition::NO_MOVE
+            | SetWindowPosition::NO_SIZE
+            | SetWindowPosition::NO_ACTIVATE
+            | SetWindowPosition::SHOW_WINDOW;
+
+        let position = HWND_BOTTOM;
         Self::set_window_pos(
             HWND(as_ptr!(hwnd)),
             &Rect::default(),


### PR DESCRIPTION
This PR makes it so when you toggle between workspace layers it moves all windows of that layer to the top. So if you move to `Floating` layer, then all floating windows are moved to the top, if you go back to `Tiling` layer all containers are moved to the top.

It also includes one important bug fix, which stops an infinite loop of focus events when you focus a floating window. This bug fix is better explained on the first commit message.

~I wanted to make this PR a draft, but made it a normal PR and now I don't know how to change it to a draft...~ Scratch that I found the button 😅 

I wanted to test this behaviour since to me it makes more sense. What I want is for when you toggle the layer all the windows for that layer show up on top. I've tried to use the `WindowsApi::raise_window()` function instead of the `raise_and_focus_window()` but that wasn't working (it was moving to top only the window with focus). Also there is currently an issue with the borders that don't update properly.

@LGUG2Z  @CtByte When you guys have the chance try this out and tell me your thoughts about this behaviour, I myself like it and prefer it but others might not... Also if you can help out with the issue with the borders that would be great!

@LGUG2Z One last thing, that first commit with the bug fix on the `FocusChange` event should probably be cherry-picked into master though or if you prefer I can create a PR just for that...

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
