### PR TITLE
fix(borders): ignore borders on all stack updates

### DIFF
--- a/komorebi/src/container.rs
+++ b/komorebi/src/container.rs
@@ -52,19 +52,12 @@ impl Container {
         }
     }
 
+    /// Hides the unfocused windows of the container and restores the focused one. This function
+    /// is used to make sure we update the window that should be shown on a stack. If the container
+    /// isn't a stack this function won't change anything.
     pub fn load_focused_window(&mut self) {
         let focused_idx = self.focused_window_idx();
-        for (i, window) in self.windows_mut().iter_mut().enumerate() {
-            if i == focused_idx {
-                window.restore();
-            } else {
-                window.hide();
-            }
-        }
-    }
 
-    pub fn load_focused_window_ignore_borders(&mut self) {
-        let focused_idx = self.focused_window_idx();
         for (i, window) in self.windows_mut().iter_mut().enumerate() {
             if i == focused_idx {
                 window.restore_with_border(false);
@@ -109,14 +102,13 @@ impl Container {
     }
 
     pub fn idx_for_window(&self, hwnd: isize) -> Option<usize> {
-        let mut idx = None;
         for (i, window) in self.windows().iter().enumerate() {
             if window.hwnd == hwnd {
-                idx = Option::from(i);
+                return Option::from(i);
             }
         }
 
-        idx
+        None
     }
 
     pub fn remove_window_by_idx(&mut self, idx: usize) -> Option<Window> {

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -2530,7 +2530,7 @@ impl WindowManager {
         let next_idx = direction.next_idx(current_idx, len);
 
         container.focus_window(next_idx);
-        container.load_focused_window_ignore_borders();
+        container.load_focused_window();
 
         self.update_focused_workspace(self.mouse_follows_focus, true)
     }
@@ -2563,7 +2563,7 @@ impl WindowManager {
         container.windows_mut().swap(current_idx, next_idx);
 
         container.focus_window(next_idx);
-        container.load_focused_window_ignore_borders();
+        container.load_focused_window();
 
         self.update_focused_workspace(self.mouse_follows_focus, true)
     }


### PR DESCRIPTION
This is a simple fix to make it so every time we call `load_focused_window` on a container we ignore the borders, since this function will only be performing hiding/restoring of windows if that container is a stack and in that case we want the container border to not be hidden so it doesn't flicker.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
