### PR TITLE
feat(core): add `ExpandEnvVars` trait to handle environment variable expansion in paths

### DIFF
--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -29,6 +29,7 @@ pub use komorebi::core::CustomLayout;
 pub use komorebi::core::CycleDirection;
 pub use komorebi::core::DefaultLayout;
 pub use komorebi::core::Direction;
+pub use komorebi::core::ExpandEnvVars;
 pub use komorebi::core::FocusFollowsMouseImplementation;
 pub use komorebi::core::HidingBehaviour;
 pub use komorebi::core::Layout;

--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::missing_errors_doc, clippy::use_self, clippy::doc_markdown)]
 
+use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -442,44 +443,114 @@ impl Sizing {
 }
 
 pub fn resolve_home_path<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
-    let mut resolved_path = PathBuf::new();
-    let mut resolved = false;
-    for c in path.as_ref().components() {
-        match c {
-            std::path::Component::Normal(c)
-                if (c == "~" || c == "$Env:USERPROFILE" || c == "$HOME") && !resolved =>
-            {
-                let home = dirs::home_dir().ok_or_else(|| anyhow!("there is no home directory"))?;
+    Ok(path.expand_vars())
+}
 
-                resolved_path.extend(home.components());
-                resolved = true;
+/// Expand environment variables components in a path.
+pub trait ExpandEnvVars {
+    /// Expand environment variables components in a path.
+    ///
+    /// Expands the follwing formats:
+    /// - CMD: `%variable%`
+    /// - PowerShell: `$Env:variable`
+    /// - Bash: `$variable`.
+    fn expand_vars(&self) -> PathBuf;
+}
+
+impl<T: AsRef<Path>> ExpandEnvVars for T {
+    fn expand_vars(&self) -> PathBuf {
+        let mut out = PathBuf::new();
+
+        for c in self.as_ref().components() {
+            match c {
+                std::path::Component::Normal(mut c) => {
+                    // Special case for ~ and $HOME, replace with $Env:USERPROFILE
+                    if c == OsStr::new("~") || c.eq_ignore_ascii_case("$HOME") {
+                        c = OsStr::new("$Env:USERPROFILE");
+                    }
+
+                    let bytes = c.as_encoded_bytes();
+
+                    // %LOCALAPPDATA%
+                    let var = if bytes[0] == b'%' && bytes[bytes.len() - 1] == b'%' {
+                        Some(&bytes[1..bytes.len() - 1])
+                    } else {
+                        // prefix length is 5 for $Env: and 1 for $
+                        // so we take the minimum of 5 and the length of the bytes
+                        let prefix = &bytes[..5.min(bytes.len())];
+                        let prefix = unsafe { OsStr::from_encoded_bytes_unchecked(prefix) };
+
+                        // $Env:LOCALAPPDATA
+                        if prefix.eq_ignore_ascii_case("$Env:") {
+                            Some(&bytes[5..])
+                        } else if bytes[0] == b'$' {
+                            // $LOCALAPPDATA
+                            Some(&bytes[1..])
+                        } else {
+                            // not a variable
+                            None
+                        }
+                    };
+
+                    // if component is a variable, get the value from the environment
+                    if let Some(var) = var {
+                        let var = unsafe { OsStr::from_encoded_bytes_unchecked(var) };
+                        if let Ok(value) = std::env::var(var) {
+                            out.push(value);
+                            continue;
+                        }
+                    }
+
+                    // if not a variable, or a value couldn't be obtained from environemnt
+                    // then push the component as is
+                    out.push(c);
+                }
+
+                // other components are pushed as is
+                _ => out.push(c),
             }
-
-            std::path::Component::Normal(c) if (c == "$Env:KOMOREBI_CONFIG_HOME") && !resolved => {
-                let komorebi_config_home =
-                    PathBuf::from(std::env::var("KOMOREBI_CONFIG_HOME").ok().ok_or_else(|| {
-                        anyhow!("there is no KOMOREBI_CONFIG_HOME environment variable set")
-                    })?);
-
-                resolved_path.extend(komorebi_config_home.components());
-                resolved = true;
-            }
-
-            _ => resolved_path.push(c),
         }
+
+        out
     }
+}
 
-    let parent = resolved_path
-        .parent()
-        .ok_or_else(|| anyhow!("cannot parse parent directory"))?;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    Ok(if parent.is_dir() {
-        let file = resolved_path
-            .components()
-            .last()
-            .ok_or_else(|| anyhow!("cannot parse filename"))?;
-        dunce::canonicalize(parent)?.join(file)
-    } else {
-        resolved_path
-    })
+    #[test]
+    fn resolves_env_vars() {
+        // helper functions
+        fn path<P: AsRef<Path>>(p: P) -> PathBuf {
+            // Ensure that the path is using the correct path separator for the OS.
+            p.as_ref().components().collect::<PathBuf>()
+        }
+
+        fn expand<P: AsRef<Path>>(p: P) -> PathBuf {
+            p.expand_vars()
+        }
+
+        // Set a variable for testing
+        std::env::set_var("VAR", "VALUE");
+
+        // %VAR% format
+        assert_eq!(expand("/path/%VAR%/to/dir"), path("/path/VALUE/to/dir"));
+        // $env:VAR format
+        assert_eq!(expand("/path/$env:VAR/to/dir"), path("/path/VALUE/to/dir"));
+        // $VAR format
+        assert_eq!(expand("/path/$VAR/to/dir"), path("/path/VALUE/to/dir"));
+
+        // non-existent variable
+        assert_eq!(expand("/path/%ASD%/to/d"), path("/path/%ASD%/to/d"));
+        assert_eq!(expand("/path/$env:ASD/to/d"), path("/path/$env:ASD/to/d"));
+        assert_eq!(expand("/path/$ASD/to/d"), path("/path/$ASD/to/d"));
+
+        // Set a $env:USERPROFILE variable for testing
+        std::env::set_var("USERPROFILE", "C:\\Users\\user");
+
+        // ~ and $HOME should be replaced with $Env:USERPROFILE
+        assert_eq!(expand("~"), path("C:\\Users\\user"));
+        assert_eq!(expand("$HOME"), path("C:\\Users\\user"));
+    }
 }

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -20,7 +20,6 @@ use crate::core::config_generation::ApplicationConfigurationGenerator;
 use crate::core::config_generation::ApplicationOptions;
 use crate::core::config_generation::MatchingRule;
 use crate::core::config_generation::MatchingStrategy;
-use crate::core::resolve_home_path;
 use crate::core::AnimationStyle;
 use crate::core::BorderImplementation;
 use crate::core::BorderStyle;
@@ -60,6 +59,7 @@ use crate::workspace::Workspace;
 use crate::AspectRatio;
 use crate::Axis;
 use crate::CrossBoundaryBehaviour;
+use crate::ExpandEnvVars;
 use crate::PredefinedAspectRatio;
 use crate::DATA_DIR;
 use crate::DEFAULT_CONTAINER_PADDING;
@@ -1066,11 +1066,11 @@ impl StaticConfig {
         if let Some(path) = &mut value.app_specific_configuration_path {
             match path {
                 AppSpecificConfigurationPath::Single(path) => {
-                    *path = resolve_home_path(&*path)?;
+                    *path = path.expand_vars();
                 }
                 AppSpecificConfigurationPath::Multiple(paths) => {
                     for path in paths {
-                        *path = resolve_home_path(&*path)?;
+                        *path = path.expand_vars();
                     }
                 }
             }
@@ -1080,12 +1080,12 @@ impl StaticConfig {
             for m in monitors {
                 for w in &mut m.workspaces {
                     if let Some(path) = &mut w.custom_layout {
-                        *path = resolve_home_path(&*path)?;
+                        *path = path.expand_vars();
                     }
 
                     if let Some(map) = &mut w.custom_layout_rules {
                         for path in map.values_mut() {
-                            *path = resolve_home_path(&*path)?;
+                            *path = path.expand_vars();
                         }
                     }
                 }
@@ -1094,7 +1094,7 @@ impl StaticConfig {
 
         if let Some(bar_configurations) = &mut value.bar_configurations {
             for path in bar_configurations {
-                *path = resolve_home_path(&*path)?;
+                *path = path.expand_vars();
             }
         }
 
@@ -1660,7 +1660,7 @@ fn handle_asc_file(
         Some(ext) => match ext.to_string_lossy().to_string().as_str() {
             "yaml" => {
                 tracing::info!("loading applications.yaml from: {}", path.display());
-                let path = resolve_home_path(path)?;
+                let path = path.expand_vars();
                 let content = std::fs::read_to_string(path)?;
                 let asc = ApplicationConfigurationGenerator::load(&content)?;
 
@@ -1709,7 +1709,7 @@ fn handle_asc_file(
             }
             "json" => {
                 tracing::info!("loading applications.json from: {}", path.display());
-                let path = resolve_home_path(path)?;
+                let path = path.expand_vars();
                 let mut asc = ApplicationSpecificConfiguration::load(&path)?;
 
                 for entry in asc.values_mut() {


### PR DESCRIPTION
This new implementation allows for expanding any environment variable so it is not limited to just `~`, `$HOME`, `$Env:USERPROFILE` and `$Env:KOMOREBI_CONFIG_HOME`.

It expands the follwing formats:
- CMD: `%variable%`
- PowerShell: `$Env:variable`
- Bash: `$variable`.


#### Remaining questions?

- Should `resolve_home_path` function be removed? It is not just a wrapper around the new trait.
- Should `ExpandEnvVars::expand_vars` return a result when a variable doesn't exit in env or keep the path as is (current behavior)?