### PR TITLE
Fix(borders): multiple borders fixes

### DIFF
--- a/komorebi/src/border_manager/border.rs
+++ b/komorebi/src/border_manager/border.rs
@@ -475,13 +475,11 @@ impl Border {
                             });
 
                             // Get window kind and color
-
                             (*border_pointer).window_kind = FOCUS_STATE
                                 .lock()
                                 .get(&(window.0 as isize))
                                 .copied()
                                 .unwrap_or(WindowKind::Unfocused);
-
                             let window_kind = (*border_pointer).window_kind;
                             if let Some(brush) = (*border_pointer).brushes.get(&window_kind) {
                                 render_target.BeginDraw();

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -736,6 +736,30 @@ impl Window {
         self.update_style(&style)
     }
 
+    /// Raise the window to the top of the Z order, but do not activate or focus
+    /// it. Use raise_and_focus_window to activate and focus a window.
+    /// It also checks if there is a border attached to this window and if it is
+    /// it raises it as well.
+    pub fn raise(self) -> Result<()> {
+        WindowsApi::raise_window(self.hwnd)?;
+        if let Some(border) = crate::border_manager::window_border(self.hwnd) {
+            WindowsApi::raise_window(border.hwnd)?;
+        }
+        Ok(())
+    }
+
+    /// Lower the window to the bottom of the Z order, but do not activate or focus
+    /// it.
+    /// It also checks if there is a border attached to this window and if it is
+    /// it lowers it as well.
+    pub fn lower(self) -> Result<()> {
+        WindowsApi::lower_window(self.hwnd)?;
+        if let Some(border) = crate::border_manager::window_border(self.hwnd) {
+            WindowsApi::lower_window(border.hwnd)?;
+        }
+        Ok(())
+    }
+
     #[tracing::instrument(fields(exe, title), skip(debug))]
     pub fn should_manage(
         self,

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -109,6 +109,7 @@ use windows::Win32::UI::WindowsAndMessaging::GWL_EXSTYLE;
 use windows::Win32::UI::WindowsAndMessaging::GWL_STYLE;
 use windows::Win32::UI::WindowsAndMessaging::GW_HWNDNEXT;
 use windows::Win32::UI::WindowsAndMessaging::HDEVNOTIFY;
+use windows::Win32::UI::WindowsAndMessaging::HWND_BOTTOM;
 use windows::Win32::UI::WindowsAndMessaging::HWND_TOP;
 use windows::Win32::UI::WindowsAndMessaging::LWA_ALPHA;
 use windows::Win32::UI::WindowsAndMessaging::REGISTER_NOTIFICATION_FLAGS;
@@ -477,12 +478,32 @@ impl WindowsApi {
         unsafe { BringWindowToTop(HWND(as_ptr!(hwnd))) }.process()
     }
 
-    // Raise the window to the top of the Z order, but do not activate or focus
-    // it. Use raise_and_focus_window to activate and focus a window.
+    /// Raise the window to the top of the Z order, but do not activate or focus
+    /// it. Use raise_and_focus_window to activate and focus a window.
     pub fn raise_window(hwnd: isize) -> Result<()> {
-        let flags = SetWindowPosition::NO_MOVE | SetWindowPosition::NO_ACTIVATE;
+        let flags = SetWindowPosition::NO_MOVE
+            | SetWindowPosition::NO_SIZE
+            | SetWindowPosition::NO_ACTIVATE
+            | SetWindowPosition::SHOW_WINDOW;
 
         let position = HWND_TOP;
+        Self::set_window_pos(
+            HWND(as_ptr!(hwnd)),
+            &Rect::default(),
+            position,
+            flags.bits(),
+        )
+    }
+
+    /// Lower the window to the bottom of the Z order, but do not activate or focus
+    /// it.
+    pub fn lower_window(hwnd: isize) -> Result<()> {
+        let flags = SetWindowPosition::NO_MOVE
+            | SetWindowPosition::NO_SIZE
+            | SetWindowPosition::NO_ACTIVATE
+            | SetWindowPosition::SHOW_WINDOW;
+
+        let position = HWND_BOTTOM;
         Self::set_window_pos(
             HWND(as_ptr!(hwnd)),
             &Rect::default(),


### PR DESCRIPTION
This PR includes 3 commits:
- The first commit changes the `komorebic toggle-workspace-layer` command to move up/down all windows of the layer. So if you are on the `Tiling` layer and toggle the layer it will bring all floating windows to front so you can see them and cycle through them. Once you toggle again, the floating windows are sent back again.
- The second commit fixes a memory leak on the border manager. More information is provided on the commit message itself
- The third commit fixes an issue with the stacking of windows, which was causing issues with the borders. The fix also makes possible to stack windows on all directions. Previously if you had focus on a stack and tried to call `stack-window` on a direction with index higher than the current focus (usually right or down), it wouldn't work! Now it does.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
