### PR TITLE
fix: forced float-override on `Floating` layer without overwriting user config

### DIFF
--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -634,11 +634,16 @@ impl WindowManager {
                         self.window_management_behaviour.current_behaviour
                     };
 
-                let float_override = if let Some(float_override) = workspace.float_override() {
+                let mut float_override = if let Some(float_override) = workspace.float_override() {
                     *float_override
                 } else {
                     self.window_management_behaviour.float_override
                 };
+
+                // If the workspace layer is `Floating`, then consider it as if it had float
+                // override so that new windows spawn as floating
+                float_override =
+                    float_override || matches!(workspace.layer, WorkspaceLayer::Floating);
 
                 return WindowManagementBehaviour {
                     current_behaviour,

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -88,7 +88,7 @@ pub struct Workspace {
     pub float_override: Option<bool>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     pub globals: WorkspaceGlobals,
-    #[getset(get = "pub", get_mut = "pub")]
+    #[getset(get = "pub", get_mut = "pub", set = "pub")]
     pub layer: WorkspaceLayer,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getset(get = "pub", set = "pub")]
@@ -591,19 +591,6 @@ impl Workspace {
         }
 
         Ok((hwnds.len() + floating_hwnds.len(), container_ids.len()))
-    }
-
-    pub fn set_layer(&mut self, layer: WorkspaceLayer) {
-        self.layer = layer;
-
-        match layer {
-            WorkspaceLayer::Tiling => {
-                self.float_override = None;
-            }
-            WorkspaceLayer::Floating => {
-                self.float_override = Some(true);
-            }
-        }
     }
 
     pub fn container_for_window(&self, hwnd: isize) -> Option<&Container> {


### PR DESCRIPTION
As mentioned on Discord this PR reverts the previous commit that turned on the `float_override` when switching to the `Floating` layer and turned it off when switching to the `Tiling` layer since this would result in an overwrite of the user config.

This PR uses a different method to accomplish the same behaviour without overwriting the user's config. It changes the `window_management_behaviour()` function to check the behaviour for the workspace in question and then it checks if the workspace has the `float_override` set or if the workspace layer is `Floating`.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
