### PR TITLE
fix(wm): correct float window move/resize

### DIFF
--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1436,9 +1436,12 @@ impl WindowManager {
                             }
                             (OperationDirection::Right, Sizing::Increase) => {
                                 if rect.left + rect.right + delta * 2
-                                    > focused_monitor_work_area.right
+                                    > focused_monitor_work_area.left
+                                        + focused_monitor_work_area.right
                                 {
-                                    rect.right = focused_monitor_work_area.right - rect.left;
+                                    rect.right = focused_monitor_work_area.left
+                                        + focused_monitor_work_area.right
+                                        - rect.left;
                                 } else {
                                     rect.right += delta * 2;
                                 }
@@ -1458,9 +1461,12 @@ impl WindowManager {
                             }
                             (OperationDirection::Down, Sizing::Increase) => {
                                 if rect.top + rect.bottom + delta * 2
-                                    > focused_monitor_work_area.bottom
+                                    > focused_monitor_work_area.top
+                                        + focused_monitor_work_area.bottom
                                 {
-                                    rect.bottom = focused_monitor_work_area.bottom - rect.top;
+                                    rect.bottom = focused_monitor_work_area.top
+                                        + focused_monitor_work_area.bottom
+                                        - rect.top;
                                 } else {
                                     rect.bottom += delta * 2;
                                 }
@@ -2196,8 +2202,12 @@ impl WindowManager {
                         }
                     }
                     OperationDirection::Right => {
-                        if rect.left + delta + rect.right > focused_monitor_work_area.right {
-                            rect.left = focused_monitor_work_area.right - rect.right;
+                        if rect.left + delta + rect.right
+                            > focused_monitor_work_area.left + focused_monitor_work_area.right
+                        {
+                            rect.left = focused_monitor_work_area.left
+                                + focused_monitor_work_area.right
+                                - rect.right;
                         } else {
                             rect.left += delta;
                         }
@@ -2210,8 +2220,12 @@ impl WindowManager {
                         }
                     }
                     OperationDirection::Down => {
-                        if rect.top + delta + rect.bottom > focused_monitor_work_area.bottom {
-                            rect.top = focused_monitor_work_area.bottom - rect.bottom;
+                        if rect.top + delta + rect.bottom
+                            > focused_monitor_work_area.top + focused_monitor_work_area.bottom
+                        {
+                            rect.top = focused_monitor_work_area.top
+                                + focused_monitor_work_area.bottom
+                                - rect.bottom;
                         } else {
                             rect.top += delta;
                         }


### PR DESCRIPTION
This commit fixes an issue where the move/resize functions for floating windows weren't properly taking into account the coordinates of secondary monitors and were only working correctly on the main monitor where top/left was 0/0.

This issue was first brought up by a user on [Discord](https://discord.com/channels/898554690126630914/1348547975055409152)

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
