### PR TITLE
feat(bar): changing icons based on the time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,7 @@ dependencies = [
  "image",
  "komorebi-client",
  "komorebi-themes",
+ "lazy_static",
  "netdev",
  "num",
  "num-derive",

--- a/komorebi-bar/Cargo.toml
+++ b/komorebi-bar/Cargo.toml
@@ -21,6 +21,7 @@ egui-phosphor = "0.9"
 font-loader = "0.11"
 hotwatch = { workspace = true }
 image = "0.25"
+lazy_static = { workspace = true }
 netdev = "0.32"
 num = "0.4"
 num-derive = "0.4"

--- a/komorebi-bar/src/date.rs
+++ b/komorebi-bar/src/date.rs
@@ -2,6 +2,7 @@ use crate::config::LabelPrefix;
 use crate::render::RenderConfig;
 use crate::selected_frame::SelectableFrame;
 use crate::widget::BarWidget;
+use chrono::Local;
 use chrono_tz::Tz;
 use eframe::egui::text::LayoutJob;
 use eframe::egui::Align;
@@ -39,7 +40,7 @@ impl CustomModifiers {
             }
 
             // get the strftime value of modifier
-            let formatted_modifier = chrono::Local::now().format(modifier).to_string();
+            let formatted_modifier = Local::now().format(modifier).to_string();
 
             // find the gotten value in the original output
             if let Some(pos) = modified_output.find(&formatted_modifier) {
@@ -143,7 +144,7 @@ impl Date {
     fn output(&mut self) -> String {
         let formatted = match &self.timezone {
             Some(timezone) => match timezone.parse::<Tz>() {
-                Ok(tz) => chrono::Local::now()
+                Ok(tz) => Local::now()
                     .with_timezone(&tz)
                     .format(&self.format.fmt_string())
                     .to_string()
@@ -151,7 +152,7 @@ impl Date {
                     .to_string(),
                 Err(_) => format!("Invalid timezone: {}", timezone),
             },
-            None => chrono::Local::now()
+            None => Local::now()
                 .format(&self.format.fmt_string())
                 .to_string()
                 .trim()

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -896,6 +896,10 @@
                   "format"
                 ],
                 "properties": {
+                  "changing_icon": {
+                    "description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
+                    "type": "boolean"
+                  },
                   "enable": {
                     "description": "Enable the Time widget",
                     "type": "boolean"
@@ -2302,6 +2306,10 @@
                   "format"
                 ],
                 "properties": {
+                  "changing_icon": {
+                    "description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
+                    "type": "boolean"
+                  },
                   "enable": {
                     "description": "Enable the Time widget",
                     "type": "boolean"
@@ -3641,6 +3649,10 @@
                   "format"
                 ],
                 "properties": {
+                  "changing_icon": {
+                    "description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
+                    "type": "boolean"
+                  },
                   "enable": {
                     "description": "Enable the Time widget",
                     "type": "boolean"


### PR DESCRIPTION
This commit adds a little Easter egg on the time widget.

Use the `changing_icon` setting to enable this feature.

Based on the current time, the widget will use different icons to indicate certain activities of the day.

00:00 MOON
06:00 ALARM
06:01 BREAD
06:30 BARBELL
08:00 COFFEE
08:30 CLOCK
12:00 HAMBURGER
12:30 CLOCK_AFTERNOON
18:00 FORK_KNIFE
18:30 MOON_STARS

![image](https://github.com/user-attachments/assets/13986521-efac-42e9-b777-ea8e2f9b9d00)
