### PR TITLE
fix(wm): focus correct window if monocled stack

### DIFF
--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -331,11 +331,9 @@ impl WindowManager {
             SocketMessage::UnstackAll => self.unstack_all()?,
             SocketMessage::CycleStack(direction) => {
                 self.cycle_container_window_in_direction(direction)?;
-                self.focused_window()?.focus(self.mouse_follows_focus)?;
             }
             SocketMessage::CycleStackIndex(direction) => {
                 self.cycle_container_window_index_in_direction(direction)?;
-                self.focused_window()?.focus(self.mouse_follows_focus)?;
             }
             SocketMessage::FocusStackWindow(idx) => {
                 // In case you are using this command on a bar on a monitor
@@ -346,7 +344,6 @@ impl WindowManager {
                     self.focus_monitor(monitor_idx)?;
                 }
                 self.focus_container_window(idx)?;
-                self.focused_window()?.focus(self.mouse_follows_focus)?;
             }
             SocketMessage::ForceFocus => {
                 let focused_window = self.focused_window()?;

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -2535,6 +2535,10 @@ impl WindowManager {
         container.focus_window(next_idx);
         container.load_focused_window();
 
+        if let Some(window) = container.focused_window() {
+            window.focus(self.mouse_follows_focus)?;
+        }
+
         self.update_focused_workspace(self.mouse_follows_focus, true)
     }
 
@@ -2568,6 +2572,10 @@ impl WindowManager {
         container.focus_window(next_idx);
         container.load_focused_window();
 
+        if let Some(window) = container.focused_window() {
+            window.focus(self.mouse_follows_focus)?;
+        }
+
         self.update_focused_workspace(self.mouse_follows_focus, true)
     }
 
@@ -2597,6 +2605,10 @@ impl WindowManager {
 
         container.focus_window(idx);
         container.load_focused_window();
+
+        if let Some(window) = container.focused_window() {
+            window.focus(self.mouse_follows_focus)?;
+        }
 
         self.update_focused_workspace(self.mouse_follows_focus, true)
     }


### PR DESCRIPTION
Previously if we had a stack on a monocle container and tried to cycle stack or move the window within the stack or even using the focus stack window from a bar it would focus the wrong window and temporarely show that wrong window. This commit fixes this.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
