### PR TITLE
fix(wm): update layer on cross monitor moves

### DIFF
--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -17,6 +17,7 @@ use crate::core::Rect;
 use crate::container::Container;
 use crate::ring::Ring;
 use crate::workspace::Workspace;
+use crate::workspace::WorkspaceLayer;
 use crate::DefaultLayout;
 use crate::Layout;
 use crate::OperationDirection;
@@ -382,6 +383,7 @@ impl Monitor {
             };
 
             target_workspace.floating_windows_mut().push(window);
+            target_workspace.set_layer(WorkspaceLayer::Floating);
         } else {
             let container = workspace
                 .remove_focused_container()
@@ -397,6 +399,8 @@ impl Monitor {
                 }
                 Some(workspace) => workspace,
             };
+
+            target_workspace.set_layer(WorkspaceLayer::Tiling);
 
             if let Some(direction) = direction {
                 self.add_container_with_direction(

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1854,6 +1854,7 @@ impl WindowManager {
 
         if let Some(window) = floating_window {
             target_workspace.floating_windows_mut().push(window);
+            target_workspace.set_layer(WorkspaceLayer::Floating);
             Window::from(window.hwnd)
                 .move_to_area(&current_area, target_monitor.work_area_size())?;
         } else if let Some(container) = container {
@@ -1862,6 +1863,8 @@ impl WindowManager {
                 .iter()
                 .map(|w| w.hwnd)
                 .collect::<Vec<_>>();
+
+            target_workspace.set_layer(WorkspaceLayer::Tiling);
 
             if let Some(direction) = move_direction {
                 target_monitor.add_container_with_direction(container, workspace_idx, direction)?;


### PR DESCRIPTION
There was an issue where if you tried to move a floating window to another monitor using a command like `komorebic cycle-move-to-monitor 1` it would move the window correctly, but the target workspace layer wouldn't change, which probably meant it would still be as `Tiling` so if you tried to move the floating window with the new floating window moves it would behave as if it was a tile move and actually moved the window across monitor again if that was the direction you moved, any other direction would just be ignored.

This PR fixes that.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
