### PR TITLE
fix(bar): added missing `focus-monitor-at-cursor` command to buttons

### DIFF
--- a/komorebi-bar/src/komorebi.rs
+++ b/komorebi-bar/src/komorebi.rs
@@ -403,6 +403,7 @@ impl BarWidget for Komorebi {
 
                             if layer_frame.clicked()
                                 && komorebi_client::send_batch([
+                                    SocketMessage::FocusMonitorAtCursor,
                                     SocketMessage::MouseFollowsFocus(false),
                                     SocketMessage::ToggleWorkspaceLayer,
                                     SocketMessage::MouseFollowsFocus(

--- a/komorebi-bar/src/komorebi_layout.rs
+++ b/komorebi-bar/src/komorebi_layout.rs
@@ -105,12 +105,22 @@ impl KomorebiLayout {
                 }
             }
             KomorebiLayout::Monocle => {
-                if komorebi_client::send_message(&SocketMessage::ToggleMonocle).is_err() {
+                if komorebi_client::send_batch([
+                    SocketMessage::FocusMonitorAtCursor,
+                    SocketMessage::ToggleMonocle,
+                ])
+                .is_err()
+                {
                     tracing::error!("could not send message to komorebi: ToggleMonocle");
                 }
             }
             KomorebiLayout::Floating => {
-                if komorebi_client::send_message(&SocketMessage::ToggleTiling).is_err() {
+                if komorebi_client::send_batch([
+                    SocketMessage::FocusMonitorAtCursor,
+                    SocketMessage::ToggleTiling,
+                ])
+                .is_err()
+                {
                     tracing::error!("could not send message to komorebi: ToggleTiling");
                 }
             }


### PR DESCRIPTION
This commit adds the `focus-monitor-at-cursor` command on all the toggle buttons as the monitor idx is not sent as a parameter and the monitor needs to be focused when these buttons are clicked on the bar (especially for multiple bars)