### PR TITLE
fix(wm): fix bugs on workspace restore and remove workarounds

### DIFF
--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1378,26 +1378,6 @@ impl WindowManager {
                     }
                 }
             }
-
-            // This is to correctly restore and focus when switching to a workspace which
-            // contains a managed maximized window
-            if let Some(window) = self.focused_workspace()?.maximized_window() {
-                window.restore();
-                if trigger_focus {
-                    window.focus(self.mouse_follows_focus)?;
-                }
-            }
-
-            // This is to correctly remove focus from the previous when changing focused workspace
-            // to a workspace which only contains floating windows and no other kind of managed window
-            if self.focused_workspace()?.containers().is_empty()
-                && self.focused_workspace()?.monocle_container().is_none()
-                && self.focused_workspace()?.maximized_window().is_none()
-            {
-                if let Some(window) = self.focused_workspace()?.floating_windows().first() {
-                    window.focus(self.mouse_follows_focus)?;
-                }
-            }
         }
 
         Ok(())

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -282,7 +282,7 @@ impl Workspace {
     }
 
     pub fn restore(&mut self, mouse_follows_focus: bool) -> Result<()> {
-        if let Some(container) = self.monocle_container_mut() {
+        if let Some(container) = self.monocle_container() {
             if let Some(window) = container.focused_window() {
                 container.restore();
                 window.focus(mouse_follows_focus)?;
@@ -318,10 +318,16 @@ impl Workspace {
             if self.maximized_window().is_none() && matches!(self.layer, WorkspaceLayer::Tiling) {
                 window.focus(mouse_follows_focus)?;
             } else if let Some(maximized_window) = self.maximized_window() {
+                maximized_window.restore();
                 maximized_window.focus(mouse_follows_focus)?;
             } else if let Some(floating_window) = self.floating_windows().first() {
                 floating_window.focus(mouse_follows_focus)?;
             }
+        } else if let Some(maximized_window) = self.maximized_window() {
+            maximized_window.restore();
+            maximized_window.focus(mouse_follows_focus)?;
+        } else if let Some(floating_window) = self.floating_windows().first() {
+            floating_window.focus(mouse_follows_focus)?;
         }
 
         Ok(())


### PR DESCRIPTION
This commit removes some workarounds on the `update_focused_workspace` function that were there to fix issues related to some bugs on the `workspace.restore()` function. This commit fixes the bugs on the `restore` function instead. The `update_focused_workspace` function should be used only to update a workspace layout.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
