### PR TITLE
feat(bar): add icons to workspace-layer widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4688,9 +4688,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.38.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec14cc798c29f4bf74a6c4299c657c04d4e9fba03875c1f0eec569af03aed89"
+checksum = "209d2a96c110f23f27b5944408d36027a2ce2c9159ca2efee3a7f333e548427e"
 dependencies = [
  "const_format",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5938,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "win32-display-data"
 version = "0.1.0"
-source = "git+https://github.com/LGUG2Z/win32-display-data?rev=376523b9e1321e033b0b0ed0e6fa75a072b46ad9#376523b9e1321e033b0b0ed0e6fa75a072b46ad9"
+source = "git+https://github.com/LGUG2Z/win32-display-data?rev=55cebdebfbd68dbd14945a1ba90f6b05b7be2893#55cebdebfbd68dbd14945a1ba90f6b05b7be2893"
 dependencies = [
  "itertools 0.14.0",
  "serde",
@@ -6001,16 +6001,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
-dependencies = [
- "windows-core 0.59.0",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
@@ -6063,19 +6053,6 @@ dependencies = [
  "windows-result 0.2.0",
  "windows-strings 0.1.0",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface 0.59.0",
- "windows-result 0.3.1",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -6326,27 +6303,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -6368,12 +6329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6390,12 +6345,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6416,22 +6365,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6452,12 +6389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6474,12 +6405,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6500,12 +6425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6522,12 +6441,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winit"
@@ -6626,17 +6539,17 @@ dependencies = [
 
 [[package]]
 name = "wmi"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58078b4e28f04064dae68f6e11a6b93133c83b88dfd5ae16738ded4942db6544"
+checksum = "ae33d16f05f9b4b819abe7a9472bad4acb17f5b5d52d3f422762ebec613c65a6"
 dependencies = [
  "chrono",
  "futures",
  "log",
  "serde",
  "thiserror 2.0.11",
- "windows 0.59.0",
- "windows-core 0.59.0",
+ "windows 0.60.0",
+ "windows-core 0.60.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,11 +285,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
 dependencies = [
  "clipboard-win",
+ "core-graphics 0.23.2",
+ "image",
  "log",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "parking_lot",
+ "windows-sys 0.48.0",
  "x11rb",
 ]
 
@@ -553,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e335041290c43101ca215eed6f43ec437eb5a42125573f600fc3fa42b9bddd62"
+checksum = "98922d6a4cfbcb08820c69d8eeccc05bb1f29bfa06b4f5b1dbfe9a868bd7608e"
 dependencies = [
  "arrayvec",
 ]
@@ -587,13 +590,13 @@ dependencies = [
 [[package]]
 name = "base16-egui-themes"
 version = "0.1.0"
-source = "git+https://github.com/LGUG2Z/base16-egui-themes?rev=911079d#911079d1ee7d60bbebf1f8e05d0e5a6bc596ad79"
+source = "git+https://github.com/LGUG2Z/base16-egui-themes?rev=96f26c88d83781f234d42222293ec73d23a39ad8#96f26c88d83781f234d42222293ec73d23a39ad8"
 dependencies = [
  "egui",
  "schemars",
  "serde",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -781,7 +784,7 @@ dependencies = [
 [[package]]
 name = "catppuccin-egui"
 version = "5.3.1"
-source = "git+https://github.com/LGUG2Z/catppuccin-egui?rev=f85cc3c#f85cc3ce187bab308bec7d50ca974d66578a5590"
+source = "git+https://github.com/LGUG2Z/catppuccin-egui?rev=bdaff30959512c4f7ee7304117076a48633d777f#bdaff30959512c4f7ee7304117076a48633d777f"
 dependencies = [
  "egui",
 ]
@@ -827,12 +830,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -848,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -858,14 +855,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -873,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -987,12 +984,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
 
 [[package]]
 name = "const_format"
@@ -1285,9 +1276,9 @@ checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "ecolor"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d72e9c39f6e11a2e922d04a34ec5e7ef522ea3f5a1acfca7a19d16ad5fe50f5"
+checksum = "878e9005799dd739e5d5d89ff7480491c12d0af571d44399bcaefa1ee172dd76"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1295,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f2d9e7ea2d11ec9e98a8683b6eb99f9d7d0448394ef6e0d6d91bd4eb817220"
+checksum = "eba4c50d905804fe9ec4e159fde06b9d38f9440228617ab64a03d7a2091ece63"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1306,7 +1297,7 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow 0.16.0",
+ "glow",
  "glutin",
  "glutin-winit",
  "image",
@@ -1331,12 +1322,13 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252d52224d35be1535d7fd1d6139ce071fb42c9097773e79f7665604f5596b5e"
+checksum = "7d2768eaa6d5c80a6e2a008da1f0e062dff3c83eb2b28605ea2d0732d46e74d6"
 dependencies = [
  "accesskit",
  "ahash",
+ "bitflags 2.8.0",
  "emath",
  "epaint",
  "log",
@@ -1346,18 +1338,18 @@ dependencies = [
 
 [[package]]
 name = "egui-phosphor"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe75c81cd796bfb6718df8a5339c47695bfb33e400fae03a77200305519f2c2"
+checksum = "171d57331491e92f0a7c73fad1088716e3200984309f4f8684731b750cee1378"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c1e821d2d8921ef6ce98b258c7e24d9d6aab2ca1f9cdf374eca997e7f67f59"
+checksum = "6d8151704bcef6271bec1806c51544d70e79ef20e8616e5eac01facfd9c8c54a"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1375,13 +1367,14 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e84c2919cd9f3a38a91e8f84ac6a245c19251fd95226ed9fae61d5ea564fce3"
+checksum = "ace791b367c1f63e6044aef2f3834904509d1d1a6912fd23ebf3f6a9af92cd84"
 dependencies = [
  "accesskit_winit",
  "ahash",
  "arboard",
+ "bytemuck",
  "egui",
  "log",
  "profiling",
@@ -1394,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7a8198c088b1007108cb2d403bc99a5e370999b200db4f14559610d7330126"
+checksum = "b5b5cf69510eb3d19211fc0c062fb90524f43fe8e2c012967dcf0e2d81cb040f"
 dependencies = [
  "ahash",
  "egui",
@@ -1408,14 +1401,14 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf6264cc7608e3e69a7d57a6175f438275f1b3889c1a551b418277721c95e6"
+checksum = "9a53e2374a964c3c793cb0b8ead81bca631f24974bc0b747d1a5622f4e39fdd0"
 dependencies = [
  "ahash",
  "bytemuck",
  "egui",
- "glow 0.16.0",
+ "glow",
  "log",
  "memoffset",
  "profiling",
@@ -1426,15 +1419,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "emath"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe73c1207b864ee40aa0b0c038d6092af1030744678c60188a05c28553515d"
+checksum = "55b7b6be5ad1d247f11738b0e4699d9c20005ed366f2c29f5ec1f8e1de180bc2"
 dependencies = [
  "bytemuck",
 ]
@@ -1504,9 +1497,9 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "epaint"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5666f8d25236293c966fbb3635eac18b04ad1914e3bab55bc7d44b9980cafcac"
+checksum = "275b665a7b9611d8317485187e5458750850f9e64604d3c58434bb3fc1d22915"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1522,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f6ddac3e6ac6fd4c3d48bb8b1943472f8da0f43a4303bcd8a18aa594401c80"
+checksum = "9343d356d7cac894dacafc161b4654e0881301097bdf32a122ed503d97cb94b6"
 
 [[package]]
 name = "equivalent"
@@ -1648,9 +1641,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.5",
@@ -1908,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded738faa0e88d3abc9d1a13cb11adc2073c400969eeb8793cf7132589959fc"
+checksum = "f3586f256131df87204eb733da72e3d3eb4f343c639f4b7be279ac7c48baeafe"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1960,18 +1953,6 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
@@ -1989,7 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03642b8b0cce622392deb0ee3e88511f75df2daac806102597905c3ea1974848"
 dependencies = [
  "bitflags 2.8.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "cgl",
  "core-foundation 0.9.4",
  "dispatch",
@@ -2013,7 +1994,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "glutin",
  "raw-window-handle",
  "winit",
@@ -2691,7 +2672,7 @@ dependencies = [
  "serde_json_lenient",
  "serde_yaml",
  "shadow-rs",
- "strum",
+ "strum 0.27.1",
  "sysinfo",
  "tracing",
  "tracing-appender",
@@ -2775,7 +2756,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_variant",
- "strum",
+ "strum 0.27.1",
 ]
 
 [[package]]
@@ -2848,9 +2829,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2915,9 +2896,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litrs"
@@ -3013,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
  "bitflags 2.8.0",
  "block",
@@ -3036,7 +3017,7 @@ dependencies = [
  "backtrace-ext",
  "cfg-if 1.0.0",
  "miette-derive",
- "owo-colors 4.1.0",
+ "owo-colors 4.2.0",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
@@ -3132,22 +3113,23 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "23.1.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.8.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
  "log",
  "rustc-hash",
  "spirv",
+ "strum 0.26.3",
  "termcolor",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "unicode-xid",
 ]
 
@@ -3307,7 +3289,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if 1.0.0",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -3792,6 +3774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,9 +3826,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "owo-colors"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "parking"
@@ -4367,9 +4358,9 @@ checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "ring"
-version = "0.17.10"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34b5020fcdea098ef7d95e9f89ec15952123a4a039badd09fabebe9e963e839"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
@@ -4475,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -4487,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4688,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209d2a96c110f23f27b5944408d36027a2ce2c9159ca2efee3a7f333e548427e"
+checksum = "3672eb035a31ac62bf171765d04e3f1f01659920847384d08ac979ca6bb56763"
 dependencies = [
  "const_format",
  "git2",
@@ -4874,7 +4865,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -4882,6 +4882,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5405,18 +5418,15 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "tz-rs"
-version = "0.6.14"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
+checksum = "e1450bf2b99397e72070e7935c89facaa80092ac812502200375f1f7d33c71a1"
 
 [[package]]
 name = "tzdb"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
+checksum = "0be2ea5956f295449f47c0b825c5e109022ff1a6a53bb4f77682a87c2341fbf5"
 dependencies = [
  "iana-time-zone",
  "tz-rs",
@@ -5425,9 +5435,9 @@ dependencies = [
 
 [[package]]
 name = "tzdb_data"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4471adcfcbd3052e8c5b5890a04a559837444b3be26b9cbbd622063171cec9d"
+checksum = "0604b35c1f390a774fdb138cac75a99981078895d24bcab175987440bbff803b"
 dependencies = [
  "tz-rs",
 ]
@@ -5825,12 +5835,13 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "23.0.1"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f70000db37c469ea9d67defdc13024ddf9a5f1b89cb2941b812ad7cde1735a"
+checksum = "47f55718f85c2fa756edffa0e7f0e0a60aba463d1362b57e23123c58f035e4b6"
 dependencies = [
  "arrayvec",
- "cfg_aliases 0.1.1",
+ "bitflags 2.8.0",
+ "cfg_aliases",
  "document-features",
  "js-sys",
  "log",
@@ -5849,14 +5860,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "23.0.1"
+version = "24.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
+checksum = "671c25545d479b47d3f0a8e373aceb2060b67c6eb841b24ac8c32348151c7a0c"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.8.0",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "document-features",
  "indexmap",
  "log",
@@ -5867,25 +5878,25 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "23.0.1"
+version = "24.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89364b8a0b211adc7b16aeaf1bd5ad4a919c1154b44c9ce27838213ba05fd821"
+checksum = "4317a17171dc20e6577bf606796794580accae0716a69edbc7388c86a3ec9f23"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bitflags 2.8.0",
  "bytemuck",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "core-graphics-types",
- "glow 0.14.2",
+ "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-descriptor",
@@ -5899,13 +5910,14 @@ dependencies = [
  "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
+ "ordered-float",
  "parking_lot",
  "profiling",
  "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -5914,12 +5926,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f6ff27778148c31093f3b03abc4840f9636d58d597ca2f5977433acfe0068"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
 dependencies = [
  "bitflags 2.8.0",
  "js-sys",
+ "log",
  "web-sys",
 ]
 
@@ -6455,7 +6468,7 @@ dependencies = [
  "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
@@ -6783,18 +6796,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 paste = "1"
 sysinfo = "0.33"
 uds_windows = "1"
-win32-display-data = { git = "https://github.com/LGUG2Z/win32-display-data", rev = "376523b9e1321e033b0b0ed0e6fa75a072b46ad9" }
+win32-display-data = { git = "https://github.com/LGUG2Z/win32-display-data", rev = "55cebdebfbd68dbd14945a1ba90f6b05b7be2893" }
 windows-numerics = { version = "0.1" }
 windows-implement = { version = "0.59" }
 windows-interface = { version = "0.59" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ windows-numerics = { version = "0.1" }
 windows-implement = { version = "0.59" }
 windows-interface = { version = "0.59" }
 windows-core = { version = "0.60" }
-shadow-rs = "0.38"
+shadow-rs = "1"
 which = "7"
 
 [workspace.dependencies.windows]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ chrono = "0.4"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"
 color-eyre = "0.6"
-eframe = "0.30"
-egui_extras = "0.30"
+eframe = "0.31"
+egui_extras = "0.31"
 dirs = "6"
 dunce = "1"
 hotwatch = "0.5"
@@ -27,6 +27,7 @@ lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { package = "serde_json_lenient", version = "0.2" }
 serde_yaml = "0.9"
+strum = { version = "0.27", features = ["derive"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,16 @@ features = [
     "Media",
     "Media_Control"
 ]
+
+[profile.dev-jeezy]
+inherits = "dev"
+debug = false
+opt-level = 1
+
+[profile.dev-jeezy.package."*"]
+opt-level = 3
+
+[profile.release-jeezy]
+inherits = "release"
+incremental = true
+codegen-units = 256

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Tiling Window Management for Windows.
     <img alt="Tech for Palestine" src="https://badge.techforpalestine.org/default">
   </a>
   <img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/LGUG2Z/komorebi/.github/workflows/windows.yaml">
-  <img alt="GitHub" src="https://img.shields.io/github/license/LGUG2Z/komorebi">
   <img alt="GitHub all releases" src="https://img.shields.io/github/downloads/LGUG2Z/komorebi/total">
   <img alt="GitHub commits since latest release (by date) for a branch" src="https://img.shields.io/github/commits-since/LGUG2Z/komorebi/latest">
+  <img alt="Active Individual Commercial Use Licenses" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Flgug2z-ecstaticmagentacheetah.web.val.run&query=%24.&label=active%20individual%20commercial%20use%20licenses&cacheSeconds=3600&link=https%3A%2F%2Flgug2z.com%2Fsoftware%2Fkomorebi">
   <a href="https://discord.gg/mGkn66PHkx">
     <img alt="Discord" src="https://img.shields.io/discord/898554690126630914">
   </a>

--- a/docs/cli/toggle-workspace-layer.md
+++ b/docs/cli/toggle-workspace-layer.md
@@ -1,0 +1,12 @@
+# toggle-workspace-layer
+
+```
+Toggle between the Tiling and Floating layers on the focused workspace
+
+Usage: komorebic.exe toggle-workspace-layer
+
+Options:
+  -h, --help
+          Print help
+
+```

--- a/justfile
+++ b/justfile
@@ -39,11 +39,14 @@ copy-target target:
 copy-targets *targets:
     "{{ targets }}" -split ' ' | ForEach-Object { just copy-target $_ }
 
+wpm target:
+    just build-target {{ target }} && wpmctl stop {{ target }}; just copy-target {{ target }} && wpmctl start {{ target }}
+
 copy:
     just copy-targets komorebic komorebic-no-console komorebi komorebi-bar komorebi-gui
 
 run target:
-    cargo +stable run --bin {{ target }} --locked --profile dev-jeezy
+    cargo +stable run --bin {{ target }} --locked
 
 warn target $RUST_LOG="warn":
     just run {{ target }}

--- a/justfile
+++ b/justfile
@@ -28,13 +28,22 @@ build-targets *targets:
     "{{ targets }}" -split ' ' | ForEach-Object { just build-target $_ }
 
 build-target target:
-    cargo +stable build --release --package {{ target }} --locked
+    cargo +stable build --package {{ target }} --locked --profile release-jeezy
 
 build:
     just build-targets komorebic komorebic-no-console komorebi komorebi-bar komorebi-gui
 
+copy-target target:
+    cp .\target\release-jeezy\{{ target }}.exe $Env:USERPROFILE\.cargo\bin
+
+copy-targets *targets:
+    "{{ targets }}" -split ' ' | ForEach-Object { just copy-target $_ }
+
+copy:
+    just copy-targets komorebic komorebic-no-console komorebi komorebi-bar komorebi-gui
+
 run target:
-    cargo +stable run --bin {{ target }} --locked
+    cargo +stable run --bin {{ target }} --locked --profile dev-jeezy
 
 warn target $RUST_LOG="warn":
     just run {{ target }}

--- a/komorebi-bar/Cargo.toml
+++ b/komorebi-bar/Cargo.toml
@@ -16,7 +16,7 @@ crossbeam-channel = { workspace = true }
 dirs = { workspace = true }
 dunce = { workspace = true }
 eframe = { workspace = true }
-egui-phosphor = "0.8"
+egui-phosphor = "0.9"
 font-loader = "0.11"
 hotwatch = { workspace = true }
 image = "0.25"

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -178,11 +178,11 @@ pub fn apply_theme(
     {
         if let Some(rounding) = config.rounding {
             ctx.style_mut(|style| {
-                style.visuals.widgets.noninteractive.rounding = rounding.into();
-                style.visuals.widgets.inactive.rounding = rounding.into();
-                style.visuals.widgets.hovered.rounding = rounding.into();
-                style.visuals.widgets.active.rounding = rounding.into();
-                style.visuals.widgets.open.rounding = rounding.into();
+                style.visuals.widgets.noninteractive.corner_radius = rounding.into();
+                style.visuals.widgets.inactive.corner_radius = rounding.into();
+                style.visuals.widgets.hovered.corner_radius = rounding.into();
+                style.visuals.widgets.active.corner_radius = rounding.into();
+                style.visuals.widgets.open.corner_radius = rounding.into();
             });
         }
     }
@@ -502,11 +502,12 @@ impl Komobar {
                         {
                             if let Some(rounding) = config.rounding {
                                 ctx.style_mut(|style| {
-                                    style.visuals.widgets.noninteractive.rounding = rounding.into();
-                                    style.visuals.widgets.inactive.rounding = rounding.into();
-                                    style.visuals.widgets.hovered.rounding = rounding.into();
-                                    style.visuals.widgets.active.rounding = rounding.into();
-                                    style.visuals.widgets.open.rounding = rounding.into();
+                                    style.visuals.widgets.noninteractive.corner_radius =
+                                        rounding.into();
+                                    style.visuals.widgets.inactive.corner_radius = rounding.into();
+                                    style.visuals.widgets.hovered.corner_radius = rounding.into();
+                                    style.visuals.widgets.active.corner_radius = rounding.into();
+                                    style.visuals.widgets.open.corner_radius = rounding.into();
                                 });
                             }
                         }
@@ -839,26 +840,26 @@ impl eframe::App for Komobar {
         let frame = match &self.config.padding {
             None => {
                 if let Some(frame) = &self.config.frame {
-                    Frame::none()
+                    Frame::NONE
                         .inner_margin(Margin::symmetric(
-                            frame.inner_margin.x,
-                            frame.inner_margin.y,
+                            frame.inner_margin.x as i8,
+                            frame.inner_margin.y as i8,
                         ))
                         .fill(*self.bg_color_with_alpha.borrow())
                 } else {
-                    Frame::none()
-                        .inner_margin(Margin::same(0.0))
+                    Frame::NONE
+                        .inner_margin(Margin::same(0))
                         .fill(*self.bg_color_with_alpha.borrow())
                 }
             }
             Some(padding) => {
                 let padding = padding.to_individual(DEFAULT_PADDING);
-                Frame::none()
+                Frame::NONE
                     .inner_margin(Margin {
-                        top: padding.top,
-                        bottom: padding.bottom,
-                        left: padding.left,
-                        right: padding.right,
+                        top: padding.top as i8,
+                        bottom: padding.bottom as i8,
+                        left: padding.left as i8,
+                        right: padding.right as i8,
                     })
                     .fill(*self.bg_color_with_alpha.borrow())
             }
@@ -871,13 +872,13 @@ impl eframe::App for Komobar {
         CentralPanel::default().frame(frame).show(ctx, |ui| {
             // Apply grouping logic for the bar as a whole
             let area_frame = if let Some(frame) = &self.config.frame {
-                Frame::none()
-                    .inner_margin(Margin::symmetric(0.0, frame.inner_margin.y))
-                    .outer_margin(Margin::same(0.0))
+                Frame::NONE
+                    .inner_margin(Margin::symmetric(0, frame.inner_margin.y as i8))
+                    .outer_margin(Margin::same(0))
             } else {
-                Frame::none()
-                    .inner_margin(Margin::same(0.0))
-                    .outer_margin(Margin::same(0.0))
+                Frame::NONE
+                    .inner_margin(Margin::same(0))
+                    .outer_margin(Margin::same(0))
             };
 
             let available_height = ui.max_rect().max.y;
@@ -897,13 +898,13 @@ impl eframe::App for Komobar {
                             .as_ref()
                             .map(|s| s.to_individual(DEFAULT_PADDING))
                         {
-                            left_area_frame.inner_margin.left = padding.left;
-                            left_area_frame.inner_margin.top = padding.top;
-                            left_area_frame.inner_margin.bottom = padding.bottom;
+                            left_area_frame.inner_margin.left = padding.left as i8;
+                            left_area_frame.inner_margin.top = padding.top as i8;
+                            left_area_frame.inner_margin.bottom = padding.bottom as i8;
                         } else if let Some(frame) = &self.config.frame {
-                            left_area_frame.inner_margin.left = frame.inner_margin.x;
-                            left_area_frame.inner_margin.top = frame.inner_margin.y;
-                            left_area_frame.inner_margin.bottom = frame.inner_margin.y;
+                            left_area_frame.inner_margin.left = frame.inner_margin.x as i8;
+                            left_area_frame.inner_margin.top = frame.inner_margin.y as i8;
+                            left_area_frame.inner_margin.bottom = frame.inner_margin.y as i8;
                         }
 
                         left_area_frame.show(ui, |ui| {
@@ -933,13 +934,13 @@ impl eframe::App for Komobar {
                             .as_ref()
                             .map(|s| s.to_individual(DEFAULT_PADDING))
                         {
-                            right_area_frame.inner_margin.right = padding.right;
-                            right_area_frame.inner_margin.top = padding.top;
-                            right_area_frame.inner_margin.bottom = padding.bottom;
+                            right_area_frame.inner_margin.right = padding.right as i8;
+                            right_area_frame.inner_margin.top = padding.top as i8;
+                            right_area_frame.inner_margin.bottom = padding.bottom as i8;
                         } else if let Some(frame) = &self.config.frame {
-                            right_area_frame.inner_margin.right = frame.inner_margin.x;
-                            right_area_frame.inner_margin.top = frame.inner_margin.y;
-                            right_area_frame.inner_margin.bottom = frame.inner_margin.y;
+                            right_area_frame.inner_margin.right = frame.inner_margin.x as i8;
+                            right_area_frame.inner_margin.top = frame.inner_margin.y as i8;
+                            right_area_frame.inner_margin.bottom = frame.inner_margin.y as i8;
                         }
 
                         right_area_frame.show(ui, |ui| {
@@ -977,11 +978,11 @@ impl eframe::App for Komobar {
                             .as_ref()
                             .map(|s| s.to_individual(DEFAULT_PADDING))
                         {
-                            center_area_frame.inner_margin.top = padding.top;
-                            center_area_frame.inner_margin.bottom = padding.bottom;
+                            center_area_frame.inner_margin.top = padding.top as i8;
+                            center_area_frame.inner_margin.bottom = padding.bottom as i8;
                         } else if let Some(frame) = &self.config.frame {
-                            center_area_frame.inner_margin.top = frame.inner_margin.y;
-                            center_area_frame.inner_margin.bottom = frame.inner_margin.y;
+                            center_area_frame.inner_margin.top = frame.inner_margin.y as i8;
+                            center_area_frame.inner_margin.bottom = frame.inner_margin.y as i8;
                         }
 
                         center_area_frame.show(ui, |ui| {

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -365,16 +365,10 @@ impl Komobar {
                         &SocketMessage::MonitorWorkAreaOffset(monitor_index, new_rect),
                     ) {
                         tracing::error!(
-                            "error applying work area offset to monitor '{}': {}",
-                            monitor_index,
-                            error,
+                            "error applying work area offset to monitor '{monitor_index}': {error}"
                         );
                     } else {
-                        tracing::info!(
-                            "work area offset applied to monitor: {}\n, {:#?}",
-                            monitor_index,
-                            new_rect
-                        );
+                        tracing::info!("work area offset applied to monitor: {monitor_index}",);
                     }
                 }
             }
@@ -631,10 +625,10 @@ impl Komobar {
             let window = komorebi_client::Window::from(hwnd);
             match window.set_position(&self.size_rect, false) {
                 Ok(_) => {
-                    tracing::info!("updated bar position: {:#?}", &self.size_rect);
+                    tracing::info!("updated bar position");
                 }
                 Err(error) => {
-                    tracing::error!("{}", error.to_string())
+                    tracing::error!("{error}")
                 }
             }
         }

--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -718,6 +718,12 @@ impl eframe::App for Komobar {
                             }
                         }
 
+                        // Reset the current `work_area_offset` so that it gets recalculated and
+                        // properly applied again, since if the monitor has connected for the first
+                        // time it won't have the work_area_offset applied but the bar thinks it
+                        // does.
+                        self.work_area_offset = komorebi_client::Rect::default();
+
                         should_apply_config = true;
                     }
                     self.disabled = false;

--- a/komorebi-bar/src/config.rs
+++ b/komorebi-bar/src/config.rs
@@ -125,6 +125,15 @@ impl KomobarConfig {
             }
         }
     }
+
+    pub fn show_all_icons_on_komorebi_workspace(widgets: &[WidgetConfig]) -> bool {
+        widgets
+            .iter()
+            .any(|w| matches!(w, WidgetConfig::Komorebi(config) if config.workspaces.is_some_and(|w| w.enable && w.display.is_some_and(|s| matches!(s,
+            WorkspacesDisplayFormat::AllIcons
+            | WorkspacesDisplayFormat::AllIconsAndText
+            | WorkspacesDisplayFormat::AllIconsAndTextOnSelected)))))
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -15,14 +15,15 @@ use eframe::egui::vec2;
 use eframe::egui::Color32;
 use eframe::egui::ColorImage;
 use eframe::egui::Context;
+use eframe::egui::CornerRadius;
 use eframe::egui::Frame;
 use eframe::egui::Image;
 use eframe::egui::Label;
 use eframe::egui::Margin;
 use eframe::egui::RichText;
-use eframe::egui::Rounding;
 use eframe::egui::Sense;
 use eframe::egui::Stroke;
+use eframe::egui::StrokeKind;
 use eframe::egui::TextureHandle;
 use eframe::egui::TextureOptions;
 use eframe::egui::Ui;
@@ -192,9 +193,9 @@ impl BarWidget for Komorebi {
                                     });
 
                                     if has_icon {
-                                        Frame::none()
+                                        Frame::NONE
                                             .inner_margin(Margin::same(
-                                                ui.style().spacing.button_padding.y,
+                                                ui.style().spacing.button_padding.y as i8,
                                             ))
                                             .show(ui, |ui| {
                                                 for (is_focused, container) in containers {
@@ -220,11 +221,11 @@ impl BarWidget for Komorebi {
                                         if is_selected { ctx.style().visuals.selection.stroke.color} else { ui.style().visuals.text_color() },
                                     );
                                     let mut rect = response.rect;
-                                    let rounding = Rounding::same(rect.width() * 0.1);
+                                    let rounding = CornerRadius::same((rect.width() * 0.1) as u8);
                                     rect = rect.shrink(stroke.width);
                                     let c = rect.center();
                                     let r = rect.width() / 2.0;
-                                    painter.rect_stroke(rect, rounding, stroke);
+                                    painter.rect_stroke(rect, rounding, stroke, StrokeKind::Outside);
                                     painter.line_segment([c - vec2(r, r), c + vec2(r, r)], stroke);
 
                                     response.on_hover_text(ws.to_string())
@@ -453,9 +454,9 @@ impl BarWidget for Komorebi {
                                             && i == focused_window_idx)
                                     {
                                         if let Some(img) = icon {
-                                            Frame::none()
+                                            Frame::NONE
                                                 .inner_margin(Margin::same(
-                                                    ui.style().spacing.button_padding.y,
+                                                    ui.style().spacing.button_padding.y as i8,
                                                 ))
                                                 .show(ui, |ui| {
                                                     let response = ui.add(

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -19,6 +19,7 @@ use eframe::egui::Frame;
 use eframe::egui::Image;
 use eframe::egui::Label;
 use eframe::egui::Margin;
+use eframe::egui::RichText;
 use eframe::egui::Rounding;
 use eframe::egui::Sense;
 use eframe::egui::Stroke;
@@ -216,7 +217,7 @@ impl BarWidget for Komorebi {
                                         ui.allocate_painter(icon_size, Sense::hover());
                                     let stroke = Stroke::new(
                                         1.0,
-                                        ctx.style().visuals.selection.stroke.color,
+                                        if is_selected { ctx.style().visuals.selection.stroke.color} else { ui.style().visuals.text_color() },
                                     );
                                     let mut rect = response.rect;
                                     let rounding = Rounding::same(rect.width() * 0.1);
@@ -237,7 +238,12 @@ impl BarWidget for Komorebi {
                                 } else if (format != WorkspacesDisplayFormat::AllIconsAndTextOnSelected && format != DisplayFormat::IconAndTextOnSelected.into())
                                     || (is_selected && matches!(format, WorkspacesDisplayFormat::AllIconsAndTextOnSelected | WorkspacesDisplayFormat::Existing(DisplayFormat::IconAndTextOnSelected)))
                                 {
-                                    ui.add(Label::new(ws.to_string()).selectable(false))
+                                     if is_selected {
+                                        ui.add(Label::new(RichText::new(ws.to_string()).color(ctx.style().visuals.selection.stroke.color)).selectable(false))
+                                    }
+                                    else {
+                                        ui.add(Label::new(ws.to_string()).selectable(false))
+                                    }
                                 } else {
                                     ui.response()
                                 }
@@ -427,6 +433,7 @@ impl BarWidget for Komorebi {
 
                         for (i, (title, icon)) in iter.enumerate() {
                             let selected = i == focused_window_idx && len != 1;
+                            let text_color = if selected { ctx.style().visuals.selection.stroke.color} else { ui.style().visuals.text_color() };
 
                             if SelectableFrame::new(selected)
                                 .show(ui, |ui| {
@@ -478,7 +485,7 @@ impl BarWidget for Komorebi {
                                                 MAX_LABEL_WIDTH.load(Ordering::SeqCst) as f32,
                                                 available_height,
                                             ),
-                                            Label::new(title).selectable(false).truncate(),
+                                            Label::new(RichText::new( title).color(text_color)).selectable(false).truncate(),
                                         );
                                     }
                                 })

--- a/komorebi-bar/src/komorebi_layout.rs
+++ b/komorebi-bar/src/komorebi_layout.rs
@@ -4,12 +4,13 @@ use crate::render::RenderConfig;
 use crate::selected_frame::SelectableFrame;
 use eframe::egui::vec2;
 use eframe::egui::Context;
+use eframe::egui::CornerRadius;
 use eframe::egui::FontId;
 use eframe::egui::Frame;
 use eframe::egui::Label;
-use eframe::egui::Rounding;
 use eframe::egui::Sense;
 use eframe::egui::Stroke;
+use eframe::egui::StrokeKind;
 use eframe::egui::Ui;
 use eframe::egui::Vec2;
 use komorebi_client::SocketMessage;
@@ -133,11 +134,11 @@ impl KomorebiLayout {
         };
         let stroke = Stroke::new(1.0, color);
         let mut rect = response.rect;
-        let rounding = Rounding::same(rect.width() * 0.1);
+        let rounding = CornerRadius::same((rect.width() * 0.1) as u8);
         rect = rect.shrink(stroke.width);
         let c = rect.center();
         let r = rect.width() / 2.0;
-        painter.rect_stroke(rect, rounding, stroke);
+        painter.rect_stroke(rect, rounding, stroke, StrokeKind::Outside);
 
         match self {
             KomorebiLayout::Default(layout) => match layout {
@@ -193,7 +194,7 @@ impl KomorebiLayout {
                     rect.width() * 0.35 + stroke.width,
                 ));
                 painter.rect_filled(rect_left, rounding, color);
-                painter.rect_stroke(rect_right, rounding, stroke);
+                painter.rect_stroke(rect_right, rounding, stroke, StrokeKind::Outside);
             }
             KomorebiLayout::Paused => {
                 let mut rect_left = response.rect;
@@ -255,7 +256,7 @@ impl KomorebiLayout {
 
             if show_options {
                 if let Some(workspace_idx) = workspace_idx {
-                    Frame::none().show(ui, |ui| {
+                    Frame::NONE.show(ui, |ui| {
                         ui.add(
                             Label::new(egui_phosphor::regular::ARROW_FAT_LINES_RIGHT.to_string())
                                 .selectable(false),

--- a/komorebi-bar/src/komorebi_layout.rs
+++ b/komorebi-bar/src/komorebi_layout.rs
@@ -122,11 +122,15 @@ impl KomorebiLayout {
         }
     }
 
-    fn show_icon(&mut self, font_id: FontId, ctx: &Context, ui: &mut Ui) {
+    fn show_icon(&mut self, is_selected: bool, font_id: FontId, ctx: &Context, ui: &mut Ui) {
         // paint custom icons for the layout
         let size = Vec2::splat(font_id.size);
         let (response, painter) = ui.allocate_painter(size, Sense::hover());
-        let color = ctx.style().visuals.selection.stroke.color;
+        let color = if is_selected {
+            ctx.style().visuals.selection.stroke.color
+        } else {
+            ui.style().visuals.text_color()
+        };
         let stroke = Stroke::new(1.0, color);
         let mut rect = response.rect;
         let rounding = Rounding::same(rect.width() * 0.1);
@@ -236,7 +240,7 @@ impl KomorebiLayout {
             let layout_frame = SelectableFrame::new(false)
                 .show(ui, |ui| {
                     if let DisplayFormat::Icon | DisplayFormat::IconAndText = format {
-                        self.show_icon(font_id.clone(), ctx, ui);
+                        self.show_icon(false, font_id.clone(), ctx, ui);
                     }
 
                     if let DisplayFormat::Text | DisplayFormat::IconAndText = format {
@@ -279,8 +283,12 @@ impl KomorebiLayout {
                         ]);
 
                         for layout_option in &mut layout_options {
-                            if SelectableFrame::new(self == layout_option)
-                                .show(ui, |ui| layout_option.show_icon(font_id.clone(), ctx, ui))
+                            let is_selected = self == layout_option;
+
+                            if SelectableFrame::new(is_selected)
+                                .show(ui, |ui| {
+                                    layout_option.show_icon(is_selected, font_id.clone(), ctx, ui)
+                                })
                                 .on_hover_text(match layout_option {
                                     KomorebiLayout::Default(layout) => layout.to_string(),
                                     KomorebiLayout::Monocle => "Toggle monocle".to_string(),

--- a/komorebi-bar/src/render.rs
+++ b/komorebi-bar/src/render.rs
@@ -54,6 +54,8 @@ pub struct RenderConfig {
     pub text_font_id: FontId,
     /// FontId for icon (based on scaling the text font id)
     pub icon_font_id: FontId,
+    /// Show all icons on the workspace section of the Komorebi widget
+    pub show_all_icons: bool,
 }
 
 pub trait RenderExt {
@@ -87,6 +89,15 @@ impl RenderExt for &KomobarConfig {
             MonitorConfigOrIndex::Index(idx) => *idx,
         };
 
+        // check if any of the alignments have a komorebi widget with the workspace set to show all icons
+        let show_all_icons =
+            KomobarConfig::show_all_icons_on_komorebi_workspace(&self.left_widgets)
+                || self
+                    .center_widgets
+                    .as_ref()
+                    .is_some_and(|list| KomobarConfig::show_all_icons_on_komorebi_workspace(list))
+                || KomobarConfig::show_all_icons_on_komorebi_workspace(&self.right_widgets);
+
         RenderConfig {
             monitor_idx,
             spacing: self.widget_spacing.unwrap_or(10.0),
@@ -97,6 +108,7 @@ impl RenderExt for &KomobarConfig {
             applied_on_widget: false,
             text_font_id,
             icon_font_id,
+            show_all_icons,
         }
     }
 }
@@ -121,6 +133,7 @@ impl RenderConfig {
             applied_on_widget: false,
             text_font_id: FontId::default(),
             icon_font_id: FontId::default(),
+            show_all_icons: false,
         }
     }
 

--- a/komorebi-bar/src/render.rs
+++ b/komorebi-bar/src/render.rs
@@ -3,15 +3,14 @@ use crate::config::KomobarConfig;
 use crate::config::MonitorConfigOrIndex;
 use eframe::egui::Color32;
 use eframe::egui::Context;
+use eframe::egui::CornerRadius;
 use eframe::egui::FontId;
 use eframe::egui::Frame;
 use eframe::egui::InnerResponse;
 use eframe::egui::Margin;
-use eframe::egui::Rounding;
 use eframe::egui::Shadow;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
-use eframe::egui::Vec2;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -148,10 +147,10 @@ impl RenderConfig {
             return self.define_group_frame(
                 //TODO: this outer margin can be a config
                 Some(Margin {
-                    left: 10.0,
-                    right: 10.0,
-                    top: 6.0,
-                    bottom: 6.0,
+                    left: 10,
+                    right: 10,
+                    top: 6,
+                    bottom: 6,
                 }),
                 config,
                 ui_style,
@@ -204,11 +203,11 @@ impl RenderConfig {
         ui: &mut Ui,
         add_contents: impl FnOnce(&mut Ui) -> R,
     ) -> InnerResponse<R> {
-        Frame::none()
+        Frame::NONE
             .outer_margin(outer_margin.unwrap_or(Margin::ZERO))
             .inner_margin(match self.more_inner_margin {
-                true => Margin::symmetric(5.0, 0.0),
-                false => Margin::same(0.0),
+                true => Margin::symmetric(5, 0),
+                false => Margin::same(0),
             })
             .show(ui, add_contents)
     }
@@ -233,13 +232,13 @@ impl RenderConfig {
         Frame::group(ui_style)
             .outer_margin(outer_margin.unwrap_or(Margin::ZERO))
             .inner_margin(match self.more_inner_margin {
-                true => Margin::symmetric(6.0, 1.0),
-                false => Margin::symmetric(1.0, 1.0),
+                true => Margin::symmetric(6, 1),
+                false => Margin::symmetric(1, 1),
             })
             .stroke(ui_style.visuals.widgets.noninteractive.bg_stroke)
-            .rounding(match config.rounding {
+            .corner_radius(match config.rounding {
                 Some(rounding) => rounding.into(),
-                None => ui_style.visuals.widgets.noninteractive.rounding,
+                None => ui_style.visuals.widgets.noninteractive.corner_radius,
             })
             .fill(
                 self.background_color
@@ -250,27 +249,27 @@ impl RenderConfig {
                     // new styles can be added if needed here
                     GroupingStyle::Default => Shadow::NONE,
                     GroupingStyle::DefaultWithShadowB4O1S3 => Shadow {
-                        blur: 4.0,
-                        offset: Vec2::new(1.0, 1.0),
-                        spread: 3.0,
+                        blur: 4,
+                        offset: [1, 1],
+                        spread: 3,
                         color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithShadowB4O0S3 => Shadow {
-                        blur: 4.0,
-                        offset: Vec2::new(0.0, 0.0),
-                        spread: 3.0,
+                        blur: 4,
+                        offset: [0, 0],
+                        spread: 3,
                         color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithShadowB0O1S3 => Shadow {
-                        blur: 0.0,
-                        offset: Vec2::new(1.0, 1.0),
-                        spread: 3.0,
+                        blur: 0,
+                        offset: [1, 1],
+                        spread: 3,
                         color: Color32::BLACK.try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithGlowB3O1S2 => Shadow {
-                        blur: 3.0,
-                        offset: Vec2::new(1.0, 1.0),
-                        spread: 2.0,
+                        blur: 3,
+                        offset: [1, 1],
+                        spread: 2,
                         color: ui_style
                             .visuals
                             .selection
@@ -279,9 +278,9 @@ impl RenderConfig {
                             .try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithGlowB3O0S2 => Shadow {
-                        blur: 3.0,
-                        offset: Vec2::new(0.0, 0.0),
-                        spread: 2.0,
+                        blur: 3,
+                        offset: [0, 0],
+                        spread: 2,
                         color: ui_style
                             .visuals
                             .selection
@@ -290,9 +289,9 @@ impl RenderConfig {
                             .try_apply_alpha(config.transparency_alpha),
                     },
                     GroupingStyle::DefaultWithGlowB0O1S2 => Shadow {
-                        blur: 0.0,
-                        offset: Vec2::new(1.0, 1.0),
-                        spread: 2.0,
+                        blur: 0,
+                        offset: [1, 1],
+                        spread: 2,
                         color: ui_style
                             .visuals
                             .selection
@@ -308,9 +307,9 @@ impl RenderConfig {
     fn widget_outer_margin(&mut self, ui: &mut Ui) -> Margin {
         let spacing = if self.applied_on_widget {
             // Remove the default item spacing from the margin
-            self.spacing - ui.spacing().item_spacing.x
+            (self.spacing - ui.spacing().item_spacing.x) as i8
         } else {
-            0.0
+            0
         };
 
         if !self.applied_on_widget {
@@ -322,20 +321,20 @@ impl RenderConfig {
                 Some(align) => match align {
                     Alignment::Left => spacing,
                     Alignment::Center => spacing,
-                    Alignment::Right => 0.0,
+                    Alignment::Right => 0,
                 },
-                None => 0.0,
+                None => 0,
             },
             right: match self.alignment {
                 Some(align) => match align {
-                    Alignment::Left => 0.0,
-                    Alignment::Center => 0.0,
+                    Alignment::Left => 0,
+                    Alignment::Center => 0,
                     Alignment::Right => spacing,
                 },
-                None => 0.0,
+                None => 0,
             },
-            top: 0.0,
-            bottom: 0.0,
+            top: 0,
+            bottom: 0,
         }
     }
 }
@@ -379,16 +378,19 @@ pub enum RoundingConfig {
     Individual([f32; 4]),
 }
 
-impl From<RoundingConfig> for Rounding {
+impl From<RoundingConfig> for CornerRadius {
     fn from(value: RoundingConfig) -> Self {
         match value {
-            RoundingConfig::Same(value) => Rounding::same(value),
-            RoundingConfig::Individual(values) => Self {
-                nw: values[0],
-                ne: values[1],
-                sw: values[2],
-                se: values[3],
-            },
+            RoundingConfig::Same(value) => Self::same(value as u8),
+            RoundingConfig::Individual(values) => {
+                let values = values.map(|f| f as u8);
+                Self {
+                    nw: values[0],
+                    ne: values[1],
+                    sw: values[2],
+                    se: values[3],
+                }
+            }
         }
     }
 }

--- a/komorebi-bar/src/selected_frame.rs
+++ b/komorebi-bar/src/selected_frame.rs
@@ -1,8 +1,10 @@
+use eframe::egui::Color32;
 use eframe::egui::CursorIcon;
 use eframe::egui::Frame;
 use eframe::egui::Margin;
 use eframe::egui::Response;
 use eframe::egui::Sense;
+use eframe::egui::Stroke;
 use eframe::egui::Ui;
 
 /// Same as SelectableLabel, but supports all content
@@ -23,26 +25,34 @@ impl SelectableFrame {
                 let response = ui.interact(ui.max_rect(), ui.unique_id(), Sense::click());
 
                 if ui.is_rect_visible(response.rect) {
+                    // take into account the stroke width
                     let inner_margin = Margin::symmetric(
-                        ui.style().spacing.button_padding.x as i8,
-                        ui.style().spacing.button_padding.y as i8,
+                        ui.style().spacing.button_padding.x as i8 - 1,
+                        ui.style().spacing.button_padding.y as i8 - 1,
                     );
 
-                    if selected
-                        || response.hovered()
-                        || response.highlighted()
-                        || response.has_focus()
-                    {
+                    // since the stroke is drawn inside the frame, we always reserve space for it
+                    if response.hovered() || response.highlighted() || response.has_focus() {
                         let visuals = ui.style().interact_selectable(&response, selected);
 
                         Frame::NONE
-                            .stroke(visuals.bg_stroke)
+                            .stroke(Stroke::new(1.0, visuals.bg_stroke.color))
+                            .corner_radius(visuals.corner_radius)
+                            .fill(visuals.bg_fill)
+                            .inner_margin(inner_margin)
+                            .show(ui, add_contents);
+                    } else if selected {
+                        let visuals = ui.style().interact_selectable(&response, selected);
+
+                        Frame::NONE
+                            .stroke(Stroke::new(1.0, visuals.bg_fill))
                             .corner_radius(visuals.corner_radius)
                             .fill(visuals.bg_fill)
                             .inner_margin(inner_margin)
                             .show(ui, add_contents);
                     } else {
                         Frame::NONE
+                            .stroke(Stroke::new(1.0, Color32::TRANSPARENT))
                             .inner_margin(inner_margin)
                             .show(ui, add_contents);
                     }

--- a/komorebi-bar/src/selected_frame.rs
+++ b/komorebi-bar/src/selected_frame.rs
@@ -18,14 +18,14 @@ impl SelectableFrame {
     pub fn show<R>(self, ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> Response {
         let Self { selected } = self;
 
-        Frame::none()
+        Frame::NONE
             .show(ui, |ui| {
                 let response = ui.interact(ui.max_rect(), ui.unique_id(), Sense::click());
 
                 if ui.is_rect_visible(response.rect) {
                     let inner_margin = Margin::symmetric(
-                        ui.style().spacing.button_padding.x,
-                        ui.style().spacing.button_padding.y,
+                        ui.style().spacing.button_padding.x as i8,
+                        ui.style().spacing.button_padding.y as i8,
                     );
 
                     if selected
@@ -35,14 +35,14 @@ impl SelectableFrame {
                     {
                         let visuals = ui.style().interact_selectable(&response, selected);
 
-                        Frame::none()
+                        Frame::NONE
                             .stroke(visuals.bg_stroke)
-                            .rounding(visuals.rounding)
+                            .corner_radius(visuals.corner_radius)
                             .fill(visuals.bg_fill)
                             .inner_margin(inner_margin)
                             .show(ui, add_contents);
                     } else {
-                        Frame::none()
+                        Frame::NONE
                             .inner_margin(inner_margin)
                             .show(ui, add_contents);
                     }

--- a/komorebi-bar/src/time.rs
+++ b/komorebi-bar/src/time.rs
@@ -6,13 +6,14 @@ use crate::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Align;
 use eframe::egui::Context;
+use eframe::egui::CornerRadius;
 use eframe::egui::Label;
-use eframe::egui::Rounding;
 use eframe::egui::Sense;
 use eframe::egui::Stroke;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
 use eframe::egui::Vec2;
+use eframe::epaint::StrokeKind;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -158,14 +159,14 @@ impl Time {
         let color = ctx.style().visuals.text_color();
         let stroke = Stroke::new(1.0, color);
 
-        let round_all = Rounding::same(response.rect.width() * 0.1);
-        let round_top = Rounding {
+        let round_all = CornerRadius::same((response.rect.width() * 0.1) as u8);
+        let round_top = CornerRadius {
             nw: round_all.nw,
             ne: round_all.ne,
             ..Default::default()
         };
-        let round_none = Rounding::ZERO;
-        let round_bottom = Rounding {
+        let round_none = CornerRadius::ZERO;
+        let round_bottom = CornerRadius {
             sw: round_all.nw,
             se: round_all.ne,
             ..Default::default()
@@ -175,14 +176,19 @@ impl Time {
             let mut rect = response.rect.shrink(stroke.width);
             rect.set_height(rect.height() - height * 2.0);
             rect = rect.translate(Vec2::new(0.0, height * 2.0));
-            painter.rect_stroke(rect, round_all, stroke);
+            painter.rect_stroke(rect, round_all, stroke, StrokeKind::Outside);
         } else if max_power == 3 {
             let mut rect = response.rect.shrink(stroke.width);
             rect.set_height(rect.height() - height);
             rect = rect.translate(Vec2::new(0.0, height));
-            painter.rect_stroke(rect, round_all, stroke);
+            painter.rect_stroke(rect, round_all, stroke, StrokeKind::Outside);
         } else {
-            painter.rect_stroke(response.rect.shrink(stroke.width), round_all, stroke);
+            painter.rect_stroke(
+                response.rect.shrink(stroke.width),
+                round_all,
+                stroke,
+                StrokeKind::Outside,
+            );
         }
 
         let mut rect_bin = response.rect;

--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -48,6 +48,7 @@ pub use komorebi::ring::Ring;
 pub use komorebi::window::Window;
 pub use komorebi::window_manager_event::WindowManagerEvent;
 pub use komorebi::workspace::Workspace;
+pub use komorebi::workspace::WorkspaceGlobals;
 pub use komorebi::workspace::WorkspaceLayer;
 pub use komorebi::AnimationsConfig;
 pub use komorebi::AspectRatio;

--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -48,6 +48,7 @@ pub use komorebi::ring::Ring;
 pub use komorebi::window::Window;
 pub use komorebi::window_manager_event::WindowManagerEvent;
 pub use komorebi::workspace::Workspace;
+pub use komorebi::workspace::WorkspaceLayer;
 pub use komorebi::AnimationsConfig;
 pub use komorebi::AspectRatio;
 pub use komorebi::BorderColours;

--- a/komorebi-themes/Cargo.toml
+++ b/komorebi-themes/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.35"
 edition = "2021"
 
 [dependencies]
-base16-egui-themes = { git = "https://github.com/LGUG2Z/base16-egui-themes", rev = "911079d" }
-catppuccin-egui = { git = "https://github.com/LGUG2Z/catppuccin-egui", rev = "f85cc3c", default-features = false, features = ["egui30"] }
+base16-egui-themes = { git = "https://github.com/LGUG2Z/base16-egui-themes", rev = "96f26c88d83781f234d42222293ec73d23a39ad8" }
+catppuccin-egui = { git = "https://github.com/LGUG2Z/catppuccin-egui", rev = "bdaff30959512c4f7ee7304117076a48633d777f", default-features = false, features = ["egui31"] }
 #catppuccin-egui = { version = "5", default-features = false, features = ["egui30"] }
 eframe = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_variant = "0.1"
-strum = "0.26"
+strum = { workspace = true }

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -34,7 +34,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 shadow-rs = { workspace = true }
-strum = { version = "0.26", features = ["derive"] }
+strum = { workspace = true }
 sysinfo = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }

--- a/komorebi/src/border_manager/border.rs
+++ b/komorebi/src/border_manager/border.rs
@@ -475,13 +475,11 @@ impl Border {
                             });
 
                             // Get window kind and color
-
                             (*border_pointer).window_kind = FOCUS_STATE
                                 .lock()
                                 .get(&(window.0 as isize))
                                 .copied()
                                 .unwrap_or(WindowKind::Unfocused);
-
                             let window_kind = (*border_pointer).window_kind;
                             if let Some(brush) = (*border_pointer).brushes.get(&window_kind) {
                                 render_target.BeginDraw();

--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -149,6 +149,7 @@ pub enum SocketMessage {
     NamedWorkspaceLayoutCustomRule(String, usize, PathBuf),
     ClearWorkspaceLayoutRules(usize, usize),
     ClearNamedWorkspaceLayoutRules(String),
+    ToggleWorkspaceLayer,
     // Configuration
     ReloadConfiguration,
     ReplaceConfiguration(PathBuf),

--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -291,7 +291,7 @@ fn main() -> Result<()> {
     transparency_manager::listen_for_notifications(wm.clone());
     workspace_reconciliator::listen_for_notifications(wm.clone());
     monitor_reconciliator::listen_for_notifications(wm.clone())?;
-    reaper::watch_for_orphans(wm.clone());
+    reaper::listen_for_notifications(wm.clone());
     focus_manager::listen_for_notifications(wm.clone());
     theme_manager::listen_for_notifications();
 

--- a/komorebi/src/monitor_reconciliator/mod.rs
+++ b/komorebi/src/monitor_reconciliator/mod.rs
@@ -264,6 +264,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                             || attached.device_id().eq(monitor.device_id())
                         {
                             monitor.set_id(attached.id());
+                            monitor.set_device(attached.device().clone());
                             monitor.set_device_id(attached.device_id().clone());
                             monitor.set_serial_number_id(attached.serial_number_id().clone());
                             monitor.set_name(attached.name().clone());
@@ -462,9 +463,31 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
 
                                 tracing::info!("found monitor and workspace configuration for {id} in the monitor cache, applying");
 
-                                // If it does, load the monitor removing any window that has since
-                                // been closed or moved to another workspace
-                                *m = cached.clone();
+                                // If it does, update the cached monitor info with the new one and
+                                // load the cached monitor removing any window that has since been
+                                // closed or moved to another workspace
+                                *m = Monitor {
+                                    // Data that should be the one just read from `win32-display-data`
+                                    id: m.id,
+                                    name: m.name.clone(),
+                                    device: m.device.clone(),
+                                    device_id: m.device_id.clone(),
+                                    serial_number_id: m.serial_number_id.clone(),
+                                    size: m.size,
+                                    work_area_size: m.work_area_size,
+
+                                    // The rest should come from the cached monitor
+                                    work_area_offset: cached.work_area_offset,
+                                    window_based_work_area_offset: cached
+                                        .window_based_work_area_offset,
+                                    window_based_work_area_offset_limit: cached
+                                        .window_based_work_area_offset_limit,
+                                    workspaces: cached.workspaces.clone(),
+                                    last_focused_workspace: cached.last_focused_workspace,
+                                    workspace_names: cached.workspace_names.clone(),
+                                    container_padding: cached.container_padding,
+                                    workspace_padding: cached.workspace_padding,
+                                };
 
                                 let focused_workspace_idx = m.focused_workspace_idx();
 

--- a/komorebi/src/monitor_reconciliator/mod.rs
+++ b/komorebi/src/monitor_reconciliator/mod.rs
@@ -385,7 +385,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                     }
 
                     // Update known_hwnds
-                    wm.known_hwnds.retain(|i| !windows_to_remove.contains(i));
+                    wm.known_hwnds.retain(|i, _| !windows_to_remove.contains(i));
 
                     if !newly_removed_displays.is_empty() {
                         // After we have cached them, remove them from our state
@@ -481,7 +481,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                                     {
                                         container.windows_mut().retain(|window| {
                                             window.exe().is_ok()
-                                                && !known_hwnds.contains(&window.hwnd)
+                                                && !known_hwnds.contains_key(&window.hwnd)
                                         });
 
                                         if container.windows().is_empty() {
@@ -519,7 +519,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
 
                                     if let Some(window) = workspace.maximized_window() {
                                         if window.exe().is_err()
-                                            || known_hwnds.contains(&window.hwnd)
+                                            || known_hwnds.contains_key(&window.hwnd)
                                         {
                                             workspace.set_maximized_window(None);
                                         } else if is_focused_workspace {
@@ -530,7 +530,7 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                                     if let Some(container) = workspace.monocle_container_mut() {
                                         container.windows_mut().retain(|window| {
                                             window.exe().is_ok()
-                                                && !known_hwnds.contains(&window.hwnd)
+                                                && !known_hwnds.contains_key(&window.hwnd)
                                         });
 
                                         if container.windows().is_empty() {
@@ -552,7 +552,8 @@ pub fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result
                                     }
 
                                     workspace.floating_windows_mut().retain(|window| {
-                                        window.exe().is_ok() && !known_hwnds.contains(&window.hwnd)
+                                        window.exe().is_ok()
+                                            && !known_hwnds.contains_key(&window.hwnd)
                                     });
 
                                     if is_focused_workspace {

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -66,6 +66,7 @@ use crate::window_manager;
 use crate::window_manager::WindowManager;
 use crate::windows_api::WindowsApi;
 use crate::winevent_listener;
+use crate::workspace::WorkspaceLayer;
 use crate::workspace::WorkspaceWindowLocation;
 use crate::GlobalState;
 use crate::Notification;
@@ -291,13 +292,37 @@ impl WindowManager {
                 }
             }
             SocketMessage::FocusWindow(direction) => {
-                self.focus_container_in_direction(direction)?;
+                let focused_workspace = self.focused_workspace()?;
+                match focused_workspace.layer() {
+                    WorkspaceLayer::Tiling => {
+                        self.focus_container_in_direction(direction)?;
+                    }
+                    WorkspaceLayer::Floating => {
+                        self.focus_floating_window_in_direction(direction)?;
+                    }
+                }
             }
             SocketMessage::MoveWindow(direction) => {
-                self.move_container_in_direction(direction)?;
+                let focused_workspace = self.focused_workspace()?;
+                match focused_workspace.layer() {
+                    WorkspaceLayer::Tiling => {
+                        self.move_container_in_direction(direction)?;
+                    }
+                    WorkspaceLayer::Floating => {
+                        self.move_floating_window_in_direction(direction)?;
+                    }
+                }
             }
             SocketMessage::CycleFocusWindow(direction) => {
-                self.focus_container_in_cycle_direction(direction)?;
+                let focused_workspace = self.focused_workspace()?;
+                match focused_workspace.layer() {
+                    WorkspaceLayer::Tiling => {
+                        self.focus_container_in_cycle_direction(direction)?;
+                    }
+                    WorkspaceLayer::Floating => {
+                        self.focus_floating_window_in_cycle_direction(direction)?;
+                    }
+                }
             }
             SocketMessage::CycleMoveWindow(direction) => {
                 self.move_container_in_cycle_direction(direction)?;
@@ -1019,6 +1044,29 @@ impl WindowManager {
                     self.focus_monitor(monitor_idx)?;
                     self.focus_workspace(workspace_idx)?;
                 }
+            }
+            SocketMessage::ToggleWorkspaceLayer => {
+                let mouse_follows_focus = self.mouse_follows_focus;
+                let workspace = self.focused_workspace_mut()?;
+
+                match workspace.layer() {
+                    WorkspaceLayer::Tiling => {
+                        workspace.set_layer(WorkspaceLayer::Floating);
+
+                        if let Some(first) = workspace.floating_windows().first() {
+                            first.focus(mouse_follows_focus)?;
+                        }
+                    }
+                    WorkspaceLayer::Floating => {
+                        workspace.set_layer(WorkspaceLayer::Tiling);
+
+                        if let Some(container) = workspace.focused_container() {
+                            if let Some(window) = container.focused_window() {
+                                window.focus(mouse_follows_focus)?;
+                            }
+                        }
+                    }
+                };
             }
             SocketMessage::Stop => {
                 self.stop(false)?;

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1835,6 +1835,9 @@ impl WindowManager {
             | SocketMessage::IdentifyBorderOverflowApplication(_, _) => {}
         };
 
+        // Update list of known_hwnds and their monitor/workspace index pair
+        self.update_known_hwnds();
+
         notify_subscribers(
             Notification {
                 event: NotificationEvent::Socket(message.clone()),

--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -26,6 +26,7 @@ use crate::window_manager::WindowManager;
 use crate::window_manager_event::WindowManagerEvent;
 use crate::windows_api::WindowsApi;
 use crate::winevent::WinEvent;
+use crate::workspace::WorkspaceLayer;
 use crate::workspace_reconciliator;
 use crate::workspace_reconciliator::ALT_TAB_HWND;
 use crate::workspace_reconciliator::ALT_TAB_HWND_INSTANT;
@@ -280,10 +281,13 @@ impl WindowManager {
                         } else {
                             workspace.focus_container_by_window(window.hwnd)?;
                         }
+
+                        workspace.set_layer(WorkspaceLayer::Tiling);
                     }
                     Some(idx) => {
                         if let Some(window) = workspace.floating_windows().get(idx) {
                             window.focus(false)?;
+                            workspace.set_layer(WorkspaceLayer::Floating);
                         }
                     }
                 }
@@ -393,11 +397,13 @@ impl WindowManager {
 
                             if behaviour.float_override {
                                 workspace.floating_windows_mut().push(window);
+                                workspace.set_layer(WorkspaceLayer::Floating);
                                 self.update_focused_workspace(false, false)?;
                             } else {
                                 match behaviour.current_behaviour {
                                     WindowContainerBehaviour::Create => {
                                         workspace.new_container_for_window(window);
+                                        workspace.set_layer(WorkspaceLayer::Tiling);
                                         self.update_focused_workspace(false, false)?;
                                     }
                                     WindowContainerBehaviour::Append => {
@@ -407,6 +413,7 @@ impl WindowManager {
                                                 anyhow!("there is no focused container")
                                             })?
                                             .add_window(window);
+                                        workspace.set_layer(WorkspaceLayer::Tiling);
                                         self.update_focused_workspace(true, false)?;
                                         stackbar_manager::send_notification();
                                     }

--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -285,8 +285,7 @@ impl WindowManager {
                         workspace.set_layer(WorkspaceLayer::Tiling);
                     }
                     Some(idx) => {
-                        if let Some(window) = workspace.floating_windows().get(idx) {
-                            window.focus(false)?;
+                        if let Some(_window) = workspace.floating_windows().get(idx) {
                             workspace.set_layer(WorkspaceLayer::Floating);
                         }
                     }

--- a/komorebi/src/reaper.rs
+++ b/komorebi/src/reaper.rs
@@ -1,14 +1,164 @@
 #![deny(clippy::unwrap_used, clippy::expect_used)]
 
 use crate::border_manager;
+use crate::notify_subscribers;
+use crate::winevent::WinEvent;
+use crate::NotificationEvent;
+use crate::Window;
 use crate::WindowManager;
+use crate::WindowManagerEvent;
+use crate::DATA_DIR;
+
+use crossbeam_channel::Receiver;
+use crossbeam_channel::Sender;
+use lazy_static::lazy_static;
 use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::fs::OpenOptions;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
-pub fn watch_for_orphans(wm: Arc<Mutex<WindowManager>>) {
+lazy_static! {
+    pub static ref HWNDS_CACHE: Arc<Mutex<HashMap<isize, (usize, usize)>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+}
+
+pub struct ReaperNotification(pub HashMap<isize, (usize, usize)>);
+
+static CHANNEL: OnceLock<(Sender<ReaperNotification>, Receiver<ReaperNotification>)> =
+    OnceLock::new();
+
+pub fn channel() -> &'static (Sender<ReaperNotification>, Receiver<ReaperNotification>) {
+    CHANNEL.get_or_init(|| crossbeam_channel::bounded(50))
+}
+
+fn event_tx() -> Sender<ReaperNotification> {
+    channel().0.clone()
+}
+
+fn event_rx() -> Receiver<ReaperNotification> {
+    channel().1.clone()
+}
+
+pub fn send_notification(hwnds: HashMap<isize, (usize, usize)>) {
+    if event_tx().try_send(ReaperNotification(hwnds)).is_err() {
+        tracing::warn!("channel is full; dropping notification")
+    }
+}
+
+pub fn listen_for_notifications(wm: Arc<Mutex<WindowManager>>) {
+    watch_for_orphans(wm.clone());
+
     std::thread::spawn(move || loop {
-        match find_orphans(wm.clone()) {
+        match handle_notifications(wm.clone()) {
+            Ok(()) => {
+                tracing::warn!("restarting finished thread");
+            }
+            Err(error) => {
+                tracing::warn!("restarting failed thread: {}", error);
+            }
+        }
+    });
+}
+
+fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()> {
+    tracing::info!("listening");
+
+    let receiver = event_rx();
+
+    for notification in receiver {
+        let orphan_hwnds = notification.0;
+        let mut wm = wm.lock();
+        let offset = wm.work_area_offset;
+
+        let mut update_borders = false;
+
+        for (hwnd, (m_idx, w_idx)) in orphan_hwnds.iter() {
+            if let Some(monitor) = wm.monitors_mut().get_mut(*m_idx) {
+                let focused_workspace_idx = monitor.focused_workspace_idx();
+                let work_area = *monitor.work_area_size();
+                let window_based_work_area_offset = (
+                    monitor.window_based_work_area_offset_limit(),
+                    monitor.window_based_work_area_offset(),
+                );
+
+                let offset = if monitor.work_area_offset().is_some() {
+                    monitor.work_area_offset()
+                } else {
+                    offset
+                };
+
+                if let Some(workspace) = monitor.workspaces_mut().get_mut(*w_idx) {
+                    // Remove orphan window
+                    if let Err(error) = workspace.remove_window(*hwnd) {
+                        tracing::warn!(
+                            "error reaping orphan window ({}) on monitor: {}, workspace: {}. Error: {}",
+                            hwnd,
+                            m_idx,
+                            w_idx,
+                            error,
+                        );
+                    }
+
+                    if focused_workspace_idx == *w_idx {
+                        // If this is not a focused workspace there is no need to update the
+                        // workspace or the borders. That will already be done when the user
+                        // changes to this workspace.
+                        workspace.update(&work_area, offset, window_based_work_area_offset)?;
+                        update_borders = true;
+                    }
+                    tracing::info!(
+                        "reaped orphan window ({}) on monitor: {}, workspace: {}",
+                        hwnd,
+                        m_idx,
+                        w_idx,
+                    );
+                }
+            }
+
+            wm.known_hwnds.remove(hwnd);
+
+            let window = Window::from(*hwnd);
+            notify_subscribers(
+                crate::Notification {
+                    event: NotificationEvent::WindowManager(WindowManagerEvent::Destroy(
+                        WinEvent::ObjectDestroy,
+                        window,
+                    )),
+                    state: wm.as_ref().into(),
+                },
+                true,
+            )?;
+        }
+
+        if update_borders {
+            border_manager::send_notification(None);
+        }
+
+        // Save to file
+        let hwnd_json = DATA_DIR.join("komorebi.hwnd.json");
+        let file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(hwnd_json)?;
+
+        serde_json::to_writer_pretty(&file, &wm.known_hwnds.keys().collect::<Vec<_>>())?;
+    }
+
+    Ok(())
+}
+
+fn watch_for_orphans(wm: Arc<Mutex<WindowManager>>) {
+    // Cache current hwnds
+    {
+        let mut cache = HWNDS_CACHE.lock();
+        *cache = wm.lock().known_hwnds.clone();
+    }
+
+    std::thread::spawn(move || loop {
+        match find_orphans() {
             Ok(()) => {
                 tracing::warn!("restarting finished thread");
             }
@@ -23,50 +173,37 @@ pub fn watch_for_orphans(wm: Arc<Mutex<WindowManager>>) {
     });
 }
 
-pub fn find_orphans(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()> {
+fn find_orphans() -> color_eyre::Result<()> {
     tracing::info!("watching");
 
-    let arc = wm.clone();
-
     loop {
-        std::thread::sleep(Duration::from_secs(1));
+        std::thread::sleep(Duration::from_millis(20));
 
-        let mut wm = arc.lock();
-        let offset = wm.work_area_offset;
+        let mut cache = HWNDS_CACHE.lock();
+        let mut orphan_hwnds = HashMap::new();
 
-        let mut update_borders = false;
+        for (hwnd, (m_idx, w_idx)) in cache.iter() {
+            let window = Window::from(*hwnd);
 
-        for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
-            let work_area = *monitor.work_area_size();
-            let window_based_work_area_offset = (
-                monitor.window_based_work_area_offset_limit(),
-                monitor.window_based_work_area_offset(),
-            );
-
-            let offset = if monitor.work_area_offset().is_some() {
-                monitor.work_area_offset()
-            } else {
-                offset
-            };
-
-            for (j, workspace) in monitor.workspaces_mut().iter_mut().enumerate() {
-                let reaped_orphans = workspace.reap_orphans()?;
-                if reaped_orphans.0 > 0 || reaped_orphans.1 > 0 {
-                    workspace.update(&work_area, offset, window_based_work_area_offset)?;
-                    update_borders = true;
-                    tracing::info!(
-                        "reaped {} orphan window(s) and {} orphaned container(s) on monitor: {}, workspace: {}",
-                        reaped_orphans.0,
-                        reaped_orphans.1,
-                        i,
-                        j
-                    );
-                }
+            if !window.is_window()
+                // This one is a hack because WINWORD.EXE is an absolute trainwreck of an app
+                // when multiple docs are open, it keeps open an invisible window, with WS_EX_LAYERED
+                // (A STYLE THAT THE REGULAR WINDOWS NEED IN ORDER TO BE MANAGED!) when one of the
+                // docs is closed
+                //
+                // I hate every single person who worked on Microsoft Office 365, especially Word
+                || !window.is_visible()
+            {
+                orphan_hwnds.insert(window.hwnd, (*m_idx, *w_idx));
             }
         }
 
-        if update_borders {
-            border_manager::send_notification(None);
+        if !orphan_hwnds.is_empty() {
+            // Update reaper cache
+            cache.retain(|h, _| !orphan_hwnds.contains_key(h));
+
+            // Send handles to remove
+            event_tx().send(ReaperNotification(orphan_hwnds))?;
         }
     }
 }

--- a/komorebi/src/reaper.rs
+++ b/komorebi/src/reaper.rs
@@ -70,24 +70,12 @@ fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()>
     for notification in receiver {
         let orphan_hwnds = notification.0;
         let mut wm = wm.lock();
-        let offset = wm.work_area_offset;
 
         let mut update_borders = false;
 
         for (hwnd, (m_idx, w_idx)) in orphan_hwnds.iter() {
             if let Some(monitor) = wm.monitors_mut().get_mut(*m_idx) {
                 let focused_workspace_idx = monitor.focused_workspace_idx();
-                let work_area = *monitor.work_area_size();
-                let window_based_work_area_offset = (
-                    monitor.window_based_work_area_offset_limit(),
-                    monitor.window_based_work_area_offset(),
-                );
-
-                let offset = if monitor.work_area_offset().is_some() {
-                    monitor.work_area_offset()
-                } else {
-                    offset
-                };
 
                 if let Some(workspace) = monitor.workspaces_mut().get_mut(*w_idx) {
                     // Remove orphan window
@@ -105,7 +93,7 @@ fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()>
                         // If this is not a focused workspace there is no need to update the
                         // workspace or the borders. That will already be done when the user
                         // changes to this workspace.
-                        workspace.update(&work_area, offset, window_based_work_area_offset)?;
+                        workspace.update()?;
                         update_borders = true;
                     }
                     tracing::info!(

--- a/komorebi/src/reaper.rs
+++ b/komorebi/src/reaper.rs
@@ -47,8 +47,11 @@ pub fn send_notification(hwnds: HashMap<isize, (usize, usize)>) {
     }
 }
 
-pub fn listen_for_notifications(wm: Arc<Mutex<WindowManager>>) {
-    watch_for_orphans(wm.clone());
+pub fn listen_for_notifications(
+    wm: Arc<Mutex<WindowManager>>,
+    known_hwnds: HashMap<isize, (usize, usize)>,
+) {
+    watch_for_orphans(known_hwnds);
 
     std::thread::spawn(move || loop {
         match handle_notifications(wm.clone()) {
@@ -138,11 +141,11 @@ fn handle_notifications(wm: Arc<Mutex<WindowManager>>) -> color_eyre::Result<()>
     Ok(())
 }
 
-fn watch_for_orphans(wm: Arc<Mutex<WindowManager>>) {
+fn watch_for_orphans(known_hwnds: HashMap<isize, (usize, usize)>) {
     // Cache current hwnds
     {
         let mut cache = HWNDS_CACHE.lock();
-        *cache = wm.lock().known_hwnds.clone();
+        *cache = known_hwnds;
     }
 
     std::thread::spawn(move || loop {

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1208,7 +1208,7 @@ impl StaticConfig {
             pending_move_op: Arc::new(None),
             already_moved_window_handles: Arc::new(Mutex::new(HashSet::new())),
             uncloack_to_ignore: 0,
-            known_hwnds: Vec::new(),
+            known_hwnds: HashMap::new(),
         };
 
         match value.focus_follows_mouse {

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -736,6 +736,30 @@ impl Window {
         self.update_style(&style)
     }
 
+    /// Raise the window to the top of the Z order, but do not activate or focus
+    /// it. Use raise_and_focus_window to activate and focus a window.
+    /// It also checks if there is a border attached to this window and if it is
+    /// it raises it as well.
+    pub fn raise(self) -> Result<()> {
+        WindowsApi::raise_window(self.hwnd)?;
+        if let Some(border) = crate::border_manager::window_border(self.hwnd) {
+            WindowsApi::raise_window(border.hwnd)?;
+        }
+        Ok(())
+    }
+
+    /// Lower the window to the bottom of the Z order, but do not activate or focus
+    /// it.
+    /// It also checks if there is a border attached to this window and if it is
+    /// it lowers it as well.
+    pub fn lower(self) -> Result<()> {
+        WindowsApi::lower_window(self.hwnd)?;
+        if let Some(border) = crate::border_manager::window_border(self.hwnd) {
+            WindowsApi::lower_window(border.hwnd)?;
+        }
+        Ok(())
+    }
+
     #[tracing::instrument(fields(exe, title), skip(debug))]
     pub fn should_manage(
         self,

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -2845,6 +2845,10 @@ impl WindowManager {
             container.hide(None);
         }
 
+        for window in workspace.floating_windows_mut() {
+            window.hide();
+        }
+
         Ok(())
     }
 
@@ -2856,6 +2860,10 @@ impl WindowManager {
 
         for container in workspace.containers_mut() {
             container.restore();
+        }
+
+        for window in workspace.floating_windows_mut() {
+            window.restore();
         }
 
         workspace.reintegrate_monocle_container()

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -337,6 +337,7 @@ impl From<&WindowManager> for State {
                                 .clone(),
                             float_override: workspace.float_override,
                             layer: workspace.layer,
+                            globals: workspace.globals,
                             workspace_config: None,
                         })
                         .collect::<VecDeque<_>>();
@@ -345,6 +346,8 @@ impl From<&WindowManager> for State {
                 },
                 last_focused_workspace: monitor.last_focused_workspace,
                 workspace_names: monitor.workspace_names.clone(),
+                container_padding: monitor.container_padding,
+                workspace_padding: monitor.workspace_padding,
             })
             .collect::<VecDeque<_>>();
         stripped_monitors.focus(wm.monitors.focused_idx());
@@ -979,17 +982,14 @@ impl WindowManager {
         let offset = self.work_area_offset;
 
         for monitor in self.monitors_mut() {
-            let work_area = *monitor.work_area_size();
-            let window_based_work_area_offset = (
-                monitor.window_based_work_area_offset_limit(),
-                monitor.window_based_work_area_offset(),
-            );
-
             let offset = if monitor.work_area_offset().is_some() {
                 monitor.work_area_offset()
             } else {
                 offset
             };
+
+            let focused_workspace_idx = monitor.focused_workspace_idx();
+            monitor.update_workspace_globals(focused_workspace_idx, offset);
 
             let workspace = monitor
                 .focused_workspace_mut()
@@ -1002,7 +1002,7 @@ impl WindowManager {
                 }
             }
 
-            workspace.update(&work_area, offset, window_based_work_area_offset)?;
+            workspace.update()?;
         }
 
         Ok(())
@@ -1704,6 +1704,7 @@ impl WindowManager {
             return Ok(());
         }
         let mouse_follows_focus = self.mouse_follows_focus;
+        let offset = self.work_area_offset;
         let first_focused_workspace = {
             let first_monitor = self
                 .monitors()
@@ -1748,11 +1749,13 @@ impl WindowManager {
 
         // Set the focused workspaces for the first and second monitors
         if let Some(first_monitor) = self.monitors_mut().get_mut(first_idx) {
+            first_monitor.update_workspaces_globals(offset);
             first_monitor.focus_workspace(second_focused_workspace)?;
             first_monitor.load_focused_workspace(mouse_follows_focus)?;
         }
 
         if let Some(second_monitor) = self.monitors_mut().get_mut(second_idx) {
+            second_monitor.update_workspaces_globals(offset);
             second_monitor.focus_workspace(first_focused_workspace)?;
             second_monitor.load_focused_workspace(mouse_follows_focus)?;
         }
@@ -1920,13 +1923,22 @@ impl WindowManager {
     pub fn remove_focused_workspace(&mut self) -> Option<Workspace> {
         let focused_monitor: &mut Monitor = self.focused_monitor_mut()?;
         let focused_workspace_idx = focused_monitor.focused_workspace_idx();
-        focused_monitor.remove_workspace_by_idx(focused_workspace_idx)
+        let workspace = focused_monitor.remove_workspace_by_idx(focused_workspace_idx);
+        if let Err(error) = focused_monitor.focus_workspace(focused_workspace_idx.saturating_sub(1))
+        {
+            tracing::error!(
+                "Error focusing previous workspace while removing the focused workspace: {}",
+                error
+            );
+        }
+        workspace
     }
 
     #[tracing::instrument(skip(self))]
     pub fn move_workspace_to_monitor(&mut self, idx: usize) -> Result<()> {
         tracing::info!("moving workspace");
         let mouse_follows_focus = self.mouse_follows_focus;
+        let offset = self.work_area_offset;
         let workspace = self
             .remove_focused_workspace()
             .ok_or_else(|| anyhow!("there is no workspace"))?;
@@ -1938,6 +1950,7 @@ impl WindowManager {
                 .ok_or_else(|| anyhow!("there is no monitor"))?;
 
             target_monitor.workspaces_mut().push_back(workspace);
+            target_monitor.update_workspaces_globals(offset);
             target_monitor.focus_workspace(target_monitor.workspaces().len().saturating_sub(1))?;
             target_monitor.load_focused_workspace(mouse_follows_focus)?;
         }
@@ -3082,7 +3095,6 @@ impl WindowManager {
     ) -> Result<()> {
         tracing::info!("setting workspace layout");
 
-        let offset = self.work_area_offset;
         let focused_monitor_idx = self.focused_monitor_idx();
 
         let monitor = self
@@ -3090,18 +3102,7 @@ impl WindowManager {
             .get_mut(monitor_idx)
             .ok_or_else(|| anyhow!("there is no monitor"))?;
 
-        let work_area = *monitor.work_area_size();
-        let window_based_work_area_offset = (
-            monitor.window_based_work_area_offset_limit(),
-            monitor.window_based_work_area_offset(),
-        );
-
         let focused_workspace_idx = monitor.focused_workspace_idx();
-        let offset = if monitor.work_area_offset().is_some() {
-            monitor.work_area_offset()
-        } else {
-            offset
-        };
 
         let workspace = monitor
             .workspaces_mut()
@@ -3115,7 +3116,7 @@ impl WindowManager {
 
         // If this is the focused workspace on a non-focused screen, let's update it
         if focused_monitor_idx != monitor_idx && focused_workspace_idx == workspace_idx {
-            workspace.update(&work_area, offset, window_based_work_area_offset)?;
+            workspace.update()?;
             Ok(())
         } else {
             Ok(self.update_focused_workspace(false, false)?)
@@ -3135,7 +3136,6 @@ impl WindowManager {
     {
         tracing::info!("setting workspace layout");
 
-        let offset = self.work_area_offset;
         let focused_monitor_idx = self.focused_monitor_idx();
 
         let monitor = self
@@ -3143,18 +3143,7 @@ impl WindowManager {
             .get_mut(monitor_idx)
             .ok_or_else(|| anyhow!("there is no monitor"))?;
 
-        let work_area = *monitor.work_area_size();
-        let window_based_work_area_offset = (
-            monitor.window_based_work_area_offset_limit(),
-            monitor.window_based_work_area_offset(),
-        );
-
         let focused_workspace_idx = monitor.focused_workspace_idx();
-        let offset = if monitor.work_area_offset().is_some() {
-            monitor.work_area_offset()
-        } else {
-            offset
-        };
 
         let workspace = monitor
             .workspaces_mut()
@@ -3170,7 +3159,7 @@ impl WindowManager {
 
         // If this is the focused workspace on a non-focused screen, let's update it
         if focused_monitor_idx != monitor_idx && focused_workspace_idx == workspace_idx {
-            workspace.update(&work_area, offset, window_based_work_area_offset)?;
+            workspace.update()?;
             Ok(())
         } else {
             Ok(self.update_focused_workspace(false, false)?)
@@ -3185,7 +3174,6 @@ impl WindowManager {
     ) -> Result<()> {
         tracing::info!("setting workspace layout");
 
-        let offset = self.work_area_offset;
         let focused_monitor_idx = self.focused_monitor_idx();
 
         let monitor = self
@@ -3193,18 +3181,7 @@ impl WindowManager {
             .get_mut(monitor_idx)
             .ok_or_else(|| anyhow!("there is no monitor"))?;
 
-        let work_area = *monitor.work_area_size();
-        let window_based_work_area_offset = (
-            monitor.window_based_work_area_offset_limit(),
-            monitor.window_based_work_area_offset(),
-        );
-
         let focused_workspace_idx = monitor.focused_workspace_idx();
-        let offset = if monitor.work_area_offset().is_some() {
-            monitor.work_area_offset()
-        } else {
-            offset
-        };
 
         let workspace = monitor
             .workspaces_mut()
@@ -3216,7 +3193,7 @@ impl WindowManager {
 
         // If this is the focused workspace on a non-focused screen, let's update it
         if focused_monitor_idx != monitor_idx && focused_workspace_idx == workspace_idx {
-            workspace.update(&work_area, offset, window_based_work_area_offset)?;
+            workspace.update()?;
             Ok(())
         } else {
             Ok(self.update_focused_workspace(false, false)?)
@@ -3232,7 +3209,6 @@ impl WindowManager {
     ) -> Result<()> {
         tracing::info!("setting workspace layout");
 
-        let offset = self.work_area_offset;
         let focused_monitor_idx = self.focused_monitor_idx();
 
         let monitor = self
@@ -3240,18 +3216,7 @@ impl WindowManager {
             .get_mut(monitor_idx)
             .ok_or_else(|| anyhow!("there is no monitor"))?;
 
-        let work_area = *monitor.work_area_size();
-        let window_based_work_area_offset = (
-            monitor.window_based_work_area_offset_limit(),
-            monitor.window_based_work_area_offset(),
-        );
-
         let focused_workspace_idx = monitor.focused_workspace_idx();
-        let offset = if monitor.work_area_offset().is_some() {
-            monitor.work_area_offset()
-        } else {
-            offset
-        };
 
         let workspace = monitor
             .workspaces_mut()
@@ -3262,7 +3227,7 @@ impl WindowManager {
 
         // If this is the focused workspace on a non-focused screen, let's update it
         if focused_monitor_idx != monitor_idx && focused_workspace_idx == workspace_idx {
-            workspace.update(&work_area, offset, window_based_work_area_offset)?;
+            workspace.update()?;
             Ok(())
         } else {
             Ok(self.update_focused_workspace(false, false)?)
@@ -3281,7 +3246,6 @@ impl WindowManager {
     {
         tracing::info!("setting workspace layout");
         let layout = CustomLayout::from_path(path)?;
-        let offset = self.work_area_offset;
         let focused_monitor_idx = self.focused_monitor_idx();
 
         let monitor = self
@@ -3289,18 +3253,7 @@ impl WindowManager {
             .get_mut(monitor_idx)
             .ok_or_else(|| anyhow!("there is no monitor"))?;
 
-        let work_area = *monitor.work_area_size();
-        let window_based_work_area_offset = (
-            monitor.window_based_work_area_offset_limit(),
-            monitor.window_based_work_area_offset(),
-        );
-
         let focused_workspace_idx = monitor.focused_workspace_idx();
-        let offset = if monitor.work_area_offset().is_some() {
-            monitor.work_area_offset()
-        } else {
-            offset
-        };
 
         let workspace = monitor
             .workspaces_mut()
@@ -3312,7 +3265,7 @@ impl WindowManager {
 
         // If this is the focused workspace on a non-focused screen, let's update it
         if focused_monitor_idx != monitor_idx && focused_workspace_idx == workspace_idx {
-            workspace.update(&work_area, offset, window_based_work_area_offset)?;
+            workspace.update()?;
             Ok(())
         } else {
             Ok(self.update_focused_workspace(false, false)?)

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -49,6 +49,8 @@ use crate::core::WindowContainerBehaviour;
 use crate::core::WindowManagementBehaviour;
 
 use crate::border_manager;
+use crate::border_manager::BORDER_OFFSET;
+use crate::border_manager::BORDER_WIDTH;
 use crate::border_manager::STYLE;
 use crate::config_generation::WorkspaceMatchingRule;
 use crate::container::Container;
@@ -75,6 +77,7 @@ use crate::window_manager_event::WindowManagerEvent;
 use crate::windows_api::WindowsApi;
 use crate::winevent_listener;
 use crate::workspace::Workspace;
+use crate::workspace::WorkspaceLayer;
 use crate::BorderColours;
 use crate::Colour;
 use crate::CrossBoundaryBehaviour;
@@ -333,6 +336,7 @@ impl From<&WindowManager> for State {
                                 .window_container_behaviour_rules
                                 .clone(),
                             float_override: workspace.float_override,
+                            layer: workspace.layer,
                             workspace_config: None,
                         })
                         .collect::<VecDeque<_>>();
@@ -1392,86 +1396,168 @@ impl WindowManager {
         delta: i32,
         update: bool,
     ) -> Result<()> {
-        let work_area = self.focused_monitor_work_area()?;
+        let mouse_follows_focus = self.mouse_follows_focus;
+        let mut focused_monitor_work_area = self.focused_monitor_work_area()?;
         let workspace = self.focused_workspace_mut()?;
 
-        match workspace.layout() {
-            Layout::Default(layout) => {
-                tracing::info!("resizing window");
-                let len = NonZeroUsize::new(workspace.containers().len())
-                    .ok_or_else(|| anyhow!("there must be at least one container"))?;
-                let focused_idx = workspace.focused_container_idx();
-                let focused_idx_resize = workspace
-                    .resize_dimensions()
-                    .get(focused_idx)
-                    .ok_or_else(|| anyhow!("there is no resize adjustment for this container"))?;
+        match workspace.layer() {
+            WorkspaceLayer::Floating => {
+                let workspace = self.focused_workspace()?;
+                let focused_hwnd = WindowsApi::foreground_window()?;
 
-                if direction
-                    .destination(
-                        workspace.layout().as_boxed_direction().as_ref(),
-                        workspace.layout_flip(),
-                        focused_idx,
-                        len,
-                    )
-                    .is_some()
-                {
-                    let unaltered = layout.calculate(
-                        &work_area,
-                        len,
-                        workspace.container_padding(),
-                        workspace.layout_flip(),
-                        &[],
-                    );
+                let border_offset = BORDER_OFFSET.load(Ordering::SeqCst);
+                let border_width = BORDER_WIDTH.load(Ordering::SeqCst);
+                focused_monitor_work_area.left += border_offset;
+                focused_monitor_work_area.left += border_width;
+                focused_monitor_work_area.top += border_offset;
+                focused_monitor_work_area.top += border_width;
+                focused_monitor_work_area.right -= border_offset;
+                focused_monitor_work_area.right -= border_width;
+                focused_monitor_work_area.bottom -= border_offset;
+                focused_monitor_work_area.bottom -= border_width;
 
-                    let mut direction = direction;
-
-                    // We only ever want to operate on the unflipped Rect positions when resizing, then we
-                    // can flip them however they need to be flipped once the resizing has been done
-                    if let Some(flip) = workspace.layout_flip() {
-                        match flip {
-                            Axis::Horizontal => {
-                                if matches!(direction, OperationDirection::Left)
-                                    || matches!(direction, OperationDirection::Right)
-                                {
-                                    direction = direction.opposite();
+                for window in workspace.floating_windows().iter() {
+                    if window.hwnd == focused_hwnd {
+                        let mut rect = WindowsApi::window_rect(window.hwnd)?;
+                        match (direction, sizing) {
+                            (OperationDirection::Left, Sizing::Increase) => {
+                                if rect.left - delta < focused_monitor_work_area.left {
+                                    rect.left = focused_monitor_work_area.left;
+                                } else {
+                                    rect.left -= delta;
                                 }
                             }
-                            Axis::Vertical => {
-                                if matches!(direction, OperationDirection::Up)
-                                    || matches!(direction, OperationDirection::Down)
+                            (OperationDirection::Left, Sizing::Decrease) => {
+                                rect.left += delta;
+                            }
+                            (OperationDirection::Right, Sizing::Increase) => {
+                                if rect.left + rect.right + delta * 2
+                                    > focused_monitor_work_area.right
                                 {
-                                    direction = direction.opposite();
+                                    rect.right = focused_monitor_work_area.right - rect.left;
+                                } else {
+                                    rect.right += delta * 2;
                                 }
                             }
-                            Axis::HorizontalAndVertical => direction = direction.opposite(),
+                            (OperationDirection::Right, Sizing::Decrease) => {
+                                rect.right -= delta * 2;
+                            }
+                            (OperationDirection::Up, Sizing::Increase) => {
+                                if rect.top - delta < focused_monitor_work_area.top {
+                                    rect.top = focused_monitor_work_area.top;
+                                } else {
+                                    rect.top -= delta;
+                                }
+                            }
+                            (OperationDirection::Up, Sizing::Decrease) => {
+                                rect.top += delta;
+                            }
+                            (OperationDirection::Down, Sizing::Increase) => {
+                                if rect.top + rect.bottom + delta * 2
+                                    > focused_monitor_work_area.bottom
+                                {
+                                    rect.bottom = focused_monitor_work_area.bottom - rect.top;
+                                } else {
+                                    rect.bottom += delta * 2;
+                                }
+                            }
+                            (OperationDirection::Down, Sizing::Decrease) => {
+                                rect.bottom -= delta * 2;
+                            }
                         }
+
+                        WindowsApi::position_window(window.hwnd, &rect, false)?;
+                        if mouse_follows_focus {
+                            WindowsApi::center_cursor_in_rect(&rect)?;
+                        }
+
+                        break;
                     }
-
-                    let resize = layout.resize(
-                        unaltered
-                            .get(focused_idx)
-                            .ok_or_else(|| anyhow!("there is no last layout"))?,
-                        focused_idx_resize,
-                        direction,
-                        sizing,
-                        delta,
-                    );
-
-                    workspace.resize_dimensions_mut()[focused_idx] = resize;
-
-                    return if update {
-                        self.update_focused_workspace(false, false)
-                    } else {
-                        Ok(())
-                    };
                 }
-
-                tracing::warn!("cannot resize container in this direction");
             }
-            Layout::Custom(_) => {
-                tracing::warn!("containers cannot be resized when using custom layouts");
+            WorkspaceLayer::Tiling => {
+                match workspace.layout() {
+                    Layout::Default(layout) => {
+                        tracing::info!("resizing window");
+                        let len = NonZeroUsize::new(workspace.containers().len())
+                            .ok_or_else(|| anyhow!("there must be at least one container"))?;
+                        let focused_idx = workspace.focused_container_idx();
+                        let focused_idx_resize = workspace
+                            .resize_dimensions()
+                            .get(focused_idx)
+                            .ok_or_else(|| {
+                                anyhow!("there is no resize adjustment for this container")
+                            })?;
+
+                        if direction
+                            .destination(
+                                workspace.layout().as_boxed_direction().as_ref(),
+                                workspace.layout_flip(),
+                                focused_idx,
+                                len,
+                            )
+                            .is_some()
+                        {
+                            let unaltered = layout.calculate(
+                                &focused_monitor_work_area,
+                                len,
+                                workspace.container_padding(),
+                                workspace.layout_flip(),
+                                &[],
+                            );
+
+                            let mut direction = direction;
+
+                            // We only ever want to operate on the unflipped Rect positions when resizing, then we
+                            // can flip them however they need to be flipped once the resizing has been done
+                            if let Some(flip) = workspace.layout_flip() {
+                                match flip {
+                                    Axis::Horizontal => {
+                                        if matches!(direction, OperationDirection::Left)
+                                            || matches!(direction, OperationDirection::Right)
+                                        {
+                                            direction = direction.opposite();
+                                        }
+                                    }
+                                    Axis::Vertical => {
+                                        if matches!(direction, OperationDirection::Up)
+                                            || matches!(direction, OperationDirection::Down)
+                                        {
+                                            direction = direction.opposite();
+                                        }
+                                    }
+                                    Axis::HorizontalAndVertical => direction = direction.opposite(),
+                                }
+                            }
+
+                            let resize = layout.resize(
+                                unaltered
+                                    .get(focused_idx)
+                                    .ok_or_else(|| anyhow!("there is no last layout"))?,
+                                focused_idx_resize,
+                                direction,
+                                sizing,
+                                delta,
+                            );
+
+                            workspace.resize_dimensions_mut()[focused_idx] = resize;
+
+                            return if update {
+                                self.update_focused_workspace(false, false)
+                            } else {
+                                Ok(())
+                            };
+                        }
+
+                        tracing::warn!("cannot resize container in this direction");
+                    }
+                    Layout::Custom(_) => {
+                        tracing::warn!("containers cannot be resized when using custom layouts");
+                    }
+                }
             }
         }
+
         Ok(())
     }
 
@@ -1861,6 +1947,56 @@ impl WindowManager {
     }
 
     #[tracing::instrument(skip(self))]
+    pub fn focus_floating_window_in_direction(
+        &mut self,
+        direction: OperationDirection,
+    ) -> Result<()> {
+        let mouse_follows_focus = self.mouse_follows_focus;
+        let focused_workspace = self.focused_workspace()?;
+
+        let mut target_idx = None;
+        let len = focused_workspace.floating_windows().len();
+
+        if len > 1 {
+            let focused_hwnd = WindowsApi::foreground_window()?;
+            for (idx, window) in focused_workspace.floating_windows().iter().enumerate() {
+                if window.hwnd == focused_hwnd {
+                    match direction {
+                        OperationDirection::Left => {}
+                        OperationDirection::Right => {}
+                        OperationDirection::Up => {
+                            if idx == len - 1 {
+                                target_idx = Some(0)
+                            } else {
+                                target_idx = Some(idx + 1)
+                            }
+                        }
+                        OperationDirection::Down => {
+                            if idx == 0 {
+                                target_idx = Some(len - 1)
+                            } else {
+                                target_idx = Some(idx - 1)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if target_idx.is_none() {
+                target_idx = Some(0);
+            }
+        }
+
+        if let Some(idx) = target_idx {
+            if let Some(window) = focused_workspace.floating_windows().get(idx) {
+                window.focus(mouse_follows_focus)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
     pub fn focus_container_in_direction(&mut self, direction: OperationDirection) -> Result<()> {
         self.handle_unmanaged_window_behaviour()?;
 
@@ -1999,6 +2135,75 @@ impl WindowManager {
         if !cross_monitor_monocle_or_max {
             if let Ok(focused_window) = self.focused_window_mut() {
                 focused_window.focus(self.mouse_follows_focus)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub fn move_floating_window_in_direction(
+        &mut self,
+        direction: OperationDirection,
+    ) -> Result<()> {
+        let mouse_follows_focus = self.mouse_follows_focus;
+
+        let mut focused_monitor_work_area = self.focused_monitor_work_area()?;
+        let border_offset = BORDER_OFFSET.load(Ordering::SeqCst);
+        let border_width = BORDER_WIDTH.load(Ordering::SeqCst);
+        focused_monitor_work_area.left += border_offset;
+        focused_monitor_work_area.left += border_width;
+        focused_monitor_work_area.top += border_offset;
+        focused_monitor_work_area.top += border_width;
+        focused_monitor_work_area.right -= border_offset;
+        focused_monitor_work_area.right -= border_width;
+        focused_monitor_work_area.bottom -= border_offset;
+        focused_monitor_work_area.bottom -= border_width;
+
+        let focused_workspace = self.focused_workspace()?;
+        let delta = self.resize_delta;
+
+        let focused_hwnd = WindowsApi::foreground_window()?;
+        for window in focused_workspace.floating_windows().iter() {
+            if window.hwnd == focused_hwnd {
+                let mut rect = WindowsApi::window_rect(window.hwnd)?;
+                match direction {
+                    OperationDirection::Left => {
+                        if rect.left - delta < focused_monitor_work_area.left {
+                            rect.left = focused_monitor_work_area.left;
+                        } else {
+                            rect.left -= delta;
+                        }
+                    }
+                    OperationDirection::Right => {
+                        if rect.left + delta + rect.right > focused_monitor_work_area.right {
+                            rect.left = focused_monitor_work_area.right - rect.right;
+                        } else {
+                            rect.left += delta;
+                        }
+                    }
+                    OperationDirection::Up => {
+                        if rect.top - delta < focused_monitor_work_area.top {
+                            rect.top = focused_monitor_work_area.top;
+                        } else {
+                            rect.top -= delta;
+                        }
+                    }
+                    OperationDirection::Down => {
+                        if rect.top + delta + rect.bottom > focused_monitor_work_area.bottom {
+                            rect.top = focused_monitor_work_area.bottom - rect.bottom;
+                        } else {
+                            rect.top += delta;
+                        }
+                    }
+                }
+
+                WindowsApi::position_window(window.hwnd, &rect, false)?;
+                if mouse_follows_focus {
+                    WindowsApi::center_cursor_in_rect(&rect)?;
+                }
+
+                break;
             }
         }
 
@@ -2177,6 +2382,54 @@ impl WindowManager {
         }
 
         self.update_focused_workspace(self.mouse_follows_focus, true)?;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub fn focus_floating_window_in_cycle_direction(
+        &mut self,
+        direction: CycleDirection,
+    ) -> Result<()> {
+        let mouse_follows_focus = self.mouse_follows_focus;
+        let focused_workspace = self.focused_workspace()?;
+
+        let mut target_idx = None;
+        let len = focused_workspace.floating_windows().len();
+
+        if len > 1 {
+            let focused_hwnd = WindowsApi::foreground_window()?;
+            for (idx, window) in focused_workspace.floating_windows().iter().enumerate() {
+                if window.hwnd == focused_hwnd {
+                    match direction {
+                        CycleDirection::Previous => {
+                            if idx == 0 {
+                                target_idx = Some(len - 1)
+                            } else {
+                                target_idx = Some(idx - 1)
+                            }
+                        }
+                        CycleDirection::Next => {
+                            if idx == len - 1 {
+                                target_idx = Some(0)
+                            } else {
+                                target_idx = Some(idx - 1)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if target_idx.is_none() {
+                target_idx = Some(0);
+            }
+        }
+
+        if let Some(idx) = target_idx {
+            if let Some(window) = focused_workspace.floating_windows().get(idx) {
+                window.focus(mouse_follows_focus)?;
+            }
+        }
 
         Ok(())
     }
@@ -2528,8 +2781,10 @@ impl WindowManager {
         }
 
         if is_floating_window {
+            workspace.set_layer(WorkspaceLayer::Tiling);
             self.unfloat_window()?;
         } else {
+            workspace.set_layer(WorkspaceLayer::Floating);
             self.float_window()?;
         }
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::env::temp_dir;
+use std::fs::OpenOptions;
 use std::io::ErrorKind;
 use std::net::Shutdown;
 use std::num::NonZeroUsize;
@@ -117,7 +118,8 @@ pub struct WindowManager {
     pub pending_move_op: Arc<Option<(usize, usize, isize)>>,
     pub already_moved_window_handles: Arc<Mutex<HashSet<isize>>>,
     pub uncloack_to_ignore: usize,
-    pub known_hwnds: Vec<isize>,
+    /// Maps each known window hwnd to the (monitor, workspace) index pair managing it
+    pub known_hwnds: HashMap<isize, (usize, usize)>,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -424,7 +426,7 @@ impl WindowManager {
             pending_move_op: Arc::new(None),
             already_moved_window_handles: Arc::new(Mutex::new(HashSet::new())),
             uncloack_to_ignore: 0,
-            known_hwnds: Vec::new(),
+            known_hwnds: HashMap::new(),
         })
     }
 
@@ -3360,5 +3362,67 @@ impl WindowManager {
         self.focused_container_mut()?
             .focused_window_mut()
             .ok_or_else(|| anyhow!("there is no window"))
+    }
+
+    /// Updates the list of `known_hwnds` and their monitor/workspace index pair
+    ///
+    /// [`known_hwnds`]: `Self.known_hwnds`
+    pub fn update_known_hwnds(&mut self) {
+        tracing::trace!("updating list of known hwnds");
+        let mut known_hwnds = HashMap::new();
+        for (m_idx, monitor) in self.monitors().iter().enumerate() {
+            for (w_idx, workspace) in monitor.workspaces().iter().enumerate() {
+                for container in workspace.containers() {
+                    for window in container.windows() {
+                        known_hwnds.insert(window.hwnd, (m_idx, w_idx));
+                    }
+                }
+
+                for window in workspace.floating_windows() {
+                    known_hwnds.insert(window.hwnd, (m_idx, w_idx));
+                }
+
+                if let Some(window) = workspace.maximized_window() {
+                    known_hwnds.insert(window.hwnd, (m_idx, w_idx));
+                }
+
+                if let Some(container) = workspace.monocle_container() {
+                    for window in container.windows() {
+                        known_hwnds.insert(window.hwnd, (m_idx, w_idx));
+                    }
+                }
+            }
+        }
+
+        if self.known_hwnds != known_hwnds {
+            // Update reaper cache
+            {
+                let mut reaper_cache = crate::reaper::HWNDS_CACHE.lock();
+                *reaper_cache = known_hwnds.clone();
+            }
+
+            // Save to file
+            let hwnd_json = DATA_DIR.join("komorebi.hwnd.json");
+            match OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .create(true)
+                .open(hwnd_json)
+            {
+                Ok(file) => {
+                    if let Err(error) =
+                        serde_json::to_writer_pretty(&file, &known_hwnds.keys().collect::<Vec<_>>())
+                    {
+                        tracing::error!("Failed to save list of known_hwnds on file: {}", error);
+                    }
+                }
+                Err(error) => {
+                    tracing::error!("Failed to save list of known_hwnds on file: {}", error);
+                }
+            }
+
+            // Store new hwnds
+            self.known_hwnds = known_hwnds;
+        }
     }
 }

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -109,6 +109,7 @@ use windows::Win32::UI::WindowsAndMessaging::GWL_EXSTYLE;
 use windows::Win32::UI::WindowsAndMessaging::GWL_STYLE;
 use windows::Win32::UI::WindowsAndMessaging::GW_HWNDNEXT;
 use windows::Win32::UI::WindowsAndMessaging::HDEVNOTIFY;
+use windows::Win32::UI::WindowsAndMessaging::HWND_BOTTOM;
 use windows::Win32::UI::WindowsAndMessaging::HWND_TOP;
 use windows::Win32::UI::WindowsAndMessaging::LWA_ALPHA;
 use windows::Win32::UI::WindowsAndMessaging::REGISTER_NOTIFICATION_FLAGS;
@@ -477,12 +478,32 @@ impl WindowsApi {
         unsafe { BringWindowToTop(HWND(as_ptr!(hwnd))) }.process()
     }
 
-    // Raise the window to the top of the Z order, but do not activate or focus
-    // it. Use raise_and_focus_window to activate and focus a window.
+    /// Raise the window to the top of the Z order, but do not activate or focus
+    /// it. Use raise_and_focus_window to activate and focus a window.
     pub fn raise_window(hwnd: isize) -> Result<()> {
-        let flags = SetWindowPosition::NO_MOVE | SetWindowPosition::NO_ACTIVATE;
+        let flags = SetWindowPosition::NO_MOVE
+            | SetWindowPosition::NO_SIZE
+            | SetWindowPosition::NO_ACTIVATE
+            | SetWindowPosition::SHOW_WINDOW;
 
         let position = HWND_TOP;
+        Self::set_window_pos(
+            HWND(as_ptr!(hwnd)),
+            &Rect::default(),
+            position,
+            flags.bits(),
+        )
+    }
+
+    /// Lower the window to the bottom of the Z order, but do not activate or focus
+    /// it.
+    pub fn lower_window(hwnd: isize) -> Result<()> {
+        let flags = SetWindowPosition::NO_MOVE
+            | SetWindowPosition::NO_SIZE
+            | SetWindowPosition::NO_ACTIVATE
+            | SetWindowPosition::SHOW_WINDOW;
+
+        let position = HWND_BOTTOM;
         Self::set_window_pos(
             HWND(as_ptr!(hwnd)),
             &Rect::default(),

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -303,7 +303,7 @@ impl Workspace {
         // Maximised windows and floating windows should always be drawn at the top of the Z order
         // when switching to a workspace
         if let Some(window) = to_focus {
-            if self.maximized_window().is_none() && self.floating_windows().is_empty() {
+            if self.maximized_window().is_none() && matches!(self.layer, WorkspaceLayer::Tiling) {
                 window.focus(mouse_follows_focus)?;
             } else if let Some(maximized_window) = self.maximized_window() {
                 maximized_window.focus(mouse_follows_focus)?;

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -1,4 +1,6 @@
 use std::collections::VecDeque;
+use std::fmt::Display;
+use std::fmt::Formatter;
 use std::num::NonZeroUsize;
 use std::sync::atomic::Ordering;
 
@@ -92,9 +94,27 @@ pub struct Workspace {
     pub window_container_behaviour_rules: Option<Vec<(usize, WindowContainerBehaviour)>>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     pub float_override: Option<bool>,
+    #[getset(get = "pub", get_mut = "pub", set = "pub")]
+    pub layer: WorkspaceLayer,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
     pub workspace_config: Option<WorkspaceConfig>,
+}
+
+#[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub enum WorkspaceLayer {
+    #[default]
+    Tiling,
+    Floating,
+}
+
+impl Display for WorkspaceLayer {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkspaceLayer::Tiling => write!(f, "Tiling"),
+            WorkspaceLayer::Floating => write!(f, "Floating"),
+        }
+    }
 }
 
 impl_ring_elements!(Workspace, Container);
@@ -122,6 +142,7 @@ impl Default for Workspace {
             window_container_behaviour_rules: None,
             float_override: None,
             workspace_config: None,
+            layer: Default::default(),
         }
     }
 }

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -1269,6 +1269,8 @@ enum SubCommand {
     /// mode, for the currently focused workspace. If there was no override value set for the
     /// workspace previously it takes the opposite of the global value.
     ToggleWorkspaceFloatOverride,
+    /// Toggle between the Tiling and Floating layers on the focused workspace
+    ToggleWorkspaceLayer,
     /// Toggle window tiling on the focused workspace
     TogglePause,
     /// Toggle window tiling on the focused workspace
@@ -2853,6 +2855,9 @@ if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
         }
         SubCommand::ToggleWorkspaceFloatOverride => {
             send_message(&SocketMessage::ToggleWorkspaceFloatOverride)?;
+        }
+        SubCommand::ToggleWorkspaceLayer => {
+            send_message(&SocketMessage::ToggleWorkspaceLayer)?;
         }
         SubCommand::WindowHidingBehaviour(arg) => {
             send_message(&SocketMessage::WindowHidingBehaviour(arg.hiding_behaviour))?;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -177,6 +177,7 @@ nav:
       - cli/toggle-float-override.md
       - cli/toggle-workspace-window-container-behaviour.md
       - cli/toggle-workspace-float-override.md
+      - cli/toggle-workspace-layer.md
       - cli/toggle-pause.md
       - cli/toggle-tiling.md
       - cli/toggle-float.md

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -529,39 +529,73 @@
                         "description": "Display format of the workspace",
                         "oneOf": [
                           {
-                            "description": "Show only icon",
+                            "description": "Show all icons only",
                             "type": "string",
                             "enum": [
-                              "Icon"
+                              "AllIcons"
                             ]
                           },
                           {
-                            "description": "Show only text",
+                            "description": "Show both all icons and text",
                             "type": "string",
                             "enum": [
-                              "Text"
+                              "AllIconsAndText"
                             ]
                           },
                           {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "description": "Show all icons and text for the selected element, and all icons on the rest",
                             "type": "string",
                             "enum": [
-                              "TextAndIconOnSelected"
+                              "AllIconsAndTextOnSelected"
                             ]
                           },
                           {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
+                            "type": "object",
+                            "required": [
+                              "Existing"
+                            ],
+                            "properties": {
+                              "Existing": {
+                                "oneOf": [
+                                  {
+                                    "description": "Show only icon",
+                                    "type": "string",
+                                    "enum": [
+                                      "Icon"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show only text",
+                                    "type": "string",
+                                    "enum": [
+                                      "Text"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and text on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "TextAndIconOnSelected"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show both icon and text",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndText"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and icons on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndTextOnSelected"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
                           }
                         ]
                       },
@@ -1849,39 +1883,73 @@
                         "description": "Display format of the workspace",
                         "oneOf": [
                           {
-                            "description": "Show only icon",
+                            "description": "Show all icons only",
                             "type": "string",
                             "enum": [
-                              "Icon"
+                              "AllIcons"
                             ]
                           },
                           {
-                            "description": "Show only text",
+                            "description": "Show both all icons and text",
                             "type": "string",
                             "enum": [
-                              "Text"
+                              "AllIconsAndText"
                             ]
                           },
                           {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "description": "Show all icons and text for the selected element, and all icons on the rest",
                             "type": "string",
                             "enum": [
-                              "TextAndIconOnSelected"
+                              "AllIconsAndTextOnSelected"
                             ]
                           },
                           {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
+                            "type": "object",
+                            "required": [
+                              "Existing"
+                            ],
+                            "properties": {
+                              "Existing": {
+                                "oneOf": [
+                                  {
+                                    "description": "Show only icon",
+                                    "type": "string",
+                                    "enum": [
+                                      "Icon"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show only text",
+                                    "type": "string",
+                                    "enum": [
+                                      "Text"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and text on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "TextAndIconOnSelected"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show both icon and text",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndText"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and icons on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndTextOnSelected"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
                           }
                         ]
                       },
@@ -3102,39 +3170,73 @@
                         "description": "Display format of the workspace",
                         "oneOf": [
                           {
-                            "description": "Show only icon",
+                            "description": "Show all icons only",
                             "type": "string",
                             "enum": [
-                              "Icon"
+                              "AllIcons"
                             ]
                           },
                           {
-                            "description": "Show only text",
+                            "description": "Show both all icons and text",
                             "type": "string",
                             "enum": [
-                              "Text"
+                              "AllIconsAndText"
                             ]
                           },
                           {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "description": "Show all icons and text for the selected element, and all icons on the rest",
                             "type": "string",
                             "enum": [
-                              "TextAndIconOnSelected"
+                              "AllIconsAndTextOnSelected"
                             ]
                           },
                           {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
+                            "type": "object",
+                            "required": [
+                              "Existing"
+                            ],
+                            "properties": {
+                              "Existing": {
+                                "oneOf": [
+                                  {
+                                    "description": "Show only icon",
+                                    "type": "string",
+                                    "enum": [
+                                      "Icon"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show only text",
+                                    "type": "string",
+                                    "enum": [
+                                      "Text"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and text on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "TextAndIconOnSelected"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show both icon and text",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndText"
+                                    ]
+                                  },
+                                  {
+                                    "description": "Show an icon and text for the selected element, and icons on the rest",
+                                    "type": "string",
+                                    "enum": [
+                                      "IconAndTextOnSelected"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
                           }
                         ]
                       },

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -504,6 +504,19 @@
                       }
                     }
                   },
+                  "workspace_layer": {
+                    "description": "Configure the Workspace Layer widget",
+                    "type": "object",
+                    "required": [
+                      "enable"
+                    ],
+                    "properties": {
+                      "enable": {
+                        "description": "Enable the Komorebi Workspace Layer widget",
+                        "type": "boolean"
+                      }
+                    }
+                  },
                   "workspaces": {
                     "description": "Configure the Workspaces widget",
                     "type": "object",
@@ -1811,6 +1824,19 @@
                       }
                     }
                   },
+                  "workspace_layer": {
+                    "description": "Configure the Workspace Layer widget",
+                    "type": "object",
+                    "required": [
+                      "enable"
+                    ],
+                    "properties": {
+                      "enable": {
+                        "description": "Enable the Komorebi Workspace Layer widget",
+                        "type": "boolean"
+                      }
+                    }
+                  },
                   "workspaces": {
                     "description": "Configure the Workspaces widget",
                     "type": "object",
@@ -3048,6 +3074,19 @@
                             }
                           ]
                         }
+                      }
+                    }
+                  },
+                  "workspace_layer": {
+                    "description": "Configure the Workspace Layer widget",
+                    "type": "object",
+                    "required": [
+                      "enable"
+                    ],
+                    "properties": {
+                      "enable": {
+                        "description": "Enable the Komorebi Workspace Layer widget",
+                        "type": "boolean"
                       }
                     }
                   },

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -511,8 +511,52 @@
                       "enable"
                     ],
                     "properties": {
+                      "display": {
+                        "description": "Display format of the current layer",
+                        "oneOf": [
+                          {
+                            "description": "Show only icon",
+                            "type": "string",
+                            "enum": [
+                              "Icon"
+                            ]
+                          },
+                          {
+                            "description": "Show only text",
+                            "type": "string",
+                            "enum": [
+                              "Text"
+                            ]
+                          },
+                          {
+                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "type": "string",
+                            "enum": [
+                              "TextAndIconOnSelected"
+                            ]
+                          },
+                          {
+                            "description": "Show both icon and text",
+                            "type": "string",
+                            "enum": [
+                              "IconAndText"
+                            ]
+                          },
+                          {
+                            "description": "Show an icon and text for the selected element, and icons on the rest",
+                            "type": "string",
+                            "enum": [
+                              "IconAndTextOnSelected"
+                            ]
+                          }
+                        ]
+                      },
                       "enable": {
                         "description": "Enable the Komorebi Workspace Layer widget",
+                        "type": "boolean"
+                      },
+                      "show_when_tiling": {
+                        "description": "Show the widget event if the layer is Tiling",
                         "type": "boolean"
                       }
                     }
@@ -1865,8 +1909,52 @@
                       "enable"
                     ],
                     "properties": {
+                      "display": {
+                        "description": "Display format of the current layer",
+                        "oneOf": [
+                          {
+                            "description": "Show only icon",
+                            "type": "string",
+                            "enum": [
+                              "Icon"
+                            ]
+                          },
+                          {
+                            "description": "Show only text",
+                            "type": "string",
+                            "enum": [
+                              "Text"
+                            ]
+                          },
+                          {
+                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "type": "string",
+                            "enum": [
+                              "TextAndIconOnSelected"
+                            ]
+                          },
+                          {
+                            "description": "Show both icon and text",
+                            "type": "string",
+                            "enum": [
+                              "IconAndText"
+                            ]
+                          },
+                          {
+                            "description": "Show an icon and text for the selected element, and icons on the rest",
+                            "type": "string",
+                            "enum": [
+                              "IconAndTextOnSelected"
+                            ]
+                          }
+                        ]
+                      },
                       "enable": {
                         "description": "Enable the Komorebi Workspace Layer widget",
+                        "type": "boolean"
+                      },
+                      "show_when_tiling": {
+                        "description": "Show the widget event if the layer is Tiling",
                         "type": "boolean"
                       }
                     }
@@ -3152,8 +3240,52 @@
                       "enable"
                     ],
                     "properties": {
+                      "display": {
+                        "description": "Display format of the current layer",
+                        "oneOf": [
+                          {
+                            "description": "Show only icon",
+                            "type": "string",
+                            "enum": [
+                              "Icon"
+                            ]
+                          },
+                          {
+                            "description": "Show only text",
+                            "type": "string",
+                            "enum": [
+                              "Text"
+                            ]
+                          },
+                          {
+                            "description": "Show an icon and text for the selected element, and text on the rest",
+                            "type": "string",
+                            "enum": [
+                              "TextAndIconOnSelected"
+                            ]
+                          },
+                          {
+                            "description": "Show both icon and text",
+                            "type": "string",
+                            "enum": [
+                              "IconAndText"
+                            ]
+                          },
+                          {
+                            "description": "Show an icon and text for the selected element, and icons on the rest",
+                            "type": "string",
+                            "enum": [
+                              "IconAndTextOnSelected"
+                            ]
+                          }
+                        ]
+                      },
                       "enable": {
                         "description": "Enable the Komorebi Workspace Layer widget",
+                        "type": "boolean"
+                      },
+                      "show_when_tiling": {
+                        "description": "Show the widget event if the layer is Tiling",
                         "type": "boolean"
                       }
                     }

--- a/schema.json
+++ b/schema.json
@@ -1075,6 +1075,11 @@
           "workspaces"
         ],
         "properties": {
+          "container_padding": {
+            "description": "Container padding (default: global)",
+            "type": "integer",
+            "format": "int32"
+          },
           "window_based_work_area_offset": {
             "description": "Window based work area offset (default: None)",
             "type": "object",
@@ -1143,6 +1148,11 @@
                 "format": "int32"
               }
             }
+          },
+          "workspace_padding": {
+            "description": "Workspace padding (default: global)",
+            "type": "integer",
+            "format": "int32"
           },
           "workspaces": {
             "description": "Workspace configurations",
@@ -1346,7 +1356,7 @@
                   }
                 },
                 "workspace_padding": {
-                  "description": "Container padding (default: global)",
+                  "description": "Workspace padding (default: global)",
                   "type": "integer",
                   "format": "int32"
                 },


### PR DESCRIPTION
This commits adds the ability to set icons for the `workspace-layer` with the `DisplayFormat` and a setting to specify if it should `show_when_tiling` or not.

collab with @alex-ds13


https://github.com/user-attachments/assets/cc3e95dd-ffe7-48df-a8b7-5a718170ed77



