### PR TITLE
feat(wm): added an unique id to the workspace

### DIFF
--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -319,6 +319,7 @@ impl From<&WindowManager> for State {
                         .iter()
                         .map(|workspace| Workspace {
                             name: workspace.name.clone(),
+                            id: workspace.id.clone(),
                             containers: workspace.containers.clone(),
                             monocle_container: workspace.monocle_container.clone(),
                             monocle_container_restore_idx: workspace.monocle_container_restore_idx,

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -11,6 +11,7 @@ use getset::CopyGetters;
 use getset::Getters;
 use getset::MutGetters;
 use getset::Setters;
+use nanoid::nanoid;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -51,6 +52,8 @@ use crate::REMOVE_TITLEBARS;
 pub struct Workspace {
     #[getset(get = "pub", set = "pub")]
     pub name: Option<String>,
+    #[getset(get = "pub")]
+    id: String,
     pub containers: Ring<Container>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     pub monocle_container: Option<Container>,
@@ -122,6 +125,7 @@ impl Default for Workspace {
     fn default() -> Self {
         Self {
             name: None,
+            id: nanoid!(),
             containers: Ring::default(),
             monocle_container: None,
             maximized_window: None,

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -53,7 +53,7 @@ pub struct Workspace {
     #[getset(get = "pub", set = "pub")]
     pub name: Option<String>,
     #[getset(get = "pub")]
-    id: String,
+    pub id: String,
     pub containers: Ring<Container>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     pub monocle_container: Option<Container>,


### PR DESCRIPTION
Added identification for workspace to identify it on the WM level not monitor level this a series of commits to maybe allow lower level socket message and workspace is the only WM type that doesn't have a unique ID across the entire WM

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
