### PR TITLE
test(window_manger.rs): tests: WM Instance and Focus Workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uds_windows",
+ "uuid",
  "which",
  "win32-display-data",
  "windows 0.60.0",
@@ -5545,6 +5546,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+dependencies = [
+ "getrandom 0.3.1",
+]
 
 [[package]]
 name = "v_frame"

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -40,6 +40,7 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 uds_windows = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
 which = { workspace = true }
 win32-display-data = { workspace = true }
 windows = { workspace = true }

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -40,7 +40,6 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 uds_windows = { workspace = true }
-uuid = { version = "1", features = ["v4"] }
 which = { workspace = true }
 win32-display-data = { workspace = true }
 windows = { workspace = true }
@@ -56,6 +55,7 @@ shadow-rs = { workspace = true }
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }
+uuid = { version = "1", features = ["v4"] }
 
 [features]
 default = ["schemars"]

--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -235,6 +235,7 @@ fn main() -> Result<()> {
     } else {
         Arc::new(Mutex::new(WindowManager::new(
             winevent_listener::event_rx(),
+            None,
         )?))
     };
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -398,8 +398,8 @@ impl EnforceWorkspaceRuleOp {
 
 impl WindowManager {
     #[tracing::instrument]
-    pub fn new(incoming: Receiver<WindowManagerEvent>) -> Result<Self> {
-        let socket = DATA_DIR.join("komorebi.sock");
+    pub fn new(incoming: Receiver<WindowManagerEvent>, custom_socket_path: Option<PathBuf>) -> Result<Self> {
+        let socket = custom_socket_path.unwrap_or_else(|| DATA_DIR.join("komorebi.sock"));
 
         match std::fs::remove_file(&socket) {
             Ok(()) => {}

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -398,7 +398,10 @@ impl EnforceWorkspaceRuleOp {
 
 impl WindowManager {
     #[tracing::instrument]
-    pub fn new(incoming: Receiver<WindowManagerEvent>, custom_socket_path: Option<PathBuf>) -> Result<Self> {
+    pub fn new(
+        incoming: Receiver<WindowManagerEvent>,
+        custom_socket_path: Option<PathBuf>,
+    ) -> Result<Self> {
         let socket = custom_socket_path.unwrap_or_else(|| DATA_DIR.join("komorebi.sock"));
 
         match std::fs::remove_file(&socket) {

--- a/komorebi/tests/window_manager.rs
+++ b/komorebi/tests/window_manager.rs
@@ -5,9 +5,10 @@ mod window_manager_tests {
     use crossbeam_channel::Receiver;
     use crossbeam_channel::Sender;
     use komorebi::monitor;
+    use komorebi::window_manager::WindowManager;
     use komorebi::Rect;
     use komorebi::WindowManagerEvent;
-    use komorebi::{window_manager::WindowManager, DATA_DIR};
+    use komorebi::DATA_DIR;
     use uuid::Uuid;
 
     #[test]
@@ -43,7 +44,7 @@ mod window_manager_tests {
 
         wm.monitors.elements_mut().push_back(m);
 
-        let monitor_idx = {
+        let workspace_idx = {
             let monitor = wm
                 .focused_monitor_mut()
                 .ok_or_else(|| anyhow!("there is no workspace"))
@@ -57,11 +58,22 @@ mod window_manager_tests {
                 .ok_or_else(|| anyhow!("there is no workspace"))
                 .unwrap();
             monitor
-                .focus_workspace(monitor_idx)
+                .focus_workspace(workspace_idx)
                 .expect("failed to focus workspace");
         }
 
-        assert_eq!(wm.focused_workspace_idx().unwrap(), 1);
+        {
+            let monitor = wm
+                .focused_monitor_mut()
+                .ok_or_else(|| anyhow!("there is no workspace"))
+                .unwrap();
+            monitor
+                .focus_workspace(workspace_idx + 1)
+                .expect("failed to focus workspace");
+            assert_eq!(monitor.workspaces().len(), 3)
+        }
+
+        assert_eq!(wm.focused_workspace_idx().unwrap(), 2);
 
         wm.focus_workspace(0).ok();
 

--- a/komorebi/tests/window_manager.rs
+++ b/komorebi/tests/window_manager.rs
@@ -1,0 +1,74 @@
+#[cfg(test)]
+mod window_manager_tests {
+    use color_eyre::eyre::anyhow;
+    use crossbeam_channel::bounded;
+    use crossbeam_channel::Receiver;
+    use crossbeam_channel::Sender;
+    use komorebi::monitor;
+    use komorebi::Rect;
+    use komorebi::WindowManagerEvent;
+    use komorebi::{window_manager::WindowManager, DATA_DIR};
+    use uuid::Uuid;
+
+    #[test]
+    fn test_create_window_manager() {
+        let (_sender, receiver): (Sender<WindowManagerEvent>, Receiver<WindowManagerEvent>) =
+            bounded(1);
+        let socket_name = format!("komorebi-test-{}.sock", Uuid::new_v4());
+        let socket = Some(DATA_DIR.join(socket_name));
+        let wm = WindowManager::new(receiver, socket.clone());
+        assert!(wm.is_ok());
+
+        if let Some(ref socket_path) = socket {
+            let _ = std::fs::remove_file(socket_path);
+        }
+    }
+
+    #[test]
+    fn test_focus_workspace() {
+        let (_sender, receiver): (Sender<WindowManagerEvent>, Receiver<WindowManagerEvent>) =
+            bounded(1);
+        let socket_name = format!("komorebi-test-{}.sock", Uuid::new_v4());
+        let socket = Some(DATA_DIR.join(socket_name));
+        let mut wm = WindowManager::new(receiver, socket.clone()).unwrap();
+        let m = monitor::new(
+            0,
+            Rect::default(),
+            Rect::default(),
+            "TestMonitor".to_string(),
+            "TestDevice".to_string(),
+            "TestDeviceID".to_string(),
+            Some("TestMonitorID".to_string()),
+        );
+
+        wm.monitors.elements_mut().push_back(m);
+
+        let monitor_idx = {
+            let monitor = wm
+                .focused_monitor_mut()
+                .ok_or_else(|| anyhow!("there is no workspace"))
+                .unwrap();
+            monitor.new_workspace_idx()
+        };
+
+        {
+            let monitor = wm
+                .focused_monitor_mut()
+                .ok_or_else(|| anyhow!("there is no workspace"))
+                .unwrap();
+            monitor
+                .focus_workspace(monitor_idx)
+                .expect("failed to focus workspace");
+        }
+
+        assert_eq!(wm.focused_workspace_idx().unwrap(), 1);
+
+        wm.focus_workspace(0).ok();
+
+        assert_eq!(wm.focused_workspace_idx().unwrap(), 0);
+
+        if let Some(ref socket_path) = socket {
+            let _ = std::fs::remove_file(socket_path);
+        }
+    }
+}


### PR DESCRIPTION
Created a test that creates the WM instance and ensures the instance is running. The test creates a custom socket and then cleans up the socket file after completion. Created a test that creates a WM instance, monitor instance, and workpace. The tests checks to ensure that the expected workspace is focused properly.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
