### PR TITLE
fix(wm): change when floating windows are centered

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -395,10 +395,19 @@ impl WindowManager {
                                     && !matches!(event, WindowManagerEvent::Manage(_)));
 
                             if behaviour.float_override {
+                                // Center floating windows if we are already on the `Floating`
+                                // layer and the window doesn't match a `floating_windows` rule and
+                                // the workspace is not a floating workspace
+                                let center_spawned_floats =
+                                    matches!(workspace.layer, WorkspaceLayer::Floating)
+                                        && !should_float
+                                        && workspace.tile;
                                 workspace.floating_windows_mut().push(window);
                                 workspace.set_layer(WorkspaceLayer::Floating);
-                                let mut floating_window = window;
-                                floating_window.center(&workspace.globals().work_area)?;
+                                if center_spawned_floats {
+                                    let mut floating_window = window;
+                                    floating_window.center(&workspace.globals().work_area)?;
+                                }
                                 self.update_focused_workspace(false, false)?;
                             } else {
                                 match behaviour.current_behaviour {


### PR DESCRIPTION
This commit changes the behaviour of when floating windows are centered by making them only center when we are on a `WorkspaceLayer::Floating` and the window doesn't match a `floating_windows` rule and the workspace is not a floating workspace.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
