### PR TITLE
feat(bar): added timezone to time widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6ac4f2c0bf0f44e9161aec9675e1050aa4a530663c4a9e37e108fa948bca9f"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94fea34d77a245229e7746bd2beb786cd2a896f306ff491fb8cecb3074b10a7"
+dependencies = [
+ "parse-zoneinfo",
+ "phf_codegen",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +2716,7 @@ name = "komorebi-bar"
 version = "0.1.35"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "clap",
  "color-eyre",
  "crossbeam-channel",
@@ -3864,6 +3886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3883,6 +3914,44 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4729,6 +4798,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "wrap_help"] }
+chrono-tz = "0.10"
 chrono = "0.4"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"

--- a/komorebi-bar/Cargo.toml
+++ b/komorebi-bar/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 komorebi-client = { path = "../komorebi-client" }
 komorebi-themes = { path = "../komorebi-themes" }
 
+chrono-tz = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -265,6 +265,10 @@
                         ]
                       }
                     ]
+                  },
+                  "timezone": {
+                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+                    "type": "string"
                   }
                 }
               }
@@ -988,6 +992,10 @@
                         ]
                       }
                     ]
+                  },
+                  "timezone": {
+                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+                    "type": "string"
                   }
                 }
               }
@@ -1663,6 +1671,10 @@
                         ]
                       }
                     ]
+                  },
+                  "timezone": {
+                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+                    "type": "string"
                   }
                 }
               }
@@ -2386,6 +2398,10 @@
                         ]
                       }
                     ]
+                  },
+                  "timezone": {
+                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+                    "type": "string"
                   }
                 }
               }
@@ -2994,6 +3010,10 @@
                         ]
                       }
                     ]
+                  },
+                  "timezone": {
+                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+                    "type": "string"
                   }
                 }
               }
@@ -3717,6 +3737,10 @@
                         ]
                       }
                     ]
+                  },
+                  "timezone": {
+                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+                    "type": "string"
                   }
                 }
               }


### PR DESCRIPTION
This commit adds a new setting on the time and date widgets to set the timezone.

In case the timezone is invalid, the time is replaced with an error message.

![image](https://github.com/user-attachments/assets/6f769fce-0e9f-43c5-a8ef-ae862ca40293)

Use a custom format to display additional information.

![image](https://github.com/user-attachments/assets/55c8e101-07bd-4ed2-987d-eaa600505e4a)

```json
    {
      "Time": {
        "enable": true,
        "format": { "Custom": "%T %Z (Tokyo)" },
        "timezone": "Asia/Tokyo"
      }
    }
```

![image](https://github.com/user-attachments/assets/a9cda0f5-eedd-4606-a8bb-2248e50cced1)

```json
    {
      "Date": {
        "enable": true,
        "format": { "Custom": "%H:%M %e %b %Z (Tokyo)" },
        "timezone": "Asia/Tokyo"
      }
    }
```

Closes: #1312