### PR TITLE
fix(wm): use preferred id when caching monitors

### DIFF
--- a/komorebi/src/lib.rs
+++ b/komorebi/src/lib.rs
@@ -65,6 +65,7 @@ use crate::core::config_generation::WorkspaceMatchingRule;
 use color_eyre::Result;
 use os_info::Version;
 use parking_lot::Mutex;
+use parking_lot::RwLock;
 use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
@@ -131,8 +132,8 @@ lazy_static! {
     static ref TRANSPARENCY_BLACKLIST: Arc<Mutex<Vec<MatchingRule>>> = Arc::new(Mutex::new(Vec::new()));
     static ref MONITOR_INDEX_PREFERENCES: Arc<Mutex<HashMap<usize, Rect>>> =
         Arc::new(Mutex::new(HashMap::new()));
-    static ref DISPLAY_INDEX_PREFERENCES: Arc<Mutex<HashMap<usize, String>>> =
-        Arc::new(Mutex::new(HashMap::new()));
+    static ref DISPLAY_INDEX_PREFERENCES: Arc<RwLock<HashMap<usize, String>>> =
+        Arc::new(RwLock::new(HashMap::new()));
     static ref WORKSPACE_MATCHING_RULES: Arc<Mutex<Vec<WorkspaceMatchingRule>>> =
         Arc::new(Mutex::new(Vec::new()));
     static ref REGEX_IDENTIFIERS: Arc<Mutex<HashMap<String, Regex>>> =

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1152,7 +1152,7 @@ impl WindowManager {
                 );
             }
             SocketMessage::DisplayIndexPreference(index_preference, ref display) => {
-                let mut display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                let mut display_index_preferences = DISPLAY_INDEX_PREFERENCES.write();
                 display_index_preferences.insert(index_preference, display.clone());
             }
             SocketMessage::EnsureWorkspaces(monitor_idx, workspace_count) => {

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -740,7 +740,7 @@ impl From<&WindowManager> for StaticConfig {
                     .collect::<Vec<_>>(),
             ),
             monitor_index_preferences: Option::from(MONITOR_INDEX_PREFERENCES.lock().clone()),
-            display_index_preferences: Option::from(DISPLAY_INDEX_PREFERENCES.lock().clone()),
+            display_index_preferences: Option::from(DISPLAY_INDEX_PREFERENCES.read().clone()),
             stackbar: None,
             animation: None,
             theme: None,
@@ -768,7 +768,7 @@ impl StaticConfig {
         }
 
         if let Some(display_index_preferences) = &self.display_index_preferences {
-            let mut preferences = DISPLAY_INDEX_PREFERENCES.lock();
+            let mut preferences = DISPLAY_INDEX_PREFERENCES.write();
             preferences.clone_from(display_index_preferences);
         }
 
@@ -1276,7 +1276,7 @@ impl StaticConfig {
         let mut wm = wm.lock();
 
         let configs_with_preference: Vec<_> =
-            DISPLAY_INDEX_PREFERENCES.lock().keys().copied().collect();
+            DISPLAY_INDEX_PREFERENCES.read().keys().copied().collect();
         let mut configs_used = Vec::new();
 
         let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
@@ -1286,7 +1286,7 @@ impl StaticConfig {
         let offset = wm.work_area_offset;
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
-                let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                let display_index_preferences = DISPLAY_INDEX_PREFERENCES.read();
                 let c_idx = display_index_preferences.iter().find_map(|(c_idx, id)| {
                     (monitor
                         .serial_number_id()
@@ -1385,7 +1385,7 @@ impl StaticConfig {
                 .filter(|i| !configs_used.contains(i))
             {
                 let id = {
-                    let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                    let display_index_preferences = DISPLAY_INDEX_PREFERENCES.read();
                     display_index_preferences.get(i).cloned()
                 };
                 if let (Some(id), Some(monitor_config)) =
@@ -1445,7 +1445,7 @@ impl StaticConfig {
         value.apply_globals()?;
 
         let configs_with_preference: Vec<_> =
-            DISPLAY_INDEX_PREFERENCES.lock().keys().copied().collect();
+            DISPLAY_INDEX_PREFERENCES.read().keys().copied().collect();
         let mut configs_used = Vec::new();
 
         let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
@@ -1455,7 +1455,7 @@ impl StaticConfig {
         let offset = wm.work_area_offset;
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
-                let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                let display_index_preferences = DISPLAY_INDEX_PREFERENCES.read();
                 let c_idx = display_index_preferences.iter().find_map(|(c_idx, id)| {
                     (monitor
                         .serial_number_id()
@@ -1557,7 +1557,7 @@ impl StaticConfig {
                 .filter(|i| !configs_used.contains(i))
             {
                 let id = {
-                    let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+                    let display_index_preferences = DISPLAY_INDEX_PREFERENCES.read();
                     display_index_preferences.get(i).cloned()
                 };
                 if let (Some(id), Some(monitor_config)) =

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -272,7 +272,7 @@ impl Default for GlobalState {
             tray_and_multi_window_identifiers: TRAY_AND_MULTI_WINDOW_IDENTIFIERS.lock().clone(),
             name_change_on_launch_identifiers: OBJECT_NAME_CHANGE_ON_LAUNCH.lock().clone(),
             monitor_index_preferences: MONITOR_INDEX_PREFERENCES.lock().clone(),
-            display_index_preferences: DISPLAY_INDEX_PREFERENCES.lock().clone(),
+            display_index_preferences: DISPLAY_INDEX_PREFERENCES.read().clone(),
             workspace_rules: WORKSPACE_MATCHING_RULES.lock().clone(),
             window_hiding_behaviour: *HIDING_BEHAVIOUR.lock(),
             configuration_dir: HOME_DIR.clone(),

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -299,7 +299,7 @@ impl WindowsApi {
                 }
             }
 
-            let display_index_preferences = DISPLAY_INDEX_PREFERENCES.lock();
+            let display_index_preferences = DISPLAY_INDEX_PREFERENCES.read();
             for (index, id) in &*display_index_preferences {
                 if m.serial_number_id().as_ref().is_some_and(|sn| sn == id) || id.eq(m.device_id())
                 {
@@ -334,7 +334,7 @@ impl WindowsApi {
         // Rebuild monitor index map
         *monitor_usr_idx_map = HashMap::new();
         let mut added_monitor_idxs = Vec::new();
-        for (index, id) in &*DISPLAY_INDEX_PREFERENCES.lock() {
+        for (index, id) in &*DISPLAY_INDEX_PREFERENCES.read() {
             if let Some(m_idx) = monitors.elements().iter().position(|m| {
                 m.serial_number_id().as_ref().is_some_and(|sn| sn == id) || m.device_id() == id
             }) {


### PR DESCRIPTION
Use the preferred id set by the user as the key when caching monitors. This way if a user is having issues with the `device_id` on their system they can use the `serial_number_id` on `display_index_preferences`. If instead a user is having issues with the `serial_number_id` they can make sure to use the `device_id` on `display_index_preferences`. Komorebi will use the preferred one as a key when caching the monitors.

@LGUG2Z This PR also includes a change of the `DISPLAY_INDEX_PREFERENCES` from a `Mutex` to `RwLock`. I believe the `RwLock` is better since it allows multiple readers at the same time, while the mutex blocks on all calls even if you just want to read or compare some value. For display index preferences (same thing applies to other existing mutexes) most times we access it is a read-only access. We only ever change it when applying a config or when a command is used to change it. Every other use is a read-only use so it doesn't make sense to block on those situations.
If you don't think this is a necessary change I can remove it from this PR though! Just say the word!

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
