### PR TITLE
feat(bar): auto select/hide widget based on value

### DIFF
--- a/komorebi-bar/src/bar.rs
+++ b/komorebi-bar/src/bar.rs
@@ -14,6 +14,8 @@ use crate::widgets::komorebi::KomorebiNotificationState;
 use crate::widgets::widget::BarWidget;
 use crate::widgets::widget::WidgetConfig;
 use crate::KomorebiEvent;
+use crate::AUTO_SELECT_FILL_COLOUR;
+use crate::AUTO_SELECT_TEXT_COLOUR;
 use crate::BAR_HEIGHT;
 use crate::DEFAULT_PADDING;
 use crate::MAX_LABEL_WIDTH;
@@ -43,6 +45,7 @@ use eframe::egui::Vec2;
 use eframe::egui::Visuals;
 use font_loader::system_fonts;
 use font_loader::system_fonts::FontPropertyBuilder;
+use komorebi_client::Colour;
 use komorebi_client::KomorebiTheme;
 use komorebi_client::MonitorNotification;
 use komorebi_client::NotificationEvent;
@@ -88,71 +91,82 @@ pub fn apply_theme(
     grouping: Option<Grouping>,
     render_config: Rc<RefCell<RenderConfig>>,
 ) {
-    match theme {
+    let (auto_select_fill, auto_select_text) = match theme {
         KomobarTheme::Catppuccin {
             name: catppuccin,
             accent: catppuccin_value,
-        } => match catppuccin {
-            Catppuccin::Frappe => {
-                catppuccin_egui::set_theme(ctx, catppuccin_egui::FRAPPE);
-                let catppuccin_value = catppuccin_value.unwrap_or_default();
-                let accent = catppuccin_value.color32(catppuccin.as_theme());
+            auto_select_fill: catppuccin_auto_select_fill,
+            auto_select_text: catppuccin_auto_select_text,
+        } => {
+            match catppuccin {
+                Catppuccin::Frappe => {
+                    catppuccin_egui::set_theme(ctx, catppuccin_egui::FRAPPE);
+                    let catppuccin_value = catppuccin_value.unwrap_or_default();
+                    let accent = catppuccin_value.color32(catppuccin.as_theme());
 
-                ctx.style_mut(|style| {
-                    style.visuals.selection.stroke.color = accent;
-                    style.visuals.widgets.hovered.fg_stroke.color = accent;
-                    style.visuals.widgets.active.fg_stroke.color = accent;
-                    style.visuals.override_text_color = None;
-                });
+                    ctx.style_mut(|style| {
+                        style.visuals.selection.stroke.color = accent;
+                        style.visuals.widgets.hovered.fg_stroke.color = accent;
+                        style.visuals.widgets.active.fg_stroke.color = accent;
+                        style.visuals.override_text_color = None;
+                    });
 
-                bg_color.replace(catppuccin_egui::FRAPPE.base);
+                    bg_color.replace(catppuccin_egui::FRAPPE.base);
+                }
+                Catppuccin::Latte => {
+                    catppuccin_egui::set_theme(ctx, catppuccin_egui::LATTE);
+                    let catppuccin_value = catppuccin_value.unwrap_or_default();
+                    let accent = catppuccin_value.color32(catppuccin.as_theme());
+
+                    ctx.style_mut(|style| {
+                        style.visuals.selection.stroke.color = accent;
+                        style.visuals.widgets.hovered.fg_stroke.color = accent;
+                        style.visuals.widgets.active.fg_stroke.color = accent;
+                        style.visuals.override_text_color = None;
+                    });
+
+                    bg_color.replace(catppuccin_egui::LATTE.base);
+                }
+                Catppuccin::Macchiato => {
+                    catppuccin_egui::set_theme(ctx, catppuccin_egui::MACCHIATO);
+                    let catppuccin_value = catppuccin_value.unwrap_or_default();
+                    let accent = catppuccin_value.color32(catppuccin.as_theme());
+
+                    ctx.style_mut(|style| {
+                        style.visuals.selection.stroke.color = accent;
+                        style.visuals.widgets.hovered.fg_stroke.color = accent;
+                        style.visuals.widgets.active.fg_stroke.color = accent;
+                        style.visuals.override_text_color = None;
+                    });
+
+                    bg_color.replace(catppuccin_egui::MACCHIATO.base);
+                }
+                Catppuccin::Mocha => {
+                    catppuccin_egui::set_theme(ctx, catppuccin_egui::MOCHA);
+                    let catppuccin_value = catppuccin_value.unwrap_or_default();
+                    let accent = catppuccin_value.color32(catppuccin.as_theme());
+
+                    ctx.style_mut(|style| {
+                        style.visuals.selection.stroke.color = accent;
+                        style.visuals.widgets.hovered.fg_stroke.color = accent;
+                        style.visuals.widgets.active.fg_stroke.color = accent;
+                        style.visuals.override_text_color = None;
+                    });
+
+                    bg_color.replace(catppuccin_egui::MOCHA.base);
+                }
             }
-            Catppuccin::Latte => {
-                catppuccin_egui::set_theme(ctx, catppuccin_egui::LATTE);
-                let catppuccin_value = catppuccin_value.unwrap_or_default();
-                let accent = catppuccin_value.color32(catppuccin.as_theme());
 
-                ctx.style_mut(|style| {
-                    style.visuals.selection.stroke.color = accent;
-                    style.visuals.widgets.hovered.fg_stroke.color = accent;
-                    style.visuals.widgets.active.fg_stroke.color = accent;
-                    style.visuals.override_text_color = None;
-                });
-
-                bg_color.replace(catppuccin_egui::LATTE.base);
-            }
-            Catppuccin::Macchiato => {
-                catppuccin_egui::set_theme(ctx, catppuccin_egui::MACCHIATO);
-                let catppuccin_value = catppuccin_value.unwrap_or_default();
-                let accent = catppuccin_value.color32(catppuccin.as_theme());
-
-                ctx.style_mut(|style| {
-                    style.visuals.selection.stroke.color = accent;
-                    style.visuals.widgets.hovered.fg_stroke.color = accent;
-                    style.visuals.widgets.active.fg_stroke.color = accent;
-                    style.visuals.override_text_color = None;
-                });
-
-                bg_color.replace(catppuccin_egui::MACCHIATO.base);
-            }
-            Catppuccin::Mocha => {
-                catppuccin_egui::set_theme(ctx, catppuccin_egui::MOCHA);
-                let catppuccin_value = catppuccin_value.unwrap_or_default();
-                let accent = catppuccin_value.color32(catppuccin.as_theme());
-
-                ctx.style_mut(|style| {
-                    style.visuals.selection.stroke.color = accent;
-                    style.visuals.widgets.hovered.fg_stroke.color = accent;
-                    style.visuals.widgets.active.fg_stroke.color = accent;
-                    style.visuals.override_text_color = None;
-                });
-
-                bg_color.replace(catppuccin_egui::MOCHA.base);
-            }
-        },
+            (
+                catppuccin_auto_select_fill.map(|c| c.color32(catppuccin.as_theme())),
+                catppuccin_auto_select_text.map(|c| c.color32(catppuccin.as_theme())),
+            )
+        }
         KomobarTheme::Base16 {
             name: base16,
             accent: base16_value,
+            auto_select_fill: base16_auto_select_fill,
+            auto_select_text: base16_auto_select_text,
         } => {
             ctx.set_style(base16.style());
             let base16_value = base16_value.unwrap_or_default();
@@ -165,15 +179,22 @@ pub fn apply_theme(
             });
 
             bg_color.replace(base16.background());
+
+            (
+                base16_auto_select_fill.map(|c| c.color32(Base16Wrapper::Base16(base16))),
+                base16_auto_select_text.map(|c| c.color32(Base16Wrapper::Base16(base16))),
+            )
         }
         KomobarTheme::Custom {
             colours,
             accent: base16_value,
+            auto_select_fill: base16_auto_select_fill,
+            auto_select_text: base16_auto_select_text,
         } => {
             let background = colours.background();
             ctx.set_style(colours.style());
             let base16_value = base16_value.unwrap_or_default();
-            let accent = base16_value.color32(Base16Wrapper::Custom(colours));
+            let accent = base16_value.color32(Base16Wrapper::Custom(colours.clone()));
 
             ctx.style_mut(|style| {
                 style.visuals.selection.stroke.color = accent;
@@ -182,8 +203,22 @@ pub fn apply_theme(
             });
 
             bg_color.replace(background);
+
+            (
+                base16_auto_select_fill.map(|c| c.color32(Base16Wrapper::Custom(colours.clone()))),
+                base16_auto_select_text.map(|c| c.color32(Base16Wrapper::Custom(colours.clone()))),
+            )
         }
-    }
+    };
+
+    AUTO_SELECT_FILL_COLOUR.store(
+        auto_select_fill.map_or(0, |c| Colour::from(c).into()),
+        Ordering::SeqCst,
+    );
+    AUTO_SELECT_TEXT_COLOUR.store(
+        auto_select_text.map_or(0, |c| Colour::from(c).into()),
+        Ordering::SeqCst,
+    );
 
     // Apply transparency_alpha
     let theme_color = *bg_color.borrow();

--- a/komorebi-bar/src/config.rs
+++ b/komorebi-bar/src/config.rs
@@ -382,18 +382,24 @@ pub enum KomobarTheme {
         /// Name of the Catppuccin theme (theme previews: https://github.com/catppuccin/catppuccin)
         name: komorebi_themes::Catppuccin,
         accent: Option<komorebi_themes::CatppuccinValue>,
+        auto_select_fill: Option<komorebi_themes::CatppuccinValue>,
+        auto_select_text: Option<komorebi_themes::CatppuccinValue>,
     },
     /// A theme from base16-egui-themes
     Base16 {
         /// Name of the Base16 theme (theme previews: https://tinted-theming.github.io/tinted-gallery/)
         name: komorebi_themes::Base16,
         accent: Option<komorebi_themes::Base16Value>,
+        auto_select_fill: Option<komorebi_themes::Base16Value>,
+        auto_select_text: Option<komorebi_themes::Base16Value>,
     },
     /// A custom Base16 theme
     Custom {
         /// Colours of the custom Base16 theme palette
         colours: Box<komorebi_themes::Base16ColourPalette>,
         accent: Option<komorebi_themes::Base16Value>,
+        auto_select_fill: Option<komorebi_themes::Base16Value>,
+        auto_select_text: Option<komorebi_themes::Base16Value>,
     },
 }
 
@@ -405,12 +411,16 @@ impl From<KomorebiTheme> for KomobarTheme {
             } => Self::Catppuccin {
                 name,
                 accent: bar_accent,
+                auto_select_fill: None,
+                auto_select_text: None,
             },
             KomorebiTheme::Base16 {
                 name, bar_accent, ..
             } => Self::Base16 {
                 name,
                 accent: bar_accent,
+                auto_select_fill: None,
+                auto_select_text: None,
             },
             KomorebiTheme::Custom {
                 colours,
@@ -419,6 +429,8 @@ impl From<KomorebiTheme> for KomobarTheme {
             } => Self::Custom {
                 colours,
                 accent: bar_accent,
+                auto_select_fill: None,
+                auto_select_text: None,
             },
         }
     }

--- a/komorebi-bar/src/main.rs
+++ b/komorebi-bar/src/main.rs
@@ -23,6 +23,7 @@ use std::io::BufReader;
 use std::io::Read;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI32;
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::LazyLock;
@@ -46,6 +47,9 @@ pub static MONITOR_RIGHT: AtomicI32 = AtomicI32::new(0);
 pub static MONITOR_INDEX: AtomicUsize = AtomicUsize::new(0);
 pub static BAR_HEIGHT: f32 = 50.0;
 pub static DEFAULT_PADDING: f32 = 10.0;
+
+pub static AUTO_SELECT_FILL_COLOUR: AtomicU32 = AtomicU32::new(0);
+pub static AUTO_SELECT_TEXT_COLOUR: AtomicU32 = AtomicU32::new(0);
 
 pub static ICON_CACHE: LazyLock<Mutex<HashMap<isize, RgbaImage>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));

--- a/komorebi-bar/src/render.rs
+++ b/komorebi-bar/src/render.rs
@@ -1,6 +1,8 @@
 use crate::bar::Alignment;
 use crate::config::KomobarConfig;
 use crate::config::MonitorConfigOrIndex;
+use crate::AUTO_SELECT_FILL_COLOUR;
+use crate::AUTO_SELECT_TEXT_COLOUR;
 use eframe::egui::Color32;
 use eframe::egui::Context;
 use eframe::egui::CornerRadius;
@@ -11,8 +13,11 @@ use eframe::egui::Margin;
 use eframe::egui::Shadow;
 use eframe::egui::TextStyle;
 use eframe::egui::Ui;
+use komorebi_client::Colour;
+use komorebi_client::Rgb;
 use serde::Deserialize;
 use serde::Serialize;
+use std::num::NonZeroU32;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -55,6 +60,10 @@ pub struct RenderConfig {
     pub icon_font_id: FontId,
     /// Show all icons on the workspace section of the Komorebi widget
     pub show_all_icons: bool,
+    /// Background color of the selected frame
+    pub auto_select_fill: Option<Color32>,
+    /// Text color of the selected frame
+    pub auto_select_text: Option<Color32>,
 }
 
 pub trait RenderExt {
@@ -108,6 +117,10 @@ impl RenderExt for &KomobarConfig {
             text_font_id,
             icon_font_id,
             show_all_icons,
+            auto_select_fill: NonZeroU32::new(AUTO_SELECT_FILL_COLOUR.load(Ordering::SeqCst))
+                .map(|c| Colour::Rgb(Rgb::from(c.get())).into()),
+            auto_select_text: NonZeroU32::new(AUTO_SELECT_TEXT_COLOUR.load(Ordering::SeqCst))
+                .map(|c| Colour::Rgb(Rgb::from(c.get())).into()),
         }
     }
 }
@@ -133,6 +146,8 @@ impl RenderConfig {
             text_font_id: FontId::default(),
             icon_font_id: FontId::default(),
             show_all_icons: false,
+            auto_select_fill: None,
+            auto_select_text: None,
         }
     }
 

--- a/komorebi-bar/src/selected_frame.rs
+++ b/komorebi-bar/src/selected_frame.rs
@@ -10,15 +10,29 @@ use eframe::egui::Ui;
 /// Same as SelectableLabel, but supports all content
 pub struct SelectableFrame {
     selected: bool,
+    selected_fill: Option<Color32>,
 }
 
 impl SelectableFrame {
     pub fn new(selected: bool) -> Self {
-        Self { selected }
+        Self {
+            selected,
+            selected_fill: None,
+        }
+    }
+
+    pub fn new_auto(selected: bool, selected_fill: Option<Color32>) -> Self {
+        Self {
+            selected,
+            selected_fill,
+        }
     }
 
     pub fn show<R>(self, ui: &mut Ui, add_contents: impl FnOnce(&mut Ui) -> R) -> Response {
-        let Self { selected } = self;
+        let Self {
+            selected,
+            selected_fill,
+        } = self;
 
         Frame::NONE
             .show(ui, |ui| {
@@ -32,7 +46,16 @@ impl SelectableFrame {
                     );
 
                     // since the stroke is drawn inside the frame, we always reserve space for it
-                    if response.hovered() || response.highlighted() || response.has_focus() {
+                    if selected && response.hovered() {
+                        let visuals = ui.style().interact_selectable(&response, selected);
+
+                        Frame::NONE
+                            .stroke(Stroke::new(1.0, visuals.bg_stroke.color))
+                            .corner_radius(visuals.corner_radius)
+                            .fill(selected_fill.unwrap_or(visuals.bg_fill))
+                            .inner_margin(inner_margin)
+                            .show(ui, add_contents);
+                    } else if response.hovered() || response.highlighted() || response.has_focus() {
                         let visuals = ui.style().interact_selectable(&response, selected);
 
                         Frame::NONE
@@ -47,7 +70,7 @@ impl SelectableFrame {
                         Frame::NONE
                             .stroke(Stroke::new(1.0, visuals.bg_fill))
                             .corner_radius(visuals.corner_radius)
-                            .fill(visuals.bg_fill)
+                            .fill(selected_fill.unwrap_or(visuals.bg_fill))
                             .inner_margin(inner_margin)
                             .show(ui, add_contents);
                     } else {

--- a/komorebi-bar/src/widgets/cpu.rs
+++ b/komorebi-bar/src/widgets/cpu.rs
@@ -25,6 +25,8 @@ pub struct CpuConfig {
     pub data_refresh_interval: Option<u64>,
     /// Display label prefix
     pub label_prefix: Option<LabelPrefix>,
+    /// Select when the current percentage is over this value [[1-100]]
+    pub auto_select_over: Option<u8>,
 }
 
 impl From<CpuConfig> for Cpu {
@@ -38,6 +40,7 @@ impl From<CpuConfig> for Cpu {
             ),
             data_refresh_interval,
             label_prefix: value.label_prefix.unwrap_or(LabelPrefix::IconAndText),
+            auto_select_over: value.auto_select_over.map(|o| o.clamp(1, 100)),
             last_updated: Instant::now()
                 .checked_sub(Duration::from_secs(data_refresh_interval))
                 .unwrap(),
@@ -45,26 +48,38 @@ impl From<CpuConfig> for Cpu {
     }
 }
 
+#[derive(Clone, Debug)]
+struct CpuOutput {
+    label: String,
+    selected: bool,
+}
+
 pub struct Cpu {
     pub enable: bool,
     system: System,
     data_refresh_interval: u64,
     label_prefix: LabelPrefix,
+    auto_select_over: Option<u8>,
     last_updated: Instant,
 }
 
 impl Cpu {
-    fn output(&mut self) -> String {
+    fn output(&mut self) -> CpuOutput {
         let now = Instant::now();
         if now.duration_since(self.last_updated) > Duration::from_secs(self.data_refresh_interval) {
             self.system.refresh_cpu_usage();
             self.last_updated = now;
         }
 
-        let used = self.system.global_cpu_usage();
-        match self.label_prefix {
-            LabelPrefix::Text | LabelPrefix::IconAndText => format!("CPU: {:.0}%", used),
-            LabelPrefix::None | LabelPrefix::Icon => format!("{:.0}%", used),
+        let used = self.system.global_cpu_usage() as u8;
+        let selected = self.auto_select_over.is_some_and(|o| used >= o);
+
+        CpuOutput {
+            label: match self.label_prefix {
+                LabelPrefix::Text | LabelPrefix::IconAndText => format!("CPU: {}%", used),
+                LabelPrefix::None | LabelPrefix::Icon => format!("{}%", used),
+            },
+            selected,
         }
     }
 }
@@ -73,7 +88,9 @@ impl BarWidget for Cpu {
     fn render(&mut self, ctx: &Context, ui: &mut Ui, config: &mut RenderConfig) {
         if self.enable {
             let output = self.output();
-            if !output.is_empty() {
+            if !output.label.is_empty() {
+                let auto_text_color = config.auto_select_text.filter(|_| output.selected);
+
                 let mut layout_job = LayoutJob::simple(
                     match self.label_prefix {
                         LabelPrefix::Icon | LabelPrefix::IconAndText => {
@@ -82,23 +99,25 @@ impl BarWidget for Cpu {
                         LabelPrefix::None | LabelPrefix::Text => String::new(),
                     },
                     config.icon_font_id.clone(),
-                    ctx.style().visuals.selection.stroke.color,
+                    auto_text_color.unwrap_or(ctx.style().visuals.selection.stroke.color),
                     100.0,
                 );
 
                 layout_job.append(
-                    &output,
+                    &output.label,
                     10.0,
                     TextFormat {
                         font_id: config.text_font_id.clone(),
-                        color: ctx.style().visuals.text_color(),
+                        color: auto_text_color.unwrap_or(ctx.style().visuals.text_color()),
                         valign: Align::Center,
                         ..Default::default()
                     },
                 );
 
+                let auto_focus_fill = config.auto_select_fill;
+
                 config.apply_on_widget(false, ui, |ui| {
-                    if SelectableFrame::new(false)
+                    if SelectableFrame::new_auto(output.selected, auto_focus_fill)
                         .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                         .clicked()
                     {

--- a/komorebi-bar/src/widgets/memory.rs
+++ b/komorebi-bar/src/widgets/memory.rs
@@ -25,6 +25,8 @@ pub struct MemoryConfig {
     pub data_refresh_interval: Option<u64>,
     /// Display label prefix
     pub label_prefix: Option<LabelPrefix>,
+    /// Select when the current percentage is over this value [[1-100]]
+    pub auto_select_over: Option<u8>,
 }
 
 impl From<MemoryConfig> for Memory {
@@ -38,6 +40,7 @@ impl From<MemoryConfig> for Memory {
             ),
             data_refresh_interval,
             label_prefix: value.label_prefix.unwrap_or(LabelPrefix::IconAndText),
+            auto_select_over: value.auto_select_over.map(|o| o.clamp(1, 100)),
             last_updated: Instant::now()
                 .checked_sub(Duration::from_secs(data_refresh_interval))
                 .unwrap(),
@@ -45,16 +48,23 @@ impl From<MemoryConfig> for Memory {
     }
 }
 
+#[derive(Clone, Debug)]
+struct MemoryOutput {
+    label: String,
+    selected: bool,
+}
+
 pub struct Memory {
     pub enable: bool,
     system: System,
     data_refresh_interval: u64,
     label_prefix: LabelPrefix,
+    auto_select_over: Option<u8>,
     last_updated: Instant,
 }
 
 impl Memory {
-    fn output(&mut self) -> String {
+    fn output(&mut self) -> MemoryOutput {
         let now = Instant::now();
         if now.duration_since(self.last_updated) > Duration::from_secs(self.data_refresh_interval) {
             self.system.refresh_memory();
@@ -63,11 +73,17 @@ impl Memory {
 
         let used = self.system.used_memory();
         let total = self.system.total_memory();
-        match self.label_prefix {
-            LabelPrefix::Text | LabelPrefix::IconAndText => {
-                format!("RAM: {}%", (used * 100) / total)
-            }
-            LabelPrefix::None | LabelPrefix::Icon => format!("{}%", (used * 100) / total),
+        let usage = ((used * 100) / total) as u8;
+        let selected = self.auto_select_over.is_some_and(|o| usage >= o);
+
+        MemoryOutput {
+            label: match self.label_prefix {
+                LabelPrefix::Text | LabelPrefix::IconAndText => {
+                    format!("RAM: {}%", usage)
+                }
+                LabelPrefix::None | LabelPrefix::Icon => format!("{}%", usage),
+            },
+            selected,
         }
     }
 }
@@ -76,7 +92,9 @@ impl BarWidget for Memory {
     fn render(&mut self, ctx: &Context, ui: &mut Ui, config: &mut RenderConfig) {
         if self.enable {
             let output = self.output();
-            if !output.is_empty() {
+            if !output.label.is_empty() {
+                let auto_text_color = config.auto_select_text.filter(|_| output.selected);
+
                 let mut layout_job = LayoutJob::simple(
                     match self.label_prefix {
                         LabelPrefix::Icon | LabelPrefix::IconAndText => {
@@ -85,23 +103,25 @@ impl BarWidget for Memory {
                         LabelPrefix::None | LabelPrefix::Text => String::new(),
                     },
                     config.icon_font_id.clone(),
-                    ctx.style().visuals.selection.stroke.color,
+                    auto_text_color.unwrap_or(ctx.style().visuals.selection.stroke.color),
                     100.0,
                 );
 
                 layout_job.append(
-                    &output,
+                    &output.label,
                     10.0,
                     TextFormat {
                         font_id: config.text_font_id.clone(),
-                        color: ctx.style().visuals.text_color(),
+                        color: auto_text_color.unwrap_or(ctx.style().visuals.text_color()),
                         valign: Align::Center,
                         ..Default::default()
                     },
                 );
 
+                let auto_focus_fill = config.auto_select_fill;
+
                 config.apply_on_widget(false, ui, |ui| {
-                    if SelectableFrame::new(false)
+                    if SelectableFrame::new_auto(output.selected, auto_focus_fill)
                         .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                         .clicked()
                     {

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -26,6 +26,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_under": {
+                    "description": "Select when the current percentage is under this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -90,6 +96,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -752,6 +764,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -810,10 +828,46 @@
                 "type": "object",
                 "required": [
                   "enable",
-                  "show_network_activity",
-                  "show_total_data_transmitted"
+                  "show_activity",
+                  "show_total_activity"
                 ],
                 "properties": {
+                  "activity_left_padding": {
+                    "description": "Characters to reserve for received and transmitted activity",
+                    "type": "integer",
+                    "format": "uint",
+                    "minimum": 0.0
+                  },
+                  "auto_select": {
+                    "description": "Select when the value is over a limit (1MiB is 1048576 bytes (1024*1024))",
+                    "type": "object",
+                    "properties": {
+                      "received_over": {
+                        "description": "Select the received data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "total_received_over": {
+                        "description": "Select the total received data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "total_transmitted_over": {
+                        "description": "Select the total transmitted data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "transmitted_over": {
+                        "description": "Select the transmitted data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      }
+                    }
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -857,22 +911,16 @@
                       }
                     ]
                   },
-                  "network_activity_fill_characters": {
-                    "description": "Characters to reserve for network activity data",
-                    "type": "integer",
-                    "format": "uint",
-                    "minimum": 0.0
+                  "show_activity": {
+                    "description": "Show received and transmitted activity",
+                    "type": "boolean"
                   },
                   "show_default_interface": {
                     "description": "Show default interface",
                     "type": "boolean"
                   },
-                  "show_network_activity": {
-                    "description": "Show network activity",
-                    "type": "boolean"
-                  },
-                  "show_total_data_transmitted": {
-                    "description": "Show total data transmitted",
+                  "show_total_activity": {
+                    "description": "Show total received and transmitted activity",
                     "type": "boolean"
                   }
                 }
@@ -892,6 +940,18 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_hide_under": {
+                    "description": "Hide when the current percentage is under this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -1493,6 +1553,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_under": {
+                    "description": "Select when the current percentage is under this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -1557,6 +1623,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -2219,6 +2291,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -2277,10 +2355,46 @@
                 "type": "object",
                 "required": [
                   "enable",
-                  "show_network_activity",
-                  "show_total_data_transmitted"
+                  "show_activity",
+                  "show_total_activity"
                 ],
                 "properties": {
+                  "activity_left_padding": {
+                    "description": "Characters to reserve for received and transmitted activity",
+                    "type": "integer",
+                    "format": "uint",
+                    "minimum": 0.0
+                  },
+                  "auto_select": {
+                    "description": "Select when the value is over a limit (1MiB is 1048576 bytes (1024*1024))",
+                    "type": "object",
+                    "properties": {
+                      "received_over": {
+                        "description": "Select the received data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "total_received_over": {
+                        "description": "Select the total received data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "total_transmitted_over": {
+                        "description": "Select the total transmitted data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "transmitted_over": {
+                        "description": "Select the transmitted data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      }
+                    }
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -2324,22 +2438,16 @@
                       }
                     ]
                   },
-                  "network_activity_fill_characters": {
-                    "description": "Characters to reserve for network activity data",
-                    "type": "integer",
-                    "format": "uint",
-                    "minimum": 0.0
+                  "show_activity": {
+                    "description": "Show received and transmitted activity",
+                    "type": "boolean"
                   },
                   "show_default_interface": {
                     "description": "Show default interface",
                     "type": "boolean"
                   },
-                  "show_network_activity": {
-                    "description": "Show network activity",
-                    "type": "boolean"
-                  },
-                  "show_total_data_transmitted": {
-                    "description": "Show total data transmitted",
+                  "show_total_activity": {
+                    "description": "Show total received and transmitted activity",
                     "type": "boolean"
                   }
                 }
@@ -2359,6 +2467,18 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_hide_under": {
+                    "description": "Hide when the current percentage is under this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -2893,6 +3013,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_under": {
+                    "description": "Select when the current percentage is under this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -2957,6 +3083,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -3619,6 +3751,12 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -3677,10 +3815,46 @@
                 "type": "object",
                 "required": [
                   "enable",
-                  "show_network_activity",
-                  "show_total_data_transmitted"
+                  "show_activity",
+                  "show_total_activity"
                 ],
                 "properties": {
+                  "activity_left_padding": {
+                    "description": "Characters to reserve for received and transmitted activity",
+                    "type": "integer",
+                    "format": "uint",
+                    "minimum": 0.0
+                  },
+                  "auto_select": {
+                    "description": "Select when the value is over a limit (1MiB is 1048576 bytes (1024*1024))",
+                    "type": "object",
+                    "properties": {
+                      "received_over": {
+                        "description": "Select the received data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "total_received_over": {
+                        "description": "Select the total received data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "total_transmitted_over": {
+                        "description": "Select the total transmitted data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      },
+                      "transmitted_over": {
+                        "description": "Select the transmitted data when it's over this value",
+                        "type": "integer",
+                        "format": "uint64",
+                        "minimum": 0.0
+                      }
+                    }
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -3724,22 +3898,16 @@
                       }
                     ]
                   },
-                  "network_activity_fill_characters": {
-                    "description": "Characters to reserve for network activity data",
-                    "type": "integer",
-                    "format": "uint",
-                    "minimum": 0.0
+                  "show_activity": {
+                    "description": "Show received and transmitted activity",
+                    "type": "boolean"
                   },
                   "show_default_interface": {
                     "description": "Show default interface",
                     "type": "boolean"
                   },
-                  "show_network_activity": {
-                    "description": "Show network activity",
-                    "type": "boolean"
-                  },
-                  "show_total_data_transmitted": {
-                    "description": "Show total data transmitted",
+                  "show_total_activity": {
+                    "description": "Show total received and transmitted activity",
                     "type": "boolean"
                   }
                 }
@@ -3759,6 +3927,18 @@
                   "enable"
                 ],
                 "properties": {
+                  "auto_hide_under": {
+                    "description": "Hide when the current percentage is under this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
+                  "auto_select_over": {
+                    "description": "Select when the current percentage is over this value [[1-100]]",
+                    "type": "integer",
+                    "format": "uint8",
+                    "minimum": 0.0
+                  },
                   "data_refresh_interval": {
                     "description": "Data refresh interval (default: 10 seconds)",
                     "type": "integer",
@@ -4035,6 +4215,68 @@
                 "Crust"
               ]
             },
+            "auto_select_fill": {
+              "type": "string",
+              "enum": [
+                "Rosewater",
+                "Flamingo",
+                "Pink",
+                "Mauve",
+                "Red",
+                "Maroon",
+                "Peach",
+                "Yellow",
+                "Green",
+                "Teal",
+                "Sky",
+                "Sapphire",
+                "Blue",
+                "Lavender",
+                "Text",
+                "Subtext1",
+                "Subtext0",
+                "Overlay2",
+                "Overlay1",
+                "Overlay0",
+                "Surface2",
+                "Surface1",
+                "Surface0",
+                "Base",
+                "Mantle",
+                "Crust"
+              ]
+            },
+            "auto_select_text": {
+              "type": "string",
+              "enum": [
+                "Rosewater",
+                "Flamingo",
+                "Pink",
+                "Mauve",
+                "Red",
+                "Maroon",
+                "Peach",
+                "Yellow",
+                "Green",
+                "Teal",
+                "Sky",
+                "Sapphire",
+                "Blue",
+                "Lavender",
+                "Text",
+                "Subtext1",
+                "Subtext0",
+                "Overlay2",
+                "Overlay1",
+                "Overlay0",
+                "Surface2",
+                "Surface1",
+                "Surface0",
+                "Base",
+                "Mantle",
+                "Crust"
+              ]
+            },
             "name": {
               "description": "Name of the Catppuccin theme (theme previews: https://github.com/catppuccin/catppuccin)",
               "type": "string",
@@ -4062,6 +4304,48 @@
           ],
           "properties": {
             "accent": {
+              "type": "string",
+              "enum": [
+                "Base00",
+                "Base01",
+                "Base02",
+                "Base03",
+                "Base04",
+                "Base05",
+                "Base06",
+                "Base07",
+                "Base08",
+                "Base09",
+                "Base0A",
+                "Base0B",
+                "Base0C",
+                "Base0D",
+                "Base0E",
+                "Base0F"
+              ]
+            },
+            "auto_select_fill": {
+              "type": "string",
+              "enum": [
+                "Base00",
+                "Base01",
+                "Base02",
+                "Base03",
+                "Base04",
+                "Base05",
+                "Base06",
+                "Base07",
+                "Base08",
+                "Base09",
+                "Base0A",
+                "Base0B",
+                "Base0C",
+                "Base0D",
+                "Base0E",
+                "Base0F"
+              ]
+            },
+            "auto_select_text": {
               "type": "string",
               "enum": [
                 "Base00",
@@ -4374,6 +4658,48 @@
           ],
           "properties": {
             "accent": {
+              "type": "string",
+              "enum": [
+                "Base00",
+                "Base01",
+                "Base02",
+                "Base03",
+                "Base04",
+                "Base05",
+                "Base06",
+                "Base07",
+                "Base08",
+                "Base09",
+                "Base0A",
+                "Base0B",
+                "Base0C",
+                "Base0D",
+                "Base0E",
+                "Base0F"
+              ]
+            },
+            "auto_select_fill": {
+              "type": "string",
+              "enum": [
+                "Base00",
+                "Base01",
+                "Base02",
+                "Base03",
+                "Base04",
+                "Base05",
+                "Base06",
+                "Base07",
+                "Base08",
+                "Base09",
+                "Base0A",
+                "Base0B",
+                "Base0C",
+                "Base0D",
+                "Base0E",
+                "Base0F"
+              ]
+            },
+            "auto_select_text": {
               "type": "string",
               "enum": [
                 "Base00",


### PR DESCRIPTION
This commit adds new settings to some widgets that allows to auto select/hide them based on their current values.

The cpu/memory/network/storage widgets get a setting that auto selects the widget if the current value/percentage is over a value.

The battery widget gets a setting that auto selects the widget if the current percentage is under a value.

The storage widget gets a setting that auto hides the disk widget if the percentage is under a value.

```json
    {
      "Memory": {
        "enable": true,
        "data_refresh_interval": 5,
        "label_prefix": "Icon",
        "auto_select_over": 40
      }
    },
    {
      "Battery": {
        "enable": true,
        "hide_on_full_charge": true,
        "auto_select_under": 15
      }
    },
    {
      "Storage": {
        "enable": true,
        "auto_select_over": 95,
        "auto_hide_under": 90
      }
    },
```

https://github.com/user-attachments/assets/546fdd10-dbc8-464c-8fcb-813dc46c1dc7

Also added 2 new settings (auto_select_fill and auto_select_text) to the theme, in order to select the fill and
text colors of an auto selected widget.

---

![Screenshot 2025-03-18 224417](https://github.com/user-attachments/assets/bd95dcf1-f0ac-46e3-9dd8-3c29fb2b256a)

```json
  "theme": {
    "palette": "Base16",
    "name": "AyuMirage",
    "accent": "Base09",
    "auto_select_fill": "Base03",
    "auto_select_text": "Base09"
  },
```

---

![image](https://github.com/user-attachments/assets/6f267c60-0c84-49cb-907f-6c1817269a25)

```json
  "theme": {
    "palette": "Base16",
    "name": "Ashes",
    "accent": "Base0D",
    "auto_select_fill": "Base05",
    "auto_select_text": "Base02"
  },
```

---

![image](https://github.com/user-attachments/assets/e49e2b34-5ad2-47e9-bb3a-4676a2924ef4)

```json
  "theme": {
    "palette": "Catppuccin",
    "name": "Latte",
    "accent": "Blue",
    "auto_select_fill": "Blue",
    "auto_select_text": "Crust"
  },
```