### PR TITLE
fix(bar): use accent color for active widget components

### DIFF
--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -19,6 +19,7 @@ use eframe::egui::Frame;
 use eframe::egui::Image;
 use eframe::egui::Label;
 use eframe::egui::Margin;
+use eframe::egui::RichText;
 use eframe::egui::Rounding;
 use eframe::egui::Sense;
 use eframe::egui::Stroke;
@@ -216,7 +217,7 @@ impl BarWidget for Komorebi {
                                         ui.allocate_painter(icon_size, Sense::hover());
                                     let stroke = Stroke::new(
                                         1.0,
-                                        ctx.style().visuals.selection.stroke.color,
+                                        if is_selected { ctx.style().visuals.selection.stroke.color} else { ui.style().visuals.text_color() },
                                     );
                                     let mut rect = response.rect;
                                     let rounding = Rounding::same(rect.width() * 0.1);
@@ -237,7 +238,12 @@ impl BarWidget for Komorebi {
                                 } else if (format != WorkspacesDisplayFormat::AllIconsAndTextOnSelected && format != DisplayFormat::IconAndTextOnSelected.into())
                                     || (is_selected && matches!(format, WorkspacesDisplayFormat::AllIconsAndTextOnSelected | WorkspacesDisplayFormat::Existing(DisplayFormat::IconAndTextOnSelected)))
                                 {
-                                    ui.add(Label::new(ws.to_string()).selectable(false))
+                                     if is_selected {
+                                        ui.add(Label::new(RichText::new(ws.to_string()).color(ctx.style().visuals.selection.stroke.color)).selectable(false))
+                                    }
+                                    else {
+                                        ui.add(Label::new(ws.to_string()).selectable(false))
+                                    }
                                 } else {
                                     ui.response()
                                 }
@@ -427,6 +433,7 @@ impl BarWidget for Komorebi {
 
                         for (i, (title, icon)) in iter.enumerate() {
                             let selected = i == focused_window_idx && len != 1;
+                            let text_color = if selected { ctx.style().visuals.selection.stroke.color} else { ui.style().visuals.text_color() };
 
                             if SelectableFrame::new(selected)
                                 .show(ui, |ui| {
@@ -478,7 +485,7 @@ impl BarWidget for Komorebi {
                                                 MAX_LABEL_WIDTH.load(Ordering::SeqCst) as f32,
                                                 available_height,
                                             ),
-                                            Label::new(title).selectable(false).truncate(),
+                                            Label::new(RichText::new( title).color(text_color)).selectable(false).truncate(),
                                         );
                                     }
                                 })

--- a/komorebi-bar/src/komorebi_layout.rs
+++ b/komorebi-bar/src/komorebi_layout.rs
@@ -122,11 +122,15 @@ impl KomorebiLayout {
         }
     }
 
-    fn show_icon(&mut self, font_id: FontId, ctx: &Context, ui: &mut Ui) {
+    fn show_icon(&mut self, is_selected: bool, font_id: FontId, ctx: &Context, ui: &mut Ui) {
         // paint custom icons for the layout
         let size = Vec2::splat(font_id.size);
         let (response, painter) = ui.allocate_painter(size, Sense::hover());
-        let color = ctx.style().visuals.selection.stroke.color;
+        let color = if is_selected {
+            ctx.style().visuals.selection.stroke.color
+        } else {
+            ui.style().visuals.text_color()
+        };
         let stroke = Stroke::new(1.0, color);
         let mut rect = response.rect;
         let rounding = Rounding::same(rect.width() * 0.1);
@@ -236,7 +240,7 @@ impl KomorebiLayout {
             let layout_frame = SelectableFrame::new(false)
                 .show(ui, |ui| {
                     if let DisplayFormat::Icon | DisplayFormat::IconAndText = format {
-                        self.show_icon(font_id.clone(), ctx, ui);
+                        self.show_icon(false, font_id.clone(), ctx, ui);
                     }
 
                     if let DisplayFormat::Text | DisplayFormat::IconAndText = format {
@@ -279,8 +283,12 @@ impl KomorebiLayout {
                         ]);
 
                         for layout_option in &mut layout_options {
-                            if SelectableFrame::new(self == layout_option)
-                                .show(ui, |ui| layout_option.show_icon(font_id.clone(), ctx, ui))
+                            let is_selected = self == layout_option;
+
+                            if SelectableFrame::new(is_selected)
+                                .show(ui, |ui| {
+                                    layout_option.show_icon(is_selected, font_id.clone(), ctx, ui)
+                                })
                                 .on_hover_text(match layout_option {
                                     KomorebiLayout::Default(layout) => layout.to_string(),
                                     KomorebiLayout::Monocle => "Toggle monocle".to_string(),


### PR DESCRIPTION
This commit makes sure that the accent color is used on certain bar components, such as active workspace, selected layout and focused window.

This will now make these components stand out even more for a better visual indication.

Fixes #1288


https://github.com/user-attachments/assets/50135377-510f-4fd7-8a10-d544de493534

```json
  "theme": {
    "palette": "Base16",
    "name": "AyuMirage",
    "accent": "Base0D"
  },
```
