### PR TITLE
perf(cargo): make schemars derives optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,16 +72,3 @@ features = [
     "Media",
     "Media_Control"
 ]
-
-[profile.dev-jeezy]
-inherits = "dev"
-debug = false
-opt-level = 1
-
-[profile.dev-jeezy.package."*"]
-opt-level = 3
-
-[profile.release-jeezy]
-inherits = "release"
-incremental = true
-codegen-units = 256

--- a/justfile
+++ b/justfile
@@ -19,22 +19,31 @@ install-targets *targets:
     "{{ targets }}" -split ' ' | ForEach-Object { just install-target $_ }
 
 install-target target:
+    cargo +stable install --path {{ target }} --locked --no-default-features
+
+install-targets-with-jsonschema *targets:
+    "{{ targets }}" -split ' ' | ForEach-Object { just install-target-with-jsonschema $_ }
+
+install-target-with-jsonschema target:
     cargo +stable install --path {{ target }} --locked
 
 install:
     just install-targets komorebic komorebic-no-console komorebi komorebi-bar komorebi-gui
 
+install-with-jsonschema:
+    just install-targets-with-jsonschema komorebic komorebic-no-console komorebi komorebi-bar komorebi-gui
+
 build-targets *targets:
     "{{ targets }}" -split ' ' | ForEach-Object { just build-target $_ }
 
 build-target target:
-    cargo +stable build --package {{ target }} --locked --profile release-jeezy
+    cargo +stable build --package {{ target }} --locked --release --no-default-features
 
 build:
     just build-targets komorebic komorebic-no-console komorebi komorebi-bar komorebi-gui
 
 copy-target target:
-    cp .\target\release-jeezy\{{ target }}.exe $Env:USERPROFILE\.cargo\bin
+    cp .\target\release\{{ target }}.exe $Env:USERPROFILE\.cargo\bin
 
 copy-targets *targets:
     "{{ targets }}" -split ' ' | ForEach-Object { just copy-target $_ }
@@ -46,7 +55,7 @@ copy:
     just copy-targets komorebic komorebic-no-console komorebi komorebi-bar komorebi-gui
 
 run target:
-    cargo +stable run --bin {{ target }} --locked
+    cargo +stable run --bin {{ target }} --locked --no-default-features
 
 warn target $RUST_LOG="warn":
     just run {{ target }}
@@ -61,7 +70,7 @@ trace target $RUST_LOG="trace":
     just run {{ target }}
 
 deadlock $RUST_LOG="trace":
-    cargo +stable run --bin komorebi --locked --features deadlock_detection
+    cargo +stable run --bin komorebi --locked --no-default-features --features deadlock_detection
 
 docgen:
     cargo run --package komorebic -- docgen

--- a/komorebi-bar/Cargo.toml
+++ b/komorebi-bar/Cargo.toml
@@ -26,7 +26,7 @@ num-derive = "0.4"
 num-traits = "0.2"
 random_word = { version = "0.4", features = ["en"] }
 reqwest = { version = "0.12", features = ["blocking"] }
-schemars = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 starship-battery = "0.10"
@@ -36,3 +36,7 @@ tracing-subscriber = { workspace = true }
 windows = { workspace = true }
 windows-core = { workspace = true }
 windows-icons = { git = "https://github.com/LGUG2Z/windows-icons", rev = "d67cc9920aa9b4883393e411fb4fa2ddd4c498b5" }
+
+[features]
+default = ["schemars"]
+schemars = ["dep:schemars"]

--- a/komorebi-bar/src/battery.rs
+++ b/komorebi-bar/src/battery.rs
@@ -8,7 +8,6 @@ use eframe::egui::Context;
 use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use starship_battery::units::ratio::percent;
@@ -18,7 +17,8 @@ use std::process::Command;
 use std::time::Duration;
 use std::time::Instant;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BatteryConfig {
     /// Enable the Battery widget
     pub enable: bool,

--- a/komorebi-bar/src/config.rs
+++ b/komorebi-bar/src/config.rs
@@ -6,13 +6,13 @@ use eframe::egui::TextBuffer;
 use eframe::egui::Vec2;
 use komorebi_client::KomorebiTheme;
 use komorebi_client::Rect;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 /// The `komorebi.bar.json` configuration file reference for `v0.1.35`
 pub struct KomobarConfig {
     /// Bar height (default: 50)
@@ -136,7 +136,8 @@ impl KomobarConfig {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct PositionConfig {
     /// The desired starting position of the bar (0,0 = top left of the screen)
     #[serde(alias = "position")]
@@ -146,13 +147,15 @@ pub struct PositionConfig {
     pub end: Option<Position>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct FrameConfig {
     /// Margin inside the painted frame
     pub inner_margin: Position,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum MonitorConfigOrIndex {
     /// The monitor index where you want the bar to show
@@ -161,7 +164,8 @@ pub enum MonitorConfigOrIndex {
     MonitorConfig(MonitorConfig),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MonitorConfig {
     /// Komorebi monitor index of the monitor on which to render the bar
     pub index: usize,
@@ -172,7 +176,8 @@ pub struct MonitorConfig {
 pub type Padding = SpacingKind;
 pub type Margin = SpacingKind;
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 // WARNING: To any developer messing with this code in the future: The order here matters!
 // `Grouped` needs to come last, otherwise serde might mistaken an `IndividualSpacingConfig` for a
@@ -223,20 +228,23 @@ impl SpacingKind {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct GroupedSpacingConfig {
     pub vertical: Option<GroupedSpacingOptions>,
     pub horizontal: Option<GroupedSpacingOptions>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum GroupedSpacingOptions {
     Symmetrical(f32),
     Split(f32, f32),
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct IndividualSpacingConfig {
     pub top: f32,
     pub bottom: f32,
@@ -338,7 +346,8 @@ impl KomobarConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Position {
     /// X coordinate
     pub x: f32,
@@ -364,7 +373,8 @@ impl From<Position> for Pos2 {
     }
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "palette")]
 pub enum KomobarTheme {
     /// A theme from catppuccin-egui
@@ -400,7 +410,8 @@ impl From<KomorebiTheme> for KomobarTheme {
     }
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum LabelPrefix {
     /// Show no prefix
     None,
@@ -412,7 +423,8 @@ pub enum LabelPrefix {
     IconAndText,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum DisplayFormat {
     /// Show only icon
     Icon,
@@ -428,7 +440,8 @@ pub enum DisplayFormat {
 
 macro_rules! extend_enum {
     ($existing_enum:ident, $new_enum:ident, { $($(#[$meta:meta])* $variant:ident),* $(,)? }) => {
-        #[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema, PartialEq)]
+        #[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+        #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
         pub enum $new_enum {
             // Add new variants
             $(
@@ -460,12 +473,11 @@ extend_enum!(DisplayFormat, WorkspacesDisplayFormat, {
 
 #[cfg(test)]
 mod tests {
-    use schemars::JsonSchema;
     use serde::Deserialize;
     use serde::Serialize;
     use serde_json::json;
 
-    #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+    #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
     pub enum OriginalDisplayFormat {
         /// Show None Of The Things
         NoneOfTheThings,

--- a/komorebi-bar/src/cpu.rs
+++ b/komorebi-bar/src/cpu.rs
@@ -8,7 +8,6 @@ use eframe::egui::Context;
 use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::process::Command;
@@ -17,7 +16,8 @@ use std::time::Instant;
 use sysinfo::RefreshKind;
 use sysinfo::System;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CpuConfig {
     /// Enable the Cpu widget
     pub enable: bool,

--- a/komorebi-bar/src/date.rs
+++ b/komorebi-bar/src/date.rs
@@ -9,12 +9,12 @@ use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
 use eframe::egui::WidgetText;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
 /// Custom format with additive modifiers for integer format specifiers
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CustomModifiers {
     /// Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)
     format: String,
@@ -55,7 +55,8 @@ impl CustomModifiers {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct DateConfig {
     /// Enable the Date widget
     pub enable: bool,
@@ -75,7 +76,8 @@ impl From<DateConfig> for Date {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum DateFormat {
     /// Month/Date/Year format (09/08/24)
     MonthDateYear,

--- a/komorebi-bar/src/keyboard.rs
+++ b/komorebi-bar/src/keyboard.rs
@@ -8,7 +8,6 @@ use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
 use eframe::egui::WidgetText;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::time::Duration;
@@ -23,7 +22,8 @@ use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
 const DEFAULT_DATA_REFRESH_INTERVAL: u64 = 1;
 const ERROR_TEXT: &str = "Error";
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KeyboardConfig {
     /// Enable the Input widget
     pub enable: bool,

--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -37,7 +37,6 @@ use komorebi_client::SocketMessage;
 use komorebi_client::Window;
 use komorebi_client::Workspace;
 use komorebi_client::WorkspaceLayer;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::cell::RefCell;
@@ -47,7 +46,8 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KomorebiConfig {
     /// Configure the Workspaces widget
     pub workspaces: Option<KomorebiWorkspacesConfig>,
@@ -61,7 +61,8 @@ pub struct KomorebiConfig {
     pub configuration_switcher: Option<KomorebiConfigurationSwitcherConfig>,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KomorebiWorkspacesConfig {
     /// Enable the Komorebi Workspaces widget
     pub enable: bool,
@@ -71,7 +72,8 @@ pub struct KomorebiWorkspacesConfig {
     pub display: Option<WorkspacesDisplayFormat>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KomorebiLayoutConfig {
     /// Enable the Komorebi Layout widget
     pub enable: bool,
@@ -81,7 +83,8 @@ pub struct KomorebiLayoutConfig {
     pub display: Option<DisplayFormat>,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KomorebiWorkspaceLayerConfig {
     /// Enable the Komorebi Workspace Layer widget
     pub enable: bool,
@@ -91,7 +94,8 @@ pub struct KomorebiWorkspaceLayerConfig {
     pub show_when_tiling: Option<bool>,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KomorebiFocusedWindowConfig {
     /// Enable the Komorebi Focused Window widget
     pub enable: bool,
@@ -101,7 +105,8 @@ pub struct KomorebiFocusedWindowConfig {
     pub display: Option<DisplayFormat>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct KomorebiConfigurationSwitcherConfig {
     /// Enable the Komorebi Configurations widget
     pub enable: bool,

--- a/komorebi-bar/src/komorebi_layout.rs
+++ b/komorebi-bar/src/komorebi_layout.rs
@@ -14,7 +14,6 @@ use eframe::egui::StrokeKind;
 use eframe::egui::Ui;
 use eframe::egui::Vec2;
 use komorebi_client::SocketMessage;
-use schemars::JsonSchema;
 use serde::de::Error;
 use serde::Deserialize;
 use serde::Deserializer;
@@ -23,7 +22,8 @@ use serde_json::from_str;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
-#[derive(Copy, Clone, Debug, Serialize, JsonSchema, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum KomorebiLayout {
     Default(komorebi_client::DefaultLayout),

--- a/komorebi-bar/src/main.rs
+++ b/komorebi-bar/src/main.rs
@@ -30,7 +30,6 @@ use hotwatch::Hotwatch;
 use image::RgbaImage;
 use komorebi_client::SocketMessage;
 use komorebi_client::SubscribeOptions;
-use schemars::gen::SchemaSettings;
 use std::collections::HashMap;
 use std::io::BufReader;
 use std::io::Read;
@@ -125,8 +124,9 @@ fn main() -> color_eyre::Result<()> {
 
     let opts: Opts = Opts::parse();
 
+    #[cfg(feature = "schemars")]
     if opts.schema {
-        let settings = SchemaSettings::default().with(|s| {
+        let settings = schemars::gen::SchemaSettings::default().with(|s| {
             s.option_nullable = false;
             s.option_add_null_type = false;
             s.inline_subschemas = true;

--- a/komorebi-bar/src/media.rs
+++ b/komorebi-bar/src/media.rs
@@ -10,13 +10,13 @@ use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
 use eframe::egui::Vec2;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::atomic::Ordering;
 use windows::Media::Control::GlobalSystemMediaTransportControlsSessionManager;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MediaConfig {
     /// Enable the Media widget
     pub enable: bool,

--- a/komorebi-bar/src/memory.rs
+++ b/komorebi-bar/src/memory.rs
@@ -8,7 +8,6 @@ use eframe::egui::Context;
 use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::process::Command;
@@ -17,7 +16,8 @@ use std::time::Instant;
 use sysinfo::RefreshKind;
 use sysinfo::System;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct MemoryConfig {
     /// Enable the Memory widget
     pub enable: bool,

--- a/komorebi-bar/src/network.rs
+++ b/komorebi-bar/src/network.rs
@@ -9,7 +9,6 @@ use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
 use num_derive::FromPrimitive;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
@@ -18,7 +17,8 @@ use std::time::Duration;
 use std::time::Instant;
 use sysinfo::Networks;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct NetworkConfig {
     /// Enable the Network widget
     pub enable: bool,

--- a/komorebi-bar/src/render.rs
+++ b/komorebi-bar/src/render.rs
@@ -11,7 +11,6 @@ use eframe::egui::Margin;
 use eframe::egui::Shadow;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::atomic::AtomicUsize;
@@ -20,7 +19,8 @@ use std::sync::Arc;
 
 static SHOW_KOMOREBI_LAYOUT_OPTIONS: AtomicUsize = AtomicUsize::new(0);
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "kind")]
 pub enum Grouping {
     /// No grouping is applied
@@ -339,7 +339,8 @@ impl RenderConfig {
     }
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct GroupingConfig {
     /// Styles for the grouping
     pub style: Option<GroupingStyle>,
@@ -349,7 +350,8 @@ pub struct GroupingConfig {
     pub rounding: Option<RoundingConfig>,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum GroupingStyle {
     #[serde(alias = "CtByte")]
     Default,
@@ -369,7 +371,8 @@ pub enum GroupingStyle {
     DefaultWithGlowB0O1S2,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum RoundingConfig {
     /// All 4 corners are the same    

--- a/komorebi-bar/src/storage.rs
+++ b/komorebi-bar/src/storage.rs
@@ -8,7 +8,6 @@ use eframe::egui::Context;
 use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::process::Command;
@@ -16,7 +15,8 @@ use std::time::Duration;
 use std::time::Instant;
 use sysinfo::Disks;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct StorageConfig {
     /// Enable the Storage widget
     pub enable: bool,

--- a/komorebi-bar/src/time.rs
+++ b/komorebi-bar/src/time.rs
@@ -14,11 +14,11 @@ use eframe::egui::TextFormat;
 use eframe::egui::Ui;
 use eframe::egui::Vec2;
 use eframe::epaint::StrokeKind;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct TimeConfig {
     /// Enable the Time widget
     pub enable: bool,
@@ -38,7 +38,8 @@ impl From<TimeConfig> for Time {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TimeFormat {
     /// Twelve-hour format (with seconds)
     TwelveHour,

--- a/komorebi-bar/src/update.rs
+++ b/komorebi-bar/src/update.rs
@@ -8,14 +8,14 @@ use eframe::egui::Context;
 use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::process::Command;
 use std::time::Duration;
 use std::time::Instant;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct UpdateConfig {
     /// Enable the Update widget
     pub enable: bool,

--- a/komorebi-bar/src/widget.rs
+++ b/komorebi-bar/src/widget.rs
@@ -23,7 +23,6 @@ use crate::update::Update;
 use crate::update::UpdateConfig;
 use eframe::egui::Context;
 use eframe::egui::Ui;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -31,7 +30,8 @@ pub trait BarWidget {
     fn render(&mut self, ctx: &Context, ui: &mut Ui, config: &mut RenderConfig);
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum WidgetConfig {
     Battery(BatteryConfig),
     Cpu(CpuConfig),

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -29,7 +29,7 @@ os_info = "3.10"
 parking_lot = "0.12"
 paste = { workspace = true }
 regex = "1"
-schemars = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -57,4 +57,6 @@ shadow-rs = { workspace = true }
 reqwest = { version = "0.12", features = ["blocking"] }
 
 [features]
+default = ["schemars"]
 deadlock_detection = ["parking_lot/deadlock_detection"]
+schemars = ["dep:schemars"]

--- a/komorebi/src/animation/engine.rs
+++ b/komorebi/src/animation/engine.rs
@@ -1,7 +1,5 @@
 use color_eyre::Result;
 
-use schemars::JsonSchema;
-
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::atomic::Ordering;
@@ -13,7 +11,8 @@ use super::ANIMATION_DURATION_GLOBAL;
 use super::ANIMATION_FPS;
 use super::ANIMATION_MANAGER;
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct AnimationEngine;
 
 impl AnimationEngine {

--- a/komorebi/src/animation/mod.rs
+++ b/komorebi/src/animation/mod.rs
@@ -18,11 +18,12 @@ pub mod prefix;
 pub mod render_dispatcher;
 pub use render_dispatcher::RenderDispatcher;
 pub mod style;
-use schemars::JsonSchema;
+
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum PerAnimationPrefixConfig<T> {
     Prefix(HashMap<AnimationPrefix, T>),

--- a/komorebi/src/animation/prefix.rs
+++ b/komorebi/src/animation/prefix.rs
@@ -1,24 +1,14 @@
 use clap::ValueEnum;
-use schemars::JsonSchema;
+
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
 use strum::EnumString;
 
 #[derive(
-    Copy,
-    Clone,
-    Debug,
-    Hash,
-    PartialEq,
-    Eq,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
+    Copy, Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize, Display, EnumString, ValueEnum,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum AnimationPrefix {

--- a/komorebi/src/border_manager/mod.rs
+++ b/komorebi/src/border_manager/mod.rs
@@ -19,7 +19,6 @@ use crossbeam_utils::atomic::AtomicCell;
 use crossbeam_utils::atomic::AtomicConsume;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::hash_map::Entry;
@@ -698,7 +697,8 @@ fn remove_border(
     Ok(())
 }
 
-#[derive(Debug, Copy, Clone, Display, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Copy, Clone, Display, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ZOrder {
     Top,
     NoTopMost,

--- a/komorebi/src/colour.rs
+++ b/komorebi/src/colour.rs
@@ -1,14 +1,19 @@
 use hex_color::HexColor;
 use komorebi_themes::Color32;
+#[cfg(feature = "schemars")]
 use schemars::gen::SchemaGenerator;
+#[cfg(feature = "schemars")]
 use schemars::schema::InstanceType;
+#[cfg(feature = "schemars")]
 use schemars::schema::Schema;
+#[cfg(feature = "schemars")]
 use schemars::schema::SchemaObject;
-use schemars::JsonSchema;
+
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum Colour {
     /// Colour represented as RGB
@@ -54,7 +59,8 @@ impl From<Colour> for Color32 {
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Hex(HexColor);
 
-impl JsonSchema for Hex {
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for Hex {
     fn schema_name() -> String {
         String::from("Hex")
     }
@@ -78,7 +84,8 @@ impl From<Colour> for u32 {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Rgb {
     /// Red
     pub r: u32,

--- a/komorebi/src/container.rs
+++ b/komorebi/src/container.rs
@@ -2,14 +2,14 @@ use std::collections::VecDeque;
 
 use getset::Getters;
 use nanoid::nanoid;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::ring::Ring;
 use crate::window::Window;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Getters, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Container {
     #[getset(get = "pub")]
     id: String,

--- a/komorebi/src/core/animation.rs
+++ b/komorebi/src/core/animation.rs
@@ -1,22 +1,12 @@
 use clap::ValueEnum;
-use schemars::JsonSchema;
+
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
 use strum::EnumString;
 
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-    PartialEq,
-)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AnimationStyle {
     Linear,
     EaseInSine,

--- a/komorebi/src/core/arrangement.rs
+++ b/komorebi/src/core/arrangement.rs
@@ -1,7 +1,6 @@
 use std::num::NonZeroUsize;
 
 use clap::ValueEnum;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
@@ -603,18 +602,8 @@ impl Arrangement for CustomLayout {
     }
 }
 
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-    PartialEq,
-)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Axis {
     Horizontal,
     Vertical,

--- a/komorebi/src/core/asc.rs
+++ b/komorebi/src/core/asc.rs
@@ -2,7 +2,6 @@ use crate::config_generation::ApplicationConfiguration;
 use crate::config_generation::ApplicationOptions;
 use crate::config_generation::MatchingRule;
 use color_eyre::Result;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -10,10 +9,12 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::path::PathBuf;
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ApplicationSpecificConfiguration(pub BTreeMap<String, AscApplicationRulesOrSchema>);
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum AscApplicationRulesOrSchema {
     AscApplicationRules(AscApplicationRules),
@@ -46,7 +47,8 @@ impl ApplicationSpecificConfiguration {
 }
 
 /// Rules that determine how an application is handled
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct AscApplicationRules {
     /// Rules to ignore specific windows
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/komorebi/src/core/config_generation.rs
+++ b/komorebi/src/core/config_generation.rs
@@ -1,6 +1,5 @@
 use clap::ValueEnum;
 use color_eyre::Result;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
@@ -8,9 +7,8 @@ use strum::EnumString;
 
 use super::ApplicationIdentifier;
 
-#[derive(
-    Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, JsonSchema,
-)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum ApplicationOptions {
@@ -52,14 +50,16 @@ impl ApplicationOptions {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum MatchingRule {
     Simple(IdWithIdentifier),
     Composite(Vec<IdWithIdentifier>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct WorkspaceMatchingRule {
     pub monitor_index: usize,
     pub workspace_index: usize,
@@ -67,7 +67,8 @@ pub struct WorkspaceMatchingRule {
     pub initial_only: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct IdWithIdentifier {
     pub kind: ApplicationIdentifier,
     pub id: String,
@@ -75,7 +76,8 @@ pub struct IdWithIdentifier {
     pub matching_strategy: Option<MatchingStrategy>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Display, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Display)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum MatchingStrategy {
     Legacy,
     Equals,
@@ -89,7 +91,8 @@ pub enum MatchingStrategy {
     DoesNotContain,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct IdWithIdentifierAndComment {
     pub kind: ApplicationIdentifier,
     pub id: String,
@@ -109,7 +112,8 @@ impl From<IdWithIdentifierAndComment> for IdWithIdentifier {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ApplicationConfiguration {
     pub name: String,
     pub identifier: IdWithIdentifier,
@@ -133,7 +137,8 @@ impl ApplicationConfiguration {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ApplicationConfigurationGenerator;
 
 impl ApplicationConfigurationGenerator {

--- a/komorebi/src/core/custom_layout.rs
+++ b/komorebi/src/core/custom_layout.rs
@@ -8,13 +8,13 @@ use std::path::Path;
 use color_eyre::eyre::anyhow;
 use color_eyre::eyre::bail;
 use color_eyre::Result;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
 use super::Rect;
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CustomLayout(Vec<Column>);
 
 impl Deref for CustomLayout {
@@ -250,7 +250,8 @@ impl CustomLayout {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "column", content = "configuration")]
 pub enum Column {
     Primary(Option<ColumnWidth>),
@@ -258,18 +259,21 @@ pub enum Column {
     Tertiary(ColumnSplit),
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ColumnWidth {
     WidthPercentage(f32),
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ColumnSplit {
     Horizontal,
     Vertical,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ColumnSplitWithCapacity {
     Horizontal(usize),
     Vertical(usize),

--- a/komorebi/src/core/cycle_direction.rs
+++ b/komorebi/src/core/cycle_direction.rs
@@ -1,15 +1,13 @@
 use std::num::NonZeroUsize;
 
 use clap::ValueEnum;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
 use strum::EnumString;
 
-#[derive(
-    Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, JsonSchema,
-)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum CycleDirection {
     Previous,
     Next,

--- a/komorebi/src/core/default_layout.rs
+++ b/komorebi/src/core/default_layout.rs
@@ -1,5 +1,4 @@
 use clap::ValueEnum;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
@@ -10,18 +9,9 @@ use super::Rect;
 use super::Sizing;
 
 #[derive(
-    Clone,
-    Copy,
-    Debug,
-    Serialize,
-    Deserialize,
-    Eq,
-    PartialEq,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
+    Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Display, EnumString, ValueEnum,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum DefaultLayout {
     BSP,
     Columns,

--- a/komorebi/src/core/layout.rs
+++ b/komorebi/src/core/layout.rs
@@ -1,4 +1,3 @@
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -7,7 +6,8 @@ use super::CustomLayout;
 use super::DefaultLayout;
 use super::Direction;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Layout {
     Default(DefaultLayout),
     Custom(CustomLayout),

--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -8,7 +8,6 @@ use std::str::FromStr;
 use clap::ValueEnum;
 use color_eyre::eyre::anyhow;
 use color_eyre::Result;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
@@ -45,7 +44,8 @@ pub mod operation_direction;
 pub mod pathext;
 pub mod rect;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Display, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, Display)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "type", content = "content")]
 pub enum SocketMessage {
     // Window / Container Commands
@@ -241,24 +241,23 @@ impl FromStr for SocketMessage {
     }
 }
 
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct SubscribeOptions {
     /// Only emit notifications when the window manager state has changed
     pub filter_state_changes: bool,
 }
 
-#[derive(
-    Debug, Copy, Clone, Eq, PartialEq, Display, Serialize, Deserialize, JsonSchema, ValueEnum,
-)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Display, Serialize, Deserialize, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum StackbarMode {
     Always,
     Never,
     OnStack,
 }
 
-#[derive(
-    Debug, Copy, Default, Clone, Eq, PartialEq, Display, Serialize, Deserialize, JsonSchema,
-)]
+#[derive(Debug, Copy, Default, Clone, Eq, PartialEq, Display, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum StackbarLabel {
     #[default]
     Process,
@@ -266,18 +265,9 @@ pub enum StackbarLabel {
 }
 
 #[derive(
-    Default,
-    Copy,
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Display,
-    Serialize,
-    Deserialize,
-    JsonSchema,
-    ValueEnum,
+    Default, Copy, Clone, Debug, Eq, PartialEq, Display, Serialize, Deserialize, ValueEnum,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum BorderStyle {
     #[default]
     /// Use the system border style
@@ -289,18 +279,9 @@ pub enum BorderStyle {
 }
 
 #[derive(
-    Default,
-    Copy,
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Display,
-    Serialize,
-    Deserialize,
-    JsonSchema,
-    ValueEnum,
+    Default, Copy, Clone, Debug, Eq, PartialEq, Display, Serialize, Deserialize, ValueEnum,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum BorderImplementation {
     #[default]
     /// Use the adjustable komorebi border implementation
@@ -310,19 +291,9 @@ pub enum BorderImplementation {
 }
 
 #[derive(
-    Copy,
-    Clone,
-    Debug,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-    PartialEq,
-    Eq,
-    Hash,
+    Copy, Clone, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq, Eq, Hash,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum WindowKind {
     Single,
     Stack,
@@ -331,9 +302,8 @@ pub enum WindowKind {
     Floating,
 }
 
-#[derive(
-    Copy, Clone, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, JsonSchema,
-)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum StateQuery {
     FocusedMonitorIndex,
     FocusedWorkspaceIndex,
@@ -343,18 +313,9 @@ pub enum StateQuery {
 }
 
 #[derive(
-    Copy,
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
+    Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ApplicationIdentifier {
     #[serde(alias = "exe")]
     Exe,
@@ -366,18 +327,8 @@ pub enum ApplicationIdentifier {
     Path,
 }
 
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FocusFollowsMouseImplementation {
     /// A custom FFM implementation (slightly more CPU-intensive)
     Komorebi,
@@ -385,7 +336,8 @@ pub enum FocusFollowsMouseImplementation {
     Windows,
 }
 
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct WindowManagementBehaviour {
     /// The current WindowContainerBehaviour to be used
     pub current_behaviour: WindowContainerBehaviour,
@@ -396,18 +348,9 @@ pub struct WindowManagementBehaviour {
 }
 
 #[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-    PartialEq,
+    Clone, Copy, Debug, Default, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum WindowContainerBehaviour {
     /// Create a new container for each new window
     #[default]
@@ -416,18 +359,8 @@ pub enum WindowContainerBehaviour {
     Append,
 }
 
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum MoveBehaviour {
     /// Swap the window container with the window container at the edge of the adjacent monitor
     Swap,
@@ -437,18 +370,8 @@ pub enum MoveBehaviour {
     NoOp,
 }
 
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-    PartialEq,
-)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum CrossBoundaryBehaviour {
     /// Attempt to perform actions across a workspace boundary
     Workspace,
@@ -456,18 +379,8 @@ pub enum CrossBoundaryBehaviour {
     Monitor,
 }
 
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-    PartialEq,
-)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum HidingBehaviour {
     /// Use the SW_HIDE flag to hide windows when switching workspaces (has issues with Electron apps)
     Hide,
@@ -477,18 +390,8 @@ pub enum HidingBehaviour {
     Cloak,
 }
 
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    Display,
-    EnumString,
-    ValueEnum,
-    JsonSchema,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum OperationBehaviour {
     /// Process komorebic commands on temporarily unmanaged/floated windows
     Op,
@@ -496,9 +399,8 @@ pub enum OperationBehaviour {
     NoOp,
 }
 
-#[derive(
-    Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, JsonSchema,
-)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Sizing {
     Increase,
     Decrease,

--- a/komorebi/src/core/operation_direction.rs
+++ b/komorebi/src/core/operation_direction.rs
@@ -1,7 +1,6 @@
 use std::num::NonZeroUsize;
 
 use clap::ValueEnum;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
@@ -10,9 +9,8 @@ use strum::EnumString;
 use super::direction::Direction;
 use super::Axis;
 
-#[derive(
-    Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, JsonSchema,
-)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum OperationDirection {
     Left,
     Right,

--- a/komorebi/src/core/rect.rs
+++ b/komorebi/src/core/rect.rs
@@ -1,9 +1,9 @@
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use windows::Win32::Foundation::RECT;
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, JsonSchema)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Rect {
     /// The left point in a Win32 Rect
     pub left: i32,

--- a/komorebi/src/lib.rs
+++ b/komorebi/src/lib.rs
@@ -66,7 +66,6 @@ use color_eyre::Result;
 use os_info::Version;
 use parking_lot::Mutex;
 use regex::Regex;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use uds_windows::UnixStream;
@@ -280,7 +279,8 @@ pub fn current_virtual_desktop() -> Option<Vec<u8>> {
     current
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum NotificationEvent {
     WindowManager(WindowManagerEvent),
@@ -288,7 +288,8 @@ pub enum NotificationEvent {
     Monitor(MonitorNotification),
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Notification {
     pub event: NotificationEvent,
     pub state: State,

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -9,7 +9,6 @@ use getset::CopyGetters;
 use getset::Getters;
 use getset::MutGetters;
 use getset::Setters;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -26,17 +25,9 @@ use crate::DEFAULT_CONTAINER_PADDING;
 use crate::DEFAULT_WORKSPACE_PADDING;
 
 #[derive(
-    Debug,
-    Clone,
-    Serialize,
-    Deserialize,
-    Getters,
-    CopyGetters,
-    MutGetters,
-    Setters,
-    JsonSchema,
-    PartialEq,
+    Debug, Clone, Serialize, Deserialize, Getters, CopyGetters, MutGetters, Setters, PartialEq,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Monitor {
     #[getset(get_copy = "pub", set = "pub")]
     pub id: isize,

--- a/komorebi/src/monitor_reconciliator/mod.rs
+++ b/komorebi/src/monitor_reconciliator/mod.rs
@@ -17,7 +17,6 @@ use crossbeam_channel::Receiver;
 use crossbeam_channel::Sender;
 use crossbeam_utils::atomic::AtomicConsume;
 use parking_lot::Mutex;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -28,7 +27,8 @@ use std::sync::OnceLock;
 
 pub mod hidden;
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "type", content = "content")]
 pub enum MonitorNotification {
     ResolutionScalingChanged,

--- a/komorebi/src/ring.rs
+++ b/komorebi/src/ring.rs
@@ -1,10 +1,10 @@
 use std::collections::VecDeque;
 
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Ring<T> {
     elements: VecDeque<T>,
     focused: usize,

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -19,7 +19,6 @@ use hotwatch::notify::ErrorKind as NotifyErrorKind;
 use hotwatch::EventKind;
 use hotwatch::Hotwatch;
 use parking_lot::Mutex;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use uds_windows::UnixListener;
@@ -126,7 +125,8 @@ pub struct WindowManager {
 }
 
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct State {
     pub monitors: Ring<Monitor>,
     pub monitor_usr_idx_map: HashMap<usize, usize>,
@@ -191,7 +191,8 @@ impl State {
 }
 
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct GlobalState {
     pub border_enabled: bool,
     pub border_colours: BorderColours,

--- a/komorebi/src/window_manager_event.rs
+++ b/komorebi/src/window_manager_event.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
 
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -12,7 +11,8 @@ use crate::OBJECT_NAME_CHANGE_ON_LAUNCH;
 use crate::OBJECT_NAME_CHANGE_TITLE_IGNORE_LIST;
 use crate::REGEX_IDENTIFIERS;
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(tag = "type", content = "content")]
 pub enum WindowManagerEvent {
     Destroy(WinEvent, Window),

--- a/komorebi/src/winevent.rs
+++ b/komorebi/src/winevent.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::use_self)]
 
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
@@ -89,7 +88,8 @@ use windows::Win32::UI::WindowsAndMessaging::EVENT_UIA_EVENTID_START;
 use windows::Win32::UI::WindowsAndMessaging::EVENT_UIA_PROPID_END;
 use windows::Win32::UI::WindowsAndMessaging::EVENT_UIA_PROPID_START;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Display, JsonSchema)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize, Display)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(u32)]
 #[allow(dead_code)]
 pub enum WinEvent {

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -10,7 +10,6 @@ use getset::CopyGetters;
 use getset::Getters;
 use getset::MutGetters;
 use getset::Setters;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -43,17 +42,9 @@ use crate::REMOVE_TITLEBARS;
 
 #[allow(clippy::struct_field_names)]
 #[derive(
-    Debug,
-    Clone,
-    Serialize,
-    Deserialize,
-    Getters,
-    CopyGetters,
-    MutGetters,
-    Setters,
-    JsonSchema,
-    PartialEq,
+    Debug, Clone, Serialize, Deserialize, Getters, CopyGetters, MutGetters, Setters, PartialEq,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Workspace {
     #[getset(get = "pub", set = "pub")]
     pub name: Option<String>,
@@ -103,7 +94,8 @@ pub struct Workspace {
     pub workspace_config: Option<WorkspaceConfig>,
 }
 
-#[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum WorkspaceLayer {
     #[default]
     Tiling,
@@ -169,9 +161,9 @@ pub enum WorkspaceWindowLocation {
     CopyGetters,
     MutGetters,
     Setters,
-    JsonSchema,
     PartialEq,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 /// Settings setup either by the parent monitor or by the `WindowManager`
 pub struct WorkspaceGlobals {
     pub container_padding: Option<i32>,

--- a/komorebic/Cargo.toml
+++ b/komorebic/Cargo.toml
@@ -21,7 +21,7 @@ miette = { version = "7", features = ["fancy"] }
 paste = { workspace = true }
 powershell_script = "1.0"
 reqwest = { version = "0.12", features = ["blocking"] }
-schemars = { workspace = true }
+schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shadow-rs = { workspace = true }
@@ -33,6 +33,10 @@ windows = { workspace = true }
 [build-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }
 shadow-rs = { workspace = true }
+
+[features]
+default = ["schemars"]
+schemars = ["dep:schemars"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(FALSE)'] }

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -26,15 +26,12 @@ use komorebi_client::resolve_home_path;
 use komorebi_client::send_message;
 use komorebi_client::send_query;
 use komorebi_client::ApplicationSpecificConfiguration;
-use komorebi_client::Notification;
 use lazy_static::lazy_static;
 use miette::NamedSource;
 use miette::Report;
 use miette::SourceOffset;
 use miette::SourceSpan;
 use paste::paste;
-use schemars::gen::SchemaSettings;
-use schemars::schema_for;
 use serde::Deserialize;
 use sysinfo::ProcessesToUpdate;
 use which::which;
@@ -2973,31 +2970,43 @@ if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
             );
         }
         SubCommand::ApplicationSpecificConfigurationSchema => {
-            let asc = schema_for!(ApplicationSpecificConfiguration);
-            let schema = serde_json::to_string_pretty(&asc)?;
-            println!("{schema}");
+            #[cfg(feature = "schemars")]
+            {
+                let asc = schemars::schema_for!(ApplicationSpecificConfiguration);
+                let schema = serde_json::to_string_pretty(&asc)?;
+                println!("{schema}");
+            }
         }
         SubCommand::NotificationSchema => {
-            let notification = schema_for!(Notification);
-            let schema = serde_json::to_string_pretty(&notification)?;
-            println!("{schema}");
+            #[cfg(feature = "schemars")]
+            {
+                let notification = schemars::schema_for!(komorebi_client::Notification);
+                let schema = serde_json::to_string_pretty(&notification)?;
+                println!("{schema}");
+            }
         }
         SubCommand::SocketSchema => {
-            let socket_message = schema_for!(SocketMessage);
-            let schema = serde_json::to_string_pretty(&socket_message)?;
-            println!("{schema}");
+            #[cfg(feature = "schemars")]
+            {
+                let socket_message = schemars::schema_for!(SocketMessage);
+                let schema = serde_json::to_string_pretty(&socket_message)?;
+                println!("{schema}");
+            }
         }
         SubCommand::StaticConfigSchema => {
-            let settings = SchemaSettings::default().with(|s| {
-                s.option_nullable = false;
-                s.option_add_null_type = false;
-                s.inline_subschemas = true;
-            });
+            #[cfg(feature = "schemars")]
+            {
+                let settings = schemars::gen::SchemaSettings::default().with(|s| {
+                    s.option_nullable = false;
+                    s.option_add_null_type = false;
+                    s.inline_subschemas = true;
+                });
 
-            let gen = settings.into_generator();
-            let socket_message = gen.into_root_schema_for::<StaticConfig>();
-            let schema = serde_json::to_string_pretty(&socket_message)?;
-            println!("{schema}");
+                let gen = settings.into_generator();
+                let socket_message = gen.into_root_schema_for::<StaticConfig>();
+                let schema = serde_json::to_string_pretty(&socket_message)?;
+                println!("{schema}");
+            }
         }
         SubCommand::GenerateStaticConfig => {
             print_query(&SocketMessage::GenerateStaticConfig);


### PR DESCRIPTION
This commit makes all schemars::JsonSchema derives optional. After analyzing the output of cargo build timings and llvm-lines, it was clear that the majority of the 2m+ incremental dev build times was taken up by codegen, and the majority of it by schemars.

Developers can now run cargo commands with --no-default-features to disable schemars::JsonSchema codegen, and all justfile commands have been updated to take this flag by default, with the exception of the jsonschema target, which will compile with all derives required to export the various jsonschema files.

Incremental dev build times for komorebi.exe on my machine are now at around ~18s, while clean dev build times for the entire workspace are at around ~1m.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
