### PR TITLE
feat(bar): added new start menu button widget

### DIFF
--- a/komorebi-bar/src/widgets/mod.rs
+++ b/komorebi-bar/src/widgets/mod.rs
@@ -7,6 +7,7 @@ mod komorebi_layout;
 pub mod media;
 pub mod memory;
 pub mod network;
+pub mod startmenu;
 pub mod storage;
 pub mod time;
 pub mod update;

--- a/komorebi-bar/src/widgets/network.rs
+++ b/komorebi-bar/src/widgets/network.rs
@@ -49,7 +49,9 @@ impl From<NetworkConfig> for Network {
             default_interface: String::new(),
             data_refresh_interval,
             label_prefix: value.label_prefix.unwrap_or(LabelPrefix::Icon),
-            network_activity_fill_characters: value.network_activity_fill_characters.unwrap_or_default(),
+            network_activity_fill_characters: value
+                .network_activity_fill_characters
+                .unwrap_or_default(),
             last_state_total_activity: vec![],
             last_state_activity: vec![],
             last_updated_network_activity: Instant::now()
@@ -88,7 +90,9 @@ impl Network {
         let mut total_activity = self.last_state_total_activity.clone();
         let now = Instant::now();
 
-        if now.duration_since(self.last_updated_network_activity) > Duration::from_secs(self.data_refresh_interval) {
+        if now.duration_since(self.last_updated_network_activity)
+            > Duration::from_secs(self.data_refresh_interval)
+        {
             activity.clear();
             total_activity.clear();
 
@@ -103,8 +107,14 @@ impl Network {
                             if self.show_activity {
                                 activity.push(NetworkReading::new(
                                     NetworkReadingFormat::Speed,
-                                    Self::to_pretty_bytes(data.received(), self.data_refresh_interval),
-                                    Self::to_pretty_bytes(data.transmitted(), self.data_refresh_interval),
+                                    Self::to_pretty_bytes(
+                                        data.received(),
+                                        self.data_refresh_interval,
+                                    ),
+                                    Self::to_pretty_bytes(
+                                        data.transmitted(),
+                                        self.data_refresh_interval,
+                                    ),
                                 ));
                             }
 
@@ -128,7 +138,12 @@ impl Network {
         (activity, total_activity)
     }
 
-    fn reading_to_label(&self, ctx: &Context, reading: NetworkReading, config: RenderConfig) -> Label {
+    fn reading_to_label(
+        &self,
+        ctx: &Context,
+        reading: NetworkReading,
+        config: RenderConfig,
+    ) -> Label {
         let (text_down, text_up) = match self.label_prefix {
             LabelPrefix::None | LabelPrefix::Icon => match reading.format {
                 NetworkReadingFormat::Speed => (
@@ -182,7 +197,9 @@ impl Network {
         // icon
         let mut layout_job = LayoutJob::simple(
             match self.label_prefix {
-                LabelPrefix::Icon | LabelPrefix::IconAndText => egui_phosphor::regular::ARROW_FAT_DOWN.to_string(),
+                LabelPrefix::Icon | LabelPrefix::IconAndText => {
+                    egui_phosphor::regular::ARROW_FAT_DOWN.to_string()
+                }
                 LabelPrefix::None | LabelPrefix::Text => String::new(),
             },
             icon_format.font_id.clone(),
@@ -200,7 +217,9 @@ impl Network {
         // icon
         layout_job.append(
             &match self.label_prefix {
-                LabelPrefix::Icon | LabelPrefix::IconAndText => egui_phosphor::regular::ARROW_FAT_UP.to_string(),
+                LabelPrefix::Icon | LabelPrefix::IconAndText => {
+                    egui_phosphor::regular::ARROW_FAT_UP.to_string()
+                }
                 LabelPrefix::None | LabelPrefix::Text => String::new(),
             },
             0.0,
@@ -269,7 +288,9 @@ impl BarWidget for Network {
                 if !self.default_interface.is_empty() {
                     let mut layout_job = LayoutJob::simple(
                         match self.label_prefix {
-                            LabelPrefix::Icon | LabelPrefix::IconAndText => egui_phosphor::regular::WIFI_HIGH.to_string(),
+                            LabelPrefix::Icon | LabelPrefix::IconAndText => {
+                                egui_phosphor::regular::WIFI_HIGH.to_string()
+                            }
                             LabelPrefix::None | LabelPrefix::Text => String::new(),
                         },
                         config.icon_font_id.clone(),
@@ -297,7 +318,8 @@ impl BarWidget for Network {
                             .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                             .clicked()
                         {
-                            if let Err(error) = Command::new("cmd.exe").args(["/C", "ncpa"]).spawn() {
+                            if let Err(error) = Command::new("cmd.exe").args(["/C", "ncpa"]).spawn()
+                            {
                                 eprintln!("{}", error)
                             }
                         }

--- a/komorebi-bar/src/widgets/network.rs
+++ b/komorebi-bar/src/widgets/network.rs
@@ -49,9 +49,7 @@ impl From<NetworkConfig> for Network {
             default_interface: String::new(),
             data_refresh_interval,
             label_prefix: value.label_prefix.unwrap_or(LabelPrefix::Icon),
-            network_activity_fill_characters: value
-                .network_activity_fill_characters
-                .unwrap_or_default(),
+            network_activity_fill_characters: value.network_activity_fill_characters.unwrap_or_default(),
             last_state_total_activity: vec![],
             last_state_activity: vec![],
             last_updated_network_activity: Instant::now()
@@ -90,9 +88,7 @@ impl Network {
         let mut total_activity = self.last_state_total_activity.clone();
         let now = Instant::now();
 
-        if now.duration_since(self.last_updated_network_activity)
-            > Duration::from_secs(self.data_refresh_interval)
-        {
+        if now.duration_since(self.last_updated_network_activity) > Duration::from_secs(self.data_refresh_interval) {
             activity.clear();
             total_activity.clear();
 
@@ -107,14 +103,8 @@ impl Network {
                             if self.show_activity {
                                 activity.push(NetworkReading::new(
                                     NetworkReadingFormat::Speed,
-                                    Self::to_pretty_bytes(
-                                        data.received(),
-                                        self.data_refresh_interval,
-                                    ),
-                                    Self::to_pretty_bytes(
-                                        data.transmitted(),
-                                        self.data_refresh_interval,
-                                    ),
+                                    Self::to_pretty_bytes(data.received(), self.data_refresh_interval),
+                                    Self::to_pretty_bytes(data.transmitted(), self.data_refresh_interval),
                                 ));
                             }
 
@@ -138,12 +128,7 @@ impl Network {
         (activity, total_activity)
     }
 
-    fn reading_to_label(
-        &self,
-        ctx: &Context,
-        reading: NetworkReading,
-        config: RenderConfig,
-    ) -> Label {
+    fn reading_to_label(&self, ctx: &Context, reading: NetworkReading, config: RenderConfig) -> Label {
         let (text_down, text_up) = match self.label_prefix {
             LabelPrefix::None | LabelPrefix::Icon => match reading.format {
                 NetworkReadingFormat::Speed => (
@@ -197,9 +182,7 @@ impl Network {
         // icon
         let mut layout_job = LayoutJob::simple(
             match self.label_prefix {
-                LabelPrefix::Icon | LabelPrefix::IconAndText => {
-                    egui_phosphor::regular::ARROW_FAT_DOWN.to_string()
-                }
+                LabelPrefix::Icon | LabelPrefix::IconAndText => egui_phosphor::regular::ARROW_FAT_DOWN.to_string(),
                 LabelPrefix::None | LabelPrefix::Text => String::new(),
             },
             icon_format.font_id.clone(),
@@ -217,9 +200,7 @@ impl Network {
         // icon
         layout_job.append(
             &match self.label_prefix {
-                LabelPrefix::Icon | LabelPrefix::IconAndText => {
-                    egui_phosphor::regular::ARROW_FAT_UP.to_string()
-                }
+                LabelPrefix::Icon | LabelPrefix::IconAndText => egui_phosphor::regular::ARROW_FAT_UP.to_string(),
                 LabelPrefix::None | LabelPrefix::Text => String::new(),
             },
             0.0,
@@ -288,9 +269,7 @@ impl BarWidget for Network {
                 if !self.default_interface.is_empty() {
                     let mut layout_job = LayoutJob::simple(
                         match self.label_prefix {
-                            LabelPrefix::Icon | LabelPrefix::IconAndText => {
-                                egui_phosphor::regular::WIFI_HIGH.to_string()
-                            }
+                            LabelPrefix::Icon | LabelPrefix::IconAndText => egui_phosphor::regular::WIFI_HIGH.to_string(),
                             LabelPrefix::None | LabelPrefix::Text => String::new(),
                         },
                         config.icon_font_id.clone(),
@@ -318,8 +297,7 @@ impl BarWidget for Network {
                             .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
                             .clicked()
                         {
-                            if let Err(error) = Command::new("cmd.exe").args(["/C", "ncpa"]).spawn()
-                            {
+                            if let Err(error) = Command::new("cmd.exe").args(["/C", "ncpa"]).spawn() {
                                 eprintln!("{}", error)
                             }
                         }

--- a/komorebi-bar/src/widgets/startmenu.rs
+++ b/komorebi-bar/src/widgets/startmenu.rs
@@ -1,25 +1,14 @@
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 use crate::config::LabelPrefix;
 use crate::render::RenderConfig;
 use crate::selected_frame::SelectableFrame;
 use crate::widgets::widget::BarWidget;
 use eframe::egui::text::LayoutJob;
-use eframe::egui::Align;
 use eframe::egui::Context;
 use eframe::egui::Label;
 use eframe::egui::TextFormat;
 use eframe::egui::Ui;
-use num_derive::FromPrimitive;
 use serde::Deserialize;
 use serde::Serialize;
-use std::fmt;
-use std::process::Command;
-use std::time::Duration;
-use std::time::Instant;
-use sysinfo::Networks;
-use windows::core::Result;
 use windows::Win32::UI::Input::KeyboardAndMouse::SendInput;
 use windows::Win32::UI::Input::KeyboardAndMouse::INPUT;
 use windows::Win32::UI::Input::KeyboardAndMouse::INPUT_0;
@@ -92,7 +81,6 @@ impl StartMenu {
 impl BarWidget for StartMenu {
     fn render(&mut self, ctx: &Context, ui: &mut Ui, config: &mut RenderConfig) {
         if self.enable {
-            // widget spacing: make sure to use the same config to call the apply_on_widget function
             let mut render_config = config.clone();
             let mut layout_job = LayoutJob::simple(
                 match self.label_prefix {
@@ -106,16 +94,20 @@ impl BarWidget for StartMenu {
                 100.0,
             );
 
-            layout_job.append(
-                &String::from("Start"),
-                10.0,
-                TextFormat {
-                    font_id: config.text_font_id.clone(),
-                    color: ctx.style().visuals.text_color(),
-                    valign: Align::Center,
-                    ..Default::default()
-                },
-            );
+            match self.label_prefix {
+                LabelPrefix::Text | LabelPrefix::IconAndText => {
+                    layout_job.append(
+                        &String::from("Start"),
+                        10.0,
+                        TextFormat {
+                            font_id: config.text_font_id.clone(),
+                            color: ctx.style().visuals.text_color(),
+                            ..Default::default()
+                        },
+                    );
+                }
+                _ => (),
+            };
 
             render_config.apply_on_widget(false, ui, |ui| {
                 if SelectableFrame::new(false)
@@ -126,7 +118,6 @@ impl BarWidget for StartMenu {
                 }
             });
 
-            // widget spacing: pass on the config that was use for calling the apply_on_widget function
             *config = render_config.clone();
         }
     }

--- a/komorebi-bar/src/widgets/startmenu.rs
+++ b/komorebi-bar/src/widgets/startmenu.rs
@@ -96,7 +96,9 @@ impl BarWidget for StartMenu {
             let mut render_config = config.clone();
             let mut layout_job = LayoutJob::simple(
                 match self.label_prefix {
-                    LabelPrefix::Icon | LabelPrefix::IconAndText => egui_phosphor::regular::YIN_YANG.to_string(),
+                    LabelPrefix::Icon | LabelPrefix::IconAndText => {
+                        egui_phosphor::regular::YIN_YANG.to_string()
+                    }
                     LabelPrefix::None | LabelPrefix::Text => String::new(),
                 },
                 config.icon_font_id.clone(),

--- a/komorebi-bar/src/widgets/startmenu.rs
+++ b/komorebi-bar/src/widgets/startmenu.rs
@@ -1,0 +1,131 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use crate::config::LabelPrefix;
+use crate::render::RenderConfig;
+use crate::selected_frame::SelectableFrame;
+use crate::widgets::widget::BarWidget;
+use eframe::egui::text::LayoutJob;
+use eframe::egui::Align;
+use eframe::egui::Context;
+use eframe::egui::Label;
+use eframe::egui::TextFormat;
+use eframe::egui::Ui;
+use num_derive::FromPrimitive;
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+use std::process::Command;
+use std::time::Duration;
+use std::time::Instant;
+use sysinfo::Networks;
+use windows::core::Result;
+use windows::Win32::UI::Input::KeyboardAndMouse::SendInput;
+use windows::Win32::UI::Input::KeyboardAndMouse::INPUT;
+use windows::Win32::UI::Input::KeyboardAndMouse::INPUT_0;
+use windows::Win32::UI::Input::KeyboardAndMouse::INPUT_KEYBOARD;
+use windows::Win32::UI::Input::KeyboardAndMouse::KEYBDINPUT;
+use windows::Win32::UI::Input::KeyboardAndMouse::KEYBD_EVENT_FLAGS;
+use windows::Win32::UI::Input::KeyboardAndMouse::KEYEVENTF_KEYUP;
+use windows::Win32::UI::Input::KeyboardAndMouse::VK_LWIN;
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct StartMenuConfig {
+    pub enable: bool,
+    pub label_prefix: Option<LabelPrefix>,
+}
+
+impl From<StartMenuConfig> for StartMenu {
+    fn from(value: StartMenuConfig) -> Self {
+        Self {
+            enable: value.enable,
+            label_prefix: value.label_prefix.unwrap_or(LabelPrefix::Icon),
+        }
+    }
+}
+
+pub struct StartMenu {
+    pub enable: bool,
+    label_prefix: LabelPrefix,
+}
+
+impl StartMenu {
+    pub fn toggle_start_menu() {
+        // Prepare the inputs
+        let inputs = [
+            // Press the left windows key
+            INPUT {
+                r#type: INPUT_KEYBOARD,
+                Anonymous: INPUT_0 {
+                    ki: KEYBDINPUT {
+                        wVk: VK_LWIN,
+                        wScan: 0,
+                        dwFlags: KEYBD_EVENT_FLAGS(0), // key down
+                        time: 0,
+                        dwExtraInfo: 0,
+                    },
+                },
+            },
+            // Release the left windows key
+            INPUT {
+                r#type: INPUT_KEYBOARD,
+                Anonymous: INPUT_0 {
+                    ki: KEYBDINPUT {
+                        wVk: VK_LWIN,
+                        wScan: 0,
+                        dwFlags: KEYEVENTF_KEYUP, // key up
+                        time: 0,
+                        dwExtraInfo: 0,
+                    },
+                },
+            },
+        ];
+
+        // Send the inputs
+        unsafe {
+            SendInput(&inputs, std::mem::size_of::<INPUT>() as i32);
+        }
+    }
+}
+
+impl BarWidget for StartMenu {
+    fn render(&mut self, ctx: &Context, ui: &mut Ui, config: &mut RenderConfig) {
+        if self.enable {
+            // widget spacing: make sure to use the same config to call the apply_on_widget function
+            let mut render_config = config.clone();
+            let mut layout_job = LayoutJob::simple(
+                match self.label_prefix {
+                    LabelPrefix::Icon | LabelPrefix::IconAndText => egui_phosphor::regular::YIN_YANG.to_string(),
+                    LabelPrefix::None | LabelPrefix::Text => String::new(),
+                },
+                config.icon_font_id.clone(),
+                ctx.style().visuals.selection.stroke.color,
+                100.0,
+            );
+
+            layout_job.append(
+                &String::from("Start"),
+                10.0,
+                TextFormat {
+                    font_id: config.text_font_id.clone(),
+                    color: ctx.style().visuals.text_color(),
+                    valign: Align::Center,
+                    ..Default::default()
+                },
+            );
+
+            render_config.apply_on_widget(false, ui, |ui| {
+                if SelectableFrame::new(false)
+                    .show(ui, |ui| ui.add(Label::new(layout_job).selectable(false)))
+                    .clicked()
+                {
+                    StartMenu::toggle_start_menu();
+                }
+            });
+
+            // widget spacing: pass on the config that was use for calling the apply_on_widget function
+            *config = render_config.clone();
+        }
+    }
+}

--- a/komorebi-bar/src/widgets/widget.rs
+++ b/komorebi-bar/src/widgets/widget.rs
@@ -15,6 +15,8 @@ use crate::widgets::memory::Memory;
 use crate::widgets::memory::MemoryConfig;
 use crate::widgets::network::Network;
 use crate::widgets::network::NetworkConfig;
+use crate::widgets::startmenu::StartMenu;
+use crate::widgets::startmenu::StartMenuConfig;
 use crate::widgets::storage::Storage;
 use crate::widgets::storage::StorageConfig;
 use crate::widgets::time::Time;
@@ -44,6 +46,7 @@ pub enum WidgetConfig {
     Storage(StorageConfig),
     Time(TimeConfig),
     Update(UpdateConfig),
+    StartMenu(StartMenuConfig),
 }
 
 impl WidgetConfig {
@@ -60,6 +63,7 @@ impl WidgetConfig {
             WidgetConfig::Storage(config) => Box::new(Storage::from(*config)),
             WidgetConfig::Time(config) => Box::new(Time::from(config.clone())),
             WidgetConfig::Update(config) => Box::new(Update::from(*config)),
+            WidgetConfig::StartMenu(config) => Box::new(StartMenu::from(*config)),
         }
     }
 
@@ -84,6 +88,7 @@ impl WidgetConfig {
             WidgetConfig::Storage(config) => config.enable,
             WidgetConfig::Time(config) => config.enable,
             WidgetConfig::Update(config) => config.enable,
+            WidgetConfig::StartMenu(config) => config.enable,
         }
     }
 }

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -3,7 +3,11 @@
 	"title": "KomobarConfig",
 	"description": "The `komorebi.bar.json` configuration file reference for `v0.1.35`",
 	"type": "object",
-	"required": ["left_widgets", "monitor", "right_widgets"],
+	"required": [
+		"left_widgets",
+		"monitor",
+		"right_widgets"
+	],
 	"properties": {
 		"center_widgets": {
 			"description": "Center widgets (ordered left-to-right)",
@@ -12,11 +16,15 @@
 				"oneOf": [
 					{
 						"type": "object",
-						"required": ["Battery"],
+						"required": [
+							"Battery"
+						],
 						"properties": {
 							"Battery": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -38,22 +46,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -64,11 +80,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Cpu"],
+						"required": [
+							"Cpu"
+						],
 						"properties": {
 							"Cpu": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -86,22 +106,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -112,11 +140,16 @@
 					},
 					{
 						"type": "object",
-						"required": ["Date"],
+						"required": [
+							"Date"
+						],
 						"properties": {
 							"Date": {
 								"type": "object",
-								"required": ["enable", "format"],
+								"required": [
+									"enable",
+									"format"
+								],
 								"properties": {
 									"enable": {
 										"description": "Enable the Date widget",
@@ -128,27 +161,37 @@
 											{
 												"description": "Month/Date/Year format (09/08/24)",
 												"type": "string",
-												"enum": ["MonthDateYear"]
+												"enum": [
+													"MonthDateYear"
+												]
 											},
 											{
 												"description": "Year-Month-Date format (2024-09-08)",
 												"type": "string",
-												"enum": ["YearMonthDate"]
+												"enum": [
+													"YearMonthDate"
+												]
 											},
 											{
 												"description": "Date-Month-Year format (8-Sep-2024)",
 												"type": "string",
-												"enum": ["DateMonthYear"]
+												"enum": [
+													"DateMonthYear"
+												]
 											},
 											{
 												"description": "Day Date Month Year format (8 September 2024)",
 												"type": "string",
-												"enum": ["DayDateMonthYear"]
+												"enum": [
+													"DayDateMonthYear"
+												]
 											},
 											{
 												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
 												"type": "object",
-												"required": ["Custom"],
+												"required": [
+													"Custom"
+												],
 												"properties": {
 													"Custom": {
 														"type": "string"
@@ -159,12 +202,17 @@
 											{
 												"description": "Custom format with modifiers",
 												"type": "object",
-												"required": ["CustomModifiers"],
+												"required": [
+													"CustomModifiers"
+												],
 												"properties": {
 													"CustomModifiers": {
 														"description": "Custom format with additive modifiers for integer format specifiers",
 														"type": "object",
-														"required": ["format", "modifiers"],
+														"required": [
+															"format",
+															"modifiers"
+														],
 														"properties": {
 															"format": {
 																"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
@@ -191,22 +239,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -221,11 +277,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Keyboard"],
+						"required": [
+							"Keyboard"
+						],
 						"properties": {
 							"Keyboard": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 1 second)",
@@ -243,22 +303,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -269,7 +337,9 @@
 					},
 					{
 						"type": "object",
-						"required": ["Komorebi"],
+						"required": [
+							"Komorebi"
+						],
 						"properties": {
 							"Komorebi": {
 								"type": "object",
@@ -277,7 +347,10 @@
 									"configuration_switcher": {
 										"description": "Configure the Configuration Switcher widget",
 										"type": "object",
-										"required": ["configurations", "enable"],
+										"required": [
+											"configurations",
+											"enable"
+										],
 										"properties": {
 											"configurations": {
 												"description": "A map of display friendly name => path to configuration.json",
@@ -295,7 +368,9 @@
 									"focused_window": {
 										"description": "Configure the Focused Window widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the currently focused window",
@@ -303,27 +378,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -340,7 +425,9 @@
 									"layout": {
 										"description": "Configure the Layout widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the current layout",
@@ -348,27 +435,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -414,7 +511,9 @@
 									"workspace_layer": {
 										"description": "Configure the Workspace Layer widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the current layer",
@@ -422,27 +521,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -459,7 +568,10 @@
 									"workspaces": {
 										"description": "Configure the Workspaces widget",
 										"type": "object",
-										"required": ["enable", "hide_empty_workspaces"],
+										"required": [
+											"enable",
+											"hide_empty_workspaces"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the workspace",
@@ -467,48 +579,66 @@
 													{
 														"description": "Show all icons only",
 														"type": "string",
-														"enum": ["AllIcons"]
+														"enum": [
+															"AllIcons"
+														]
 													},
 													{
 														"description": "Show both all icons and text",
 														"type": "string",
-														"enum": ["AllIconsAndText"]
+														"enum": [
+															"AllIconsAndText"
+														]
 													},
 													{
 														"description": "Show all icons and text for the selected element, and all icons on the rest",
 														"type": "string",
-														"enum": ["AllIconsAndTextOnSelected"]
+														"enum": [
+															"AllIconsAndTextOnSelected"
+														]
 													},
 													{
 														"type": "object",
-														"required": ["Existing"],
+														"required": [
+															"Existing"
+														],
 														"properties": {
 															"Existing": {
 																"oneOf": [
 																	{
 																		"description": "Show only icon",
 																		"type": "string",
-																		"enum": ["Icon"]
+																		"enum": [
+																			"Icon"
+																		]
 																	},
 																	{
 																		"description": "Show only text",
 																		"type": "string",
-																		"enum": ["Text"]
+																		"enum": [
+																			"Text"
+																		]
 																	},
 																	{
 																		"description": "Show an icon and text for the selected element, and text on the rest",
 																		"type": "string",
-																		"enum": ["TextAndIconOnSelected"]
+																		"enum": [
+																			"TextAndIconOnSelected"
+																		]
 																	},
 																	{
 																		"description": "Show both icon and text",
 																		"type": "string",
-																		"enum": ["IconAndText"]
+																		"enum": [
+																			"IconAndText"
+																		]
 																	},
 																	{
 																		"description": "Show an icon and text for the selected element, and icons on the rest",
 																		"type": "string",
-																		"enum": ["IconAndTextOnSelected"]
+																		"enum": [
+																			"IconAndTextOnSelected"
+																		]
 																	}
 																]
 															}
@@ -534,11 +664,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Media"],
+						"required": [
+							"Media"
+						],
 						"properties": {
 							"Media": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"enable": {
 										"description": "Enable the Media widget",
@@ -551,11 +685,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Memory"],
+						"required": [
+							"Memory"
+						],
 						"properties": {
 							"Memory": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -573,22 +711,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -599,14 +745,18 @@
 					},
 					{
 						"type": "object",
-						"required": ["StartMenu"],
+						"required": [
+							"StartMenu"
+						],
 						"properties": {
 							"StartMenu": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"enable": {
-										"description": "Enable the Network widget",
+										"description": "Enable the start menu button widget",
 										"type": "boolean"
 									},
 									"label_prefix": {
@@ -615,22 +765,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -641,7 +799,9 @@
 					},
 					{
 						"type": "object",
-						"required": ["Network"],
+						"required": [
+							"Network"
+						],
 						"properties": {
 							"Network": {
 								"type": "object",
@@ -667,22 +827,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -711,11 +879,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Storage"],
+						"required": [
+							"Storage"
+						],
 						"properties": {
 							"Storage": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -733,22 +905,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -759,11 +939,16 @@
 					},
 					{
 						"type": "object",
-						"required": ["Time"],
+						"required": [
+							"Time"
+						],
 						"properties": {
 							"Time": {
 								"type": "object",
-								"required": ["enable", "format"],
+								"required": [
+									"enable",
+									"format"
+								],
 								"properties": {
 									"changing_icon": {
 										"description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
@@ -779,37 +964,51 @@
 											{
 												"description": "Twelve-hour format (with seconds)",
 												"type": "string",
-												"enum": ["TwelveHour"]
+												"enum": [
+													"TwelveHour"
+												]
 											},
 											{
 												"description": "Twelve-hour format (without seconds)",
 												"type": "string",
-												"enum": ["TwelveHourWithoutSeconds"]
+												"enum": [
+													"TwelveHourWithoutSeconds"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format (with seconds)",
 												"type": "string",
-												"enum": ["TwentyFourHour"]
+												"enum": [
+													"TwentyFourHour"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format (without seconds)",
 												"type": "string",
-												"enum": ["TwentyFourHourWithoutSeconds"]
+												"enum": [
+													"TwentyFourHourWithoutSeconds"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
 												"type": "string",
-												"enum": ["BinaryCircle"]
+												"enum": [
+													"BinaryCircle"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
 												"type": "string",
-												"enum": ["BinaryRectangle"]
+												"enum": [
+													"BinaryRectangle"
+												]
 											},
 											{
 												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
 												"type": "object",
-												"required": ["Custom"],
+												"required": [
+													"Custom"
+												],
 												"properties": {
 													"Custom": {
 														"type": "string"
@@ -825,22 +1024,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -855,11 +1062,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Update"],
+						"required": [
+							"Update"
+						],
 						"properties": {
 							"Update": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 12 hours)",
@@ -877,22 +1088,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -916,12 +1135,17 @@
 		"frame": {
 			"description": "Frame options (see: https://docs.rs/egui/latest/egui/containers/frame/struct.Frame.html)",
 			"type": "object",
-			"required": ["inner_margin"],
+			"required": [
+				"inner_margin"
+			],
 			"properties": {
 				"inner_margin": {
 					"description": "Margin inside the painted frame",
 					"type": "object",
-					"required": ["x", "y"],
+					"required": [
+						"x",
+						"y"
+					],
 					"properties": {
 						"x": {
 							"description": "X coordinate",
@@ -943,22 +1167,30 @@
 				{
 					"description": "No grouping is applied",
 					"type": "object",
-					"required": ["kind"],
+					"required": [
+						"kind"
+					],
 					"properties": {
 						"kind": {
 							"type": "string",
-							"enum": ["None"]
+							"enum": [
+								"None"
+							]
 						}
 					}
 				},
 				{
 					"description": "Widgets are grouped as a whole",
 					"type": "object",
-					"required": ["kind"],
+					"required": [
+						"kind"
+					],
 					"properties": {
 						"kind": {
 							"type": "string",
-							"enum": ["Bar"]
+							"enum": [
+								"Bar"
+							]
 						},
 						"rounding": {
 							"description": "Rounding values for the 4 corners. Can be a single or 4 values.",
@@ -985,37 +1217,51 @@
 							"oneOf": [
 								{
 									"type": "string",
-									"enum": ["Default"]
+									"enum": [
+										"Default"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB4O1S3"]
+									"enum": [
+										"DefaultWithShadowB4O1S3"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB4O0S3"]
+									"enum": [
+										"DefaultWithShadowB4O0S3"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB0O1S3"]
+									"enum": [
+										"DefaultWithShadowB0O1S3"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB3O1S2"]
+									"enum": [
+										"DefaultWithGlowB3O1S2"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB3O0S2"]
+									"enum": [
+										"DefaultWithGlowB3O0S2"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB0O1S2"]
+									"enum": [
+										"DefaultWithGlowB0O1S2"
+									]
 								}
 							]
 						},
@@ -1030,11 +1276,15 @@
 				{
 					"description": "Widgets are grouped by alignment",
 					"type": "object",
-					"required": ["kind"],
+					"required": [
+						"kind"
+					],
 					"properties": {
 						"kind": {
 							"type": "string",
-							"enum": ["Alignment"]
+							"enum": [
+								"Alignment"
+							]
 						},
 						"rounding": {
 							"description": "Rounding values for the 4 corners. Can be a single or 4 values.",
@@ -1061,37 +1311,51 @@
 							"oneOf": [
 								{
 									"type": "string",
-									"enum": ["Default"]
+									"enum": [
+										"Default"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB4O1S3"]
+									"enum": [
+										"DefaultWithShadowB4O1S3"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB4O0S3"]
+									"enum": [
+										"DefaultWithShadowB4O0S3"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB0O1S3"]
+									"enum": [
+										"DefaultWithShadowB0O1S3"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB3O1S2"]
+									"enum": [
+										"DefaultWithGlowB3O1S2"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB3O0S2"]
+									"enum": [
+										"DefaultWithGlowB3O0S2"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB0O1S2"]
+									"enum": [
+										"DefaultWithGlowB0O1S2"
+									]
 								}
 							]
 						},
@@ -1106,11 +1370,15 @@
 				{
 					"description": "Widgets are grouped individually",
 					"type": "object",
-					"required": ["kind"],
+					"required": [
+						"kind"
+					],
 					"properties": {
 						"kind": {
 							"type": "string",
-							"enum": ["Widget"]
+							"enum": [
+								"Widget"
+							]
 						},
 						"rounding": {
 							"description": "Rounding values for the 4 corners. Can be a single or 4 values.",
@@ -1137,37 +1405,51 @@
 							"oneOf": [
 								{
 									"type": "string",
-									"enum": ["Default"]
+									"enum": [
+										"Default"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB4O1S3"]
+									"enum": [
+										"DefaultWithShadowB4O1S3"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB4O0S3"]
+									"enum": [
+										"DefaultWithShadowB4O0S3"
+									]
 								},
 								{
 									"description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
 									"type": "string",
-									"enum": ["DefaultWithShadowB0O1S3"]
+									"enum": [
+										"DefaultWithShadowB0O1S3"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB3O1S2"]
+									"enum": [
+										"DefaultWithGlowB3O1S2"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB3O0S2"]
+									"enum": [
+										"DefaultWithGlowB3O0S2"
+									]
 								},
 								{
 									"description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
 									"type": "string",
-									"enum": ["DefaultWithGlowB0O1S2"]
+									"enum": [
+										"DefaultWithGlowB0O1S2"
+									]
 								}
 							]
 						},
@@ -1198,11 +1480,15 @@
 				"oneOf": [
 					{
 						"type": "object",
-						"required": ["Battery"],
+						"required": [
+							"Battery"
+						],
 						"properties": {
 							"Battery": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -1224,22 +1510,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -1250,11 +1544,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Cpu"],
+						"required": [
+							"Cpu"
+						],
 						"properties": {
 							"Cpu": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -1272,22 +1570,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -1298,11 +1604,16 @@
 					},
 					{
 						"type": "object",
-						"required": ["Date"],
+						"required": [
+							"Date"
+						],
 						"properties": {
 							"Date": {
 								"type": "object",
-								"required": ["enable", "format"],
+								"required": [
+									"enable",
+									"format"
+								],
 								"properties": {
 									"enable": {
 										"description": "Enable the Date widget",
@@ -1314,27 +1625,37 @@
 											{
 												"description": "Month/Date/Year format (09/08/24)",
 												"type": "string",
-												"enum": ["MonthDateYear"]
+												"enum": [
+													"MonthDateYear"
+												]
 											},
 											{
 												"description": "Year-Month-Date format (2024-09-08)",
 												"type": "string",
-												"enum": ["YearMonthDate"]
+												"enum": [
+													"YearMonthDate"
+												]
 											},
 											{
 												"description": "Date-Month-Year format (8-Sep-2024)",
 												"type": "string",
-												"enum": ["DateMonthYear"]
+												"enum": [
+													"DateMonthYear"
+												]
 											},
 											{
 												"description": "Day Date Month Year format (8 September 2024)",
 												"type": "string",
-												"enum": ["DayDateMonthYear"]
+												"enum": [
+													"DayDateMonthYear"
+												]
 											},
 											{
 												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
 												"type": "object",
-												"required": ["Custom"],
+												"required": [
+													"Custom"
+												],
 												"properties": {
 													"Custom": {
 														"type": "string"
@@ -1345,12 +1666,17 @@
 											{
 												"description": "Custom format with modifiers",
 												"type": "object",
-												"required": ["CustomModifiers"],
+												"required": [
+													"CustomModifiers"
+												],
 												"properties": {
 													"CustomModifiers": {
 														"description": "Custom format with additive modifiers for integer format specifiers",
 														"type": "object",
-														"required": ["format", "modifiers"],
+														"required": [
+															"format",
+															"modifiers"
+														],
 														"properties": {
 															"format": {
 																"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
@@ -1377,22 +1703,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -1407,11 +1741,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Keyboard"],
+						"required": [
+							"Keyboard"
+						],
 						"properties": {
 							"Keyboard": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 1 second)",
@@ -1429,22 +1767,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -1455,7 +1801,9 @@
 					},
 					{
 						"type": "object",
-						"required": ["Komorebi"],
+						"required": [
+							"Komorebi"
+						],
 						"properties": {
 							"Komorebi": {
 								"type": "object",
@@ -1463,7 +1811,10 @@
 									"configuration_switcher": {
 										"description": "Configure the Configuration Switcher widget",
 										"type": "object",
-										"required": ["configurations", "enable"],
+										"required": [
+											"configurations",
+											"enable"
+										],
 										"properties": {
 											"configurations": {
 												"description": "A map of display friendly name => path to configuration.json",
@@ -1481,7 +1832,9 @@
 									"focused_window": {
 										"description": "Configure the Focused Window widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the currently focused window",
@@ -1489,27 +1842,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -1526,7 +1889,9 @@
 									"layout": {
 										"description": "Configure the Layout widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the current layout",
@@ -1534,27 +1899,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -1600,7 +1975,9 @@
 									"workspace_layer": {
 										"description": "Configure the Workspace Layer widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the current layer",
@@ -1608,27 +1985,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -1645,7 +2032,10 @@
 									"workspaces": {
 										"description": "Configure the Workspaces widget",
 										"type": "object",
-										"required": ["enable", "hide_empty_workspaces"],
+										"required": [
+											"enable",
+											"hide_empty_workspaces"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the workspace",
@@ -1653,48 +2043,66 @@
 													{
 														"description": "Show all icons only",
 														"type": "string",
-														"enum": ["AllIcons"]
+														"enum": [
+															"AllIcons"
+														]
 													},
 													{
 														"description": "Show both all icons and text",
 														"type": "string",
-														"enum": ["AllIconsAndText"]
+														"enum": [
+															"AllIconsAndText"
+														]
 													},
 													{
 														"description": "Show all icons and text for the selected element, and all icons on the rest",
 														"type": "string",
-														"enum": ["AllIconsAndTextOnSelected"]
+														"enum": [
+															"AllIconsAndTextOnSelected"
+														]
 													},
 													{
 														"type": "object",
-														"required": ["Existing"],
+														"required": [
+															"Existing"
+														],
 														"properties": {
 															"Existing": {
 																"oneOf": [
 																	{
 																		"description": "Show only icon",
 																		"type": "string",
-																		"enum": ["Icon"]
+																		"enum": [
+																			"Icon"
+																		]
 																	},
 																	{
 																		"description": "Show only text",
 																		"type": "string",
-																		"enum": ["Text"]
+																		"enum": [
+																			"Text"
+																		]
 																	},
 																	{
 																		"description": "Show an icon and text for the selected element, and text on the rest",
 																		"type": "string",
-																		"enum": ["TextAndIconOnSelected"]
+																		"enum": [
+																			"TextAndIconOnSelected"
+																		]
 																	},
 																	{
 																		"description": "Show both icon and text",
 																		"type": "string",
-																		"enum": ["IconAndText"]
+																		"enum": [
+																			"IconAndText"
+																		]
 																	},
 																	{
 																		"description": "Show an icon and text for the selected element, and icons on the rest",
 																		"type": "string",
-																		"enum": ["IconAndTextOnSelected"]
+																		"enum": [
+																			"IconAndTextOnSelected"
+																		]
 																	}
 																]
 															}
@@ -1720,11 +2128,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Media"],
+						"required": [
+							"Media"
+						],
 						"properties": {
 							"Media": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"enable": {
 										"description": "Enable the Media widget",
@@ -1737,11 +2149,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Memory"],
+						"required": [
+							"Memory"
+						],
 						"properties": {
 							"Memory": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -1759,22 +2175,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -1785,7 +2209,9 @@
 					},
 					{
 						"type": "object",
-						"required": ["Network"],
+						"required": [
+							"Network"
+						],
 						"properties": {
 							"Network": {
 								"type": "object",
@@ -1811,22 +2237,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -1855,14 +2289,18 @@
 					},
 					{
 						"type": "object",
-						"required": ["StartMenu"],
+						"required": [
+							"StartMenu"
+						],
 						"properties": {
 							"StartMenu": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"enable": {
-										"description": "Enable the Network widget",
+										"description": "Enable the start menu button widget",
 										"type": "boolean"
 									},
 									"label_prefix": {
@@ -1871,22 +2309,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -1897,11 +2343,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Storage"],
+						"required": [
+							"Storage"
+						],
 						"properties": {
 							"Storage": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -1919,22 +2369,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -1945,11 +2403,16 @@
 					},
 					{
 						"type": "object",
-						"required": ["Time"],
+						"required": [
+							"Time"
+						],
 						"properties": {
 							"Time": {
 								"type": "object",
-								"required": ["enable", "format"],
+								"required": [
+									"enable",
+									"format"
+								],
 								"properties": {
 									"changing_icon": {
 										"description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
@@ -1965,37 +2428,51 @@
 											{
 												"description": "Twelve-hour format (with seconds)",
 												"type": "string",
-												"enum": ["TwelveHour"]
+												"enum": [
+													"TwelveHour"
+												]
 											},
 											{
 												"description": "Twelve-hour format (without seconds)",
 												"type": "string",
-												"enum": ["TwelveHourWithoutSeconds"]
+												"enum": [
+													"TwelveHourWithoutSeconds"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format (with seconds)",
 												"type": "string",
-												"enum": ["TwentyFourHour"]
+												"enum": [
+													"TwentyFourHour"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format (without seconds)",
 												"type": "string",
-												"enum": ["TwentyFourHourWithoutSeconds"]
+												"enum": [
+													"TwentyFourHourWithoutSeconds"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
 												"type": "string",
-												"enum": ["BinaryCircle"]
+												"enum": [
+													"BinaryCircle"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
 												"type": "string",
-												"enum": ["BinaryRectangle"]
+												"enum": [
+													"BinaryRectangle"
+												]
 											},
 											{
 												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
 												"type": "object",
-												"required": ["Custom"],
+												"required": [
+													"Custom"
+												],
 												"properties": {
 													"Custom": {
 														"type": "string"
@@ -2011,22 +2488,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -2041,11 +2526,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Update"],
+						"required": [
+							"Update"
+						],
 						"properties": {
 							"Update": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 12 hours)",
@@ -2063,22 +2552,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -2099,7 +2596,12 @@
 				},
 				{
 					"type": "object",
-					"required": ["bottom", "left", "right", "top"],
+					"required": [
+						"bottom",
+						"left",
+						"right",
+						"top"
+					],
 					"properties": {
 						"bottom": {
 							"type": "number",
@@ -2189,7 +2691,9 @@
 				{
 					"description": "The full monitor options with the index and an optional work_area_offset",
 					"type": "object",
-					"required": ["index"],
+					"required": [
+						"index"
+					],
 					"properties": {
 						"index": {
 							"description": "Komorebi monitor index of the monitor on which to render the bar",
@@ -2200,7 +2704,12 @@
 						"work_area_offset": {
 							"description": "Automatically apply a work area offset for this monitor to accommodate the bar",
 							"type": "object",
-							"required": ["bottom", "left", "right", "top"],
+							"required": [
+								"bottom",
+								"left",
+								"right",
+								"top"
+							],
 							"properties": {
 								"bottom": {
 									"description": "The bottom point in a Win32 Rect",
@@ -2237,7 +2746,12 @@
 				},
 				{
 					"type": "object",
-					"required": ["bottom", "left", "right", "top"],
+					"required": [
+						"bottom",
+						"left",
+						"right",
+						"top"
+					],
 					"properties": {
 						"bottom": {
 							"type": "number",
@@ -2317,7 +2831,10 @@
 				"end": {
 					"description": "The desired size of the bar from the starting position (usually monitor width x desired height)",
 					"type": "object",
-					"required": ["x", "y"],
+					"required": [
+						"x",
+						"y"
+					],
 					"properties": {
 						"x": {
 							"description": "X coordinate",
@@ -2334,7 +2851,10 @@
 				"start": {
 					"description": "The desired starting position of the bar (0,0 = top left of the screen)",
 					"type": "object",
-					"required": ["x", "y"],
+					"required": [
+						"x",
+						"y"
+					],
 					"properties": {
 						"x": {
 							"description": "X coordinate",
@@ -2357,11 +2877,15 @@
 				"oneOf": [
 					{
 						"type": "object",
-						"required": ["Battery"],
+						"required": [
+							"Battery"
+						],
 						"properties": {
 							"Battery": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -2383,22 +2907,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -2409,11 +2941,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Cpu"],
+						"required": [
+							"Cpu"
+						],
 						"properties": {
 							"Cpu": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -2431,22 +2967,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -2457,11 +3001,16 @@
 					},
 					{
 						"type": "object",
-						"required": ["Date"],
+						"required": [
+							"Date"
+						],
 						"properties": {
 							"Date": {
 								"type": "object",
-								"required": ["enable", "format"],
+								"required": [
+									"enable",
+									"format"
+								],
 								"properties": {
 									"enable": {
 										"description": "Enable the Date widget",
@@ -2473,27 +3022,37 @@
 											{
 												"description": "Month/Date/Year format (09/08/24)",
 												"type": "string",
-												"enum": ["MonthDateYear"]
+												"enum": [
+													"MonthDateYear"
+												]
 											},
 											{
 												"description": "Year-Month-Date format (2024-09-08)",
 												"type": "string",
-												"enum": ["YearMonthDate"]
+												"enum": [
+													"YearMonthDate"
+												]
 											},
 											{
 												"description": "Date-Month-Year format (8-Sep-2024)",
 												"type": "string",
-												"enum": ["DateMonthYear"]
+												"enum": [
+													"DateMonthYear"
+												]
 											},
 											{
 												"description": "Day Date Month Year format (8 September 2024)",
 												"type": "string",
-												"enum": ["DayDateMonthYear"]
+												"enum": [
+													"DayDateMonthYear"
+												]
 											},
 											{
 												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
 												"type": "object",
-												"required": ["Custom"],
+												"required": [
+													"Custom"
+												],
 												"properties": {
 													"Custom": {
 														"type": "string"
@@ -2504,12 +3063,17 @@
 											{
 												"description": "Custom format with modifiers",
 												"type": "object",
-												"required": ["CustomModifiers"],
+												"required": [
+													"CustomModifiers"
+												],
 												"properties": {
 													"CustomModifiers": {
 														"description": "Custom format with additive modifiers for integer format specifiers",
 														"type": "object",
-														"required": ["format", "modifiers"],
+														"required": [
+															"format",
+															"modifiers"
+														],
 														"properties": {
 															"format": {
 																"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
@@ -2536,22 +3100,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -2566,11 +3138,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Keyboard"],
+						"required": [
+							"Keyboard"
+						],
 						"properties": {
 							"Keyboard": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 1 second)",
@@ -2588,22 +3164,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -2614,7 +3198,9 @@
 					},
 					{
 						"type": "object",
-						"required": ["Komorebi"],
+						"required": [
+							"Komorebi"
+						],
 						"properties": {
 							"Komorebi": {
 								"type": "object",
@@ -2622,7 +3208,10 @@
 									"configuration_switcher": {
 										"description": "Configure the Configuration Switcher widget",
 										"type": "object",
-										"required": ["configurations", "enable"],
+										"required": [
+											"configurations",
+											"enable"
+										],
 										"properties": {
 											"configurations": {
 												"description": "A map of display friendly name => path to configuration.json",
@@ -2640,7 +3229,9 @@
 									"focused_window": {
 										"description": "Configure the Focused Window widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the currently focused window",
@@ -2648,27 +3239,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -2685,7 +3286,9 @@
 									"layout": {
 										"description": "Configure the Layout widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the current layout",
@@ -2693,27 +3296,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -2759,7 +3372,9 @@
 									"workspace_layer": {
 										"description": "Configure the Workspace Layer widget",
 										"type": "object",
-										"required": ["enable"],
+										"required": [
+											"enable"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the current layer",
@@ -2767,27 +3382,37 @@
 													{
 														"description": "Show only icon",
 														"type": "string",
-														"enum": ["Icon"]
+														"enum": [
+															"Icon"
+														]
 													},
 													{
 														"description": "Show only text",
 														"type": "string",
-														"enum": ["Text"]
+														"enum": [
+															"Text"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and text on the rest",
 														"type": "string",
-														"enum": ["TextAndIconOnSelected"]
+														"enum": [
+															"TextAndIconOnSelected"
+														]
 													},
 													{
 														"description": "Show both icon and text",
 														"type": "string",
-														"enum": ["IconAndText"]
+														"enum": [
+															"IconAndText"
+														]
 													},
 													{
 														"description": "Show an icon and text for the selected element, and icons on the rest",
 														"type": "string",
-														"enum": ["IconAndTextOnSelected"]
+														"enum": [
+															"IconAndTextOnSelected"
+														]
 													}
 												]
 											},
@@ -2804,7 +3429,10 @@
 									"workspaces": {
 										"description": "Configure the Workspaces widget",
 										"type": "object",
-										"required": ["enable", "hide_empty_workspaces"],
+										"required": [
+											"enable",
+											"hide_empty_workspaces"
+										],
 										"properties": {
 											"display": {
 												"description": "Display format of the workspace",
@@ -2812,48 +3440,66 @@
 													{
 														"description": "Show all icons only",
 														"type": "string",
-														"enum": ["AllIcons"]
+														"enum": [
+															"AllIcons"
+														]
 													},
 													{
 														"description": "Show both all icons and text",
 														"type": "string",
-														"enum": ["AllIconsAndText"]
+														"enum": [
+															"AllIconsAndText"
+														]
 													},
 													{
 														"description": "Show all icons and text for the selected element, and all icons on the rest",
 														"type": "string",
-														"enum": ["AllIconsAndTextOnSelected"]
+														"enum": [
+															"AllIconsAndTextOnSelected"
+														]
 													},
 													{
 														"type": "object",
-														"required": ["Existing"],
+														"required": [
+															"Existing"
+														],
 														"properties": {
 															"Existing": {
 																"oneOf": [
 																	{
 																		"description": "Show only icon",
 																		"type": "string",
-																		"enum": ["Icon"]
+																		"enum": [
+																			"Icon"
+																		]
 																	},
 																	{
 																		"description": "Show only text",
 																		"type": "string",
-																		"enum": ["Text"]
+																		"enum": [
+																			"Text"
+																		]
 																	},
 																	{
 																		"description": "Show an icon and text for the selected element, and text on the rest",
 																		"type": "string",
-																		"enum": ["TextAndIconOnSelected"]
+																		"enum": [
+																			"TextAndIconOnSelected"
+																		]
 																	},
 																	{
 																		"description": "Show both icon and text",
 																		"type": "string",
-																		"enum": ["IconAndText"]
+																		"enum": [
+																			"IconAndText"
+																		]
 																	},
 																	{
 																		"description": "Show an icon and text for the selected element, and icons on the rest",
 																		"type": "string",
-																		"enum": ["IconAndTextOnSelected"]
+																		"enum": [
+																			"IconAndTextOnSelected"
+																		]
 																	}
 																]
 															}
@@ -2879,11 +3525,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Media"],
+						"required": [
+							"Media"
+						],
 						"properties": {
 							"Media": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"enable": {
 										"description": "Enable the Media widget",
@@ -2896,11 +3546,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Memory"],
+						"required": [
+							"Memory"
+						],
 						"properties": {
 							"Memory": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -2918,22 +3572,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -2944,7 +3606,9 @@
 					},
 					{
 						"type": "object",
-						"required": ["Network"],
+						"required": [
+							"Network"
+						],
 						"properties": {
 							"Network": {
 								"type": "object",
@@ -2970,22 +3634,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -3014,14 +3686,18 @@
 					},
 					{
 						"type": "object",
-						"required": ["StartMenu"],
+						"required": [
+							"StartMenu"
+						],
 						"properties": {
 							"StartMenu": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"enable": {
-										"description": "Enable the Network widget",
+										"description": "Enable the start menu button widget",
 										"type": "boolean"
 									},
 									"label_prefix": {
@@ -3030,22 +3706,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -3056,11 +3740,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Storage"],
+						"required": [
+							"Storage"
+						],
 						"properties": {
 							"Storage": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 10 seconds)",
@@ -3078,22 +3766,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -3104,11 +3800,16 @@
 					},
 					{
 						"type": "object",
-						"required": ["Time"],
+						"required": [
+							"Time"
+						],
 						"properties": {
 							"Time": {
 								"type": "object",
-								"required": ["enable", "format"],
+								"required": [
+									"enable",
+									"format"
+								],
 								"properties": {
 									"changing_icon": {
 										"description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
@@ -3124,37 +3825,51 @@
 											{
 												"description": "Twelve-hour format (with seconds)",
 												"type": "string",
-												"enum": ["TwelveHour"]
+												"enum": [
+													"TwelveHour"
+												]
 											},
 											{
 												"description": "Twelve-hour format (without seconds)",
 												"type": "string",
-												"enum": ["TwelveHourWithoutSeconds"]
+												"enum": [
+													"TwelveHourWithoutSeconds"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format (with seconds)",
 												"type": "string",
-												"enum": ["TwentyFourHour"]
+												"enum": [
+													"TwentyFourHour"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format (without seconds)",
 												"type": "string",
-												"enum": ["TwentyFourHourWithoutSeconds"]
+												"enum": [
+													"TwentyFourHourWithoutSeconds"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
 												"type": "string",
-												"enum": ["BinaryCircle"]
+												"enum": [
+													"BinaryCircle"
+												]
 											},
 											{
 												"description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
 												"type": "string",
-												"enum": ["BinaryRectangle"]
+												"enum": [
+													"BinaryRectangle"
+												]
 											},
 											{
 												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
 												"type": "object",
-												"required": ["Custom"],
+												"required": [
+													"Custom"
+												],
 												"properties": {
 													"Custom": {
 														"type": "string"
@@ -3170,22 +3885,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									},
@@ -3200,11 +3923,15 @@
 					},
 					{
 						"type": "object",
-						"required": ["Update"],
+						"required": [
+							"Update"
+						],
 						"properties": {
 							"Update": {
 								"type": "object",
-								"required": ["enable"],
+								"required": [
+									"enable"
+								],
 								"properties": {
 									"data_refresh_interval": {
 										"description": "Data refresh interval (default: 12 hours)",
@@ -3222,22 +3949,30 @@
 											{
 												"description": "Show no prefix",
 												"type": "string",
-												"enum": ["None"]
+												"enum": [
+													"None"
+												]
 											},
 											{
 												"description": "Show an icon",
 												"type": "string",
-												"enum": ["Icon"]
+												"enum": [
+													"Icon"
+												]
 											},
 											{
 												"description": "Show text",
 												"type": "string",
-												"enum": ["Text"]
+												"enum": [
+													"Text"
+												]
 											},
 											{
 												"description": "Show an icon and text",
 												"type": "string",
-												"enum": ["IconAndText"]
+												"enum": [
+													"IconAndText"
+												]
 											}
 										]
 									}
@@ -3255,7 +3990,10 @@
 				{
 					"description": "A theme from catppuccin-egui",
 					"type": "object",
-					"required": ["name", "palette"],
+					"required": [
+						"name",
+						"palette"
+					],
 					"properties": {
 						"accent": {
 							"type": "string",
@@ -3291,18 +4029,28 @@
 						"name": {
 							"description": "Name of the Catppuccin theme (theme previews: https://github.com/catppuccin/catppuccin)",
 							"type": "string",
-							"enum": ["Frappe", "Latte", "Macchiato", "Mocha"]
+							"enum": [
+								"Frappe",
+								"Latte",
+								"Macchiato",
+								"Mocha"
+							]
 						},
 						"palette": {
 							"type": "string",
-							"enum": ["Catppuccin"]
+							"enum": [
+								"Catppuccin"
+							]
 						}
 					}
 				},
 				{
 					"description": "A theme from base16-egui-themes",
 					"type": "object",
-					"required": ["name", "palette"],
+					"required": [
+						"name",
+						"palette"
+					],
 					"properties": {
 						"accent": {
 							"type": "string",
@@ -3602,7 +4350,9 @@
 						},
 						"palette": {
 							"type": "string",
-							"enum": ["Base16"]
+							"enum": [
+								"Base16"
+							]
 						}
 					}
 				}

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -746,6 +746,60 @@
           {
             "type": "object",
             "required": [
+              "StartMenu"
+            ],
+            "properties": {
+              "StartMenu": {
+                "type": "object",
+                "required": [
+                  "enable"
+                ],
+                "properties": {
+                  "enable": {
+                    "description": "Enable the Network widget",
+                    "type": "boolean"
+                  },
+                  "label_prefix": {
+                    "description": "Display label prefix",
+                    "oneOf": [
+                      {
+                        "description": "Show no prefix",
+                        "type": "string",
+                        "enum": [
+                          "None"
+                        ]
+                      },
+                      {
+                        "description": "Show an icon",
+                        "type": "string",
+                        "enum": [
+                          "Icon"
+                        ]
+                      },
+                      {
+                        "description": "Show text",
+                        "type": "string",
+                        "enum": [
+                          "Text"
+                        ]
+                      },
+                      {
+                        "description": "Show an icon and text",
+                        "type": "string",
+                        "enum": [
+                          "IconAndText"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
               "Network"
             ],
             "properties": {

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -1,4265 +1,3623 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "KomobarConfig",
-  "description": "The `komorebi.bar.json` configuration file reference for `v0.1.35`",
-  "type": "object",
-  "required": [
-    "left_widgets",
-    "monitor",
-    "right_widgets"
-  ],
-  "properties": {
-    "center_widgets": {
-      "description": "Center widgets (ordered left-to-right)",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "Battery"
-            ],
-            "properties": {
-              "Battery": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Battery widget",
-                    "type": "boolean"
-                  },
-                  "hide_on_full_charge": {
-                    "description": "Hide the widget if the battery is at full charge",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Cpu"
-            ],
-            "properties": {
-              "Cpu": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Cpu widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Date"
-            ],
-            "properties": {
-              "Date": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "format"
-                ],
-                "properties": {
-                  "enable": {
-                    "description": "Enable the Date widget",
-                    "type": "boolean"
-                  },
-                  "format": {
-                    "description": "Set the Date format",
-                    "oneOf": [
-                      {
-                        "description": "Month/Date/Year format (09/08/24)",
-                        "type": "string",
-                        "enum": [
-                          "MonthDateYear"
-                        ]
-                      },
-                      {
-                        "description": "Year-Month-Date format (2024-09-08)",
-                        "type": "string",
-                        "enum": [
-                          "YearMonthDate"
-                        ]
-                      },
-                      {
-                        "description": "Date-Month-Year format (8-Sep-2024)",
-                        "type": "string",
-                        "enum": [
-                          "DateMonthYear"
-                        ]
-                      },
-                      {
-                        "description": "Day Date Month Year format (8 September 2024)",
-                        "type": "string",
-                        "enum": [
-                          "DayDateMonthYear"
-                        ]
-                      },
-                      {
-                        "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                        "type": "object",
-                        "required": [
-                          "Custom"
-                        ],
-                        "properties": {
-                          "Custom": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      {
-                        "description": "Custom format with modifiers",
-                        "type": "object",
-                        "required": [
-                          "CustomModifiers"
-                        ],
-                        "properties": {
-                          "CustomModifiers": {
-                            "description": "Custom format with additive modifiers for integer format specifiers",
-                            "type": "object",
-                            "required": [
-                              "format",
-                              "modifiers"
-                            ],
-                            "properties": {
-                              "format": {
-                                "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                                "type": "string"
-                              },
-                              "modifiers": {
-                                "description": "Additive modifiers for integer format specifiers (e.g. { \"%U\": 1 } to increment the zero-indexed week number by 1)",
-                                "type": "object",
-                                "additionalProperties": {
-                                  "type": "integer",
-                                  "format": "int32"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "timezone": {
-                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Keyboard"
-            ],
-            "properties": {
-              "Keyboard": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 1 second)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Input widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Komorebi"
-            ],
-            "properties": {
-              "Komorebi": {
-                "type": "object",
-                "properties": {
-                  "configuration_switcher": {
-                    "description": "Configure the Configuration Switcher widget",
-                    "type": "object",
-                    "required": [
-                      "configurations",
-                      "enable"
-                    ],
-                    "properties": {
-                      "configurations": {
-                        "description": "A map of display friendly name => path to configuration.json",
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "string"
-                        }
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Configurations widget",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "focused_window": {
-                    "description": "Configure the Focused Window widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the currently focused window",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Focused Window widget",
-                        "type": "boolean"
-                      },
-                      "show_icon": {
-                        "description": "DEPRECATED: use 'display' instead (Show the icon of the currently focused window)",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "layout": {
-                    "description": "Configure the Layout widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the current layout",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Layout widget",
-                        "type": "boolean"
-                      },
-                      "options": {
-                        "description": "List of layout options",
-                        "type": "array",
-                        "items": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                              "enum": [
-                                "BSP",
-                                "Columns",
-                                "Rows",
-                                "VerticalStack",
-                                "HorizontalStack",
-                                "UltrawideVerticalStack",
-                                "Grid",
-                                "RightMainVerticalStack"
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "workspace_layer": {
-                    "description": "Configure the Workspace Layer widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the current layer",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Workspace Layer widget",
-                        "type": "boolean"
-                      },
-                      "show_when_tiling": {
-                        "description": "Show the widget event if the layer is Tiling",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "workspaces": {
-                    "description": "Configure the Workspaces widget",
-                    "type": "object",
-                    "required": [
-                      "enable",
-                      "hide_empty_workspaces"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the workspace",
-                        "oneOf": [
-                          {
-                            "description": "Show all icons only",
-                            "type": "string",
-                            "enum": [
-                              "AllIcons"
-                            ]
-                          },
-                          {
-                            "description": "Show both all icons and text",
-                            "type": "string",
-                            "enum": [
-                              "AllIconsAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show all icons and text for the selected element, and all icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "AllIconsAndTextOnSelected"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "required": [
-                              "Existing"
-                            ],
-                            "properties": {
-                              "Existing": {
-                                "oneOf": [
-                                  {
-                                    "description": "Show only icon",
-                                    "type": "string",
-                                    "enum": [
-                                      "Icon"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show only text",
-                                    "type": "string",
-                                    "enum": [
-                                      "Text"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show an icon and text for the selected element, and text on the rest",
-                                    "type": "string",
-                                    "enum": [
-                                      "TextAndIconOnSelected"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show both icon and text",
-                                    "type": "string",
-                                    "enum": [
-                                      "IconAndText"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show an icon and text for the selected element, and icons on the rest",
-                                    "type": "string",
-                                    "enum": [
-                                      "IconAndTextOnSelected"
-                                    ]
-                                  }
-                                ]
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Workspaces widget",
-                        "type": "boolean"
-                      },
-                      "hide_empty_workspaces": {
-                        "description": "Hide workspaces without any windows",
-                        "type": "boolean"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Media"
-            ],
-            "properties": {
-              "Media": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "enable": {
-                    "description": "Enable the Media widget",
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Memory"
-            ],
-            "properties": {
-              "Memory": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Memory widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "StartMenu"
-            ],
-            "properties": {
-              "StartMenu": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "enable": {
-                    "description": "Enable the Network widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Network"
-            ],
-            "properties": {
-              "Network": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "show_network_activity",
-                  "show_total_data_transmitted"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Network widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "network_activity_fill_characters": {
-                    "description": "Characters to reserve for network activity data",
-                    "type": "integer",
-                    "format": "uint",
-                    "minimum": 0.0
-                  },
-                  "show_default_interface": {
-                    "description": "Show default interface",
-                    "type": "boolean"
-                  },
-                  "show_network_activity": {
-                    "description": "Show network activity",
-                    "type": "boolean"
-                  },
-                  "show_total_data_transmitted": {
-                    "description": "Show total data transmitted",
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Storage"
-            ],
-            "properties": {
-              "Storage": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Storage widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Time"
-            ],
-            "properties": {
-              "Time": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "format"
-                ],
-                "properties": {
-                  "changing_icon": {
-                    "description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
-                    "type": "boolean"
-                  },
-                  "enable": {
-                    "description": "Enable the Time widget",
-                    "type": "boolean"
-                  },
-                  "format": {
-                    "description": "Set the Time format",
-                    "oneOf": [
-                      {
-                        "description": "Twelve-hour format (with seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwelveHour"
-                        ]
-                      },
-                      {
-                        "description": "Twelve-hour format (without seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwelveHourWithoutSeconds"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format (with seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwentyFourHour"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format (without seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwentyFourHourWithoutSeconds"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
-                        "type": "string",
-                        "enum": [
-                          "BinaryCircle"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
-                        "type": "string",
-                        "enum": [
-                          "BinaryRectangle"
-                        ]
-                      },
-                      {
-                        "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                        "type": "object",
-                        "required": [
-                          "Custom"
-                        ],
-                        "properties": {
-                          "Custom": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "timezone": {
-                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Update"
-            ],
-            "properties": {
-              "Update": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 12 hours)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Update widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      }
-    },
-    "font_family": {
-      "description": "Font family",
-      "type": "string"
-    },
-    "font_size": {
-      "description": "Font size (default: 12.5)",
-      "type": "number",
-      "format": "float"
-    },
-    "frame": {
-      "description": "Frame options (see: https://docs.rs/egui/latest/egui/containers/frame/struct.Frame.html)",
-      "type": "object",
-      "required": [
-        "inner_margin"
-      ],
-      "properties": {
-        "inner_margin": {
-          "description": "Margin inside the painted frame",
-          "type": "object",
-          "required": [
-            "x",
-            "y"
-          ],
-          "properties": {
-            "x": {
-              "description": "X coordinate",
-              "type": "number",
-              "format": "float"
-            },
-            "y": {
-              "description": "Y coordinate",
-              "type": "number",
-              "format": "float"
-            }
-          }
-        }
-      }
-    },
-    "grouping": {
-      "description": "Visual grouping for widgets",
-      "oneOf": [
-        {
-          "description": "No grouping is applied",
-          "type": "object",
-          "required": [
-            "kind"
-          ],
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": [
-                "None"
-              ]
-            }
-          }
-        },
-        {
-          "description": "Widgets are grouped as a whole",
-          "type": "object",
-          "required": [
-            "kind"
-          ],
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": [
-                "Bar"
-              ]
-            },
-            "rounding": {
-              "description": "Rounding values for the 4 corners. Can be a single or 4 values.",
-              "anyOf": [
-                {
-                  "description": "All 4 corners are the same",
-                  "type": "number",
-                  "format": "float"
-                },
-                {
-                  "description": "All 4 corners are custom. Order: NW, NE, SW, SE",
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "float"
-                  },
-                  "maxItems": 4,
-                  "minItems": 4
-                }
-              ]
-            },
-            "style": {
-              "description": "Styles for the grouping",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "enum": [
-                    "Default"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB4O1S3"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB4O0S3"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB0O1S3"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB3O1S2"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB3O0S2"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB0O1S2"
-                  ]
-                }
-              ]
-            },
-            "transparency_alpha": {
-              "description": "Alpha value for the color transparency [[0-255]] (default: 200)",
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          }
-        },
-        {
-          "description": "Widgets are grouped by alignment",
-          "type": "object",
-          "required": [
-            "kind"
-          ],
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": [
-                "Alignment"
-              ]
-            },
-            "rounding": {
-              "description": "Rounding values for the 4 corners. Can be a single or 4 values.",
-              "anyOf": [
-                {
-                  "description": "All 4 corners are the same",
-                  "type": "number",
-                  "format": "float"
-                },
-                {
-                  "description": "All 4 corners are custom. Order: NW, NE, SW, SE",
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "float"
-                  },
-                  "maxItems": 4,
-                  "minItems": 4
-                }
-              ]
-            },
-            "style": {
-              "description": "Styles for the grouping",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "enum": [
-                    "Default"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB4O1S3"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB4O0S3"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB0O1S3"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB3O1S2"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB3O0S2"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB0O1S2"
-                  ]
-                }
-              ]
-            },
-            "transparency_alpha": {
-              "description": "Alpha value for the color transparency [[0-255]] (default: 200)",
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          }
-        },
-        {
-          "description": "Widgets are grouped individually",
-          "type": "object",
-          "required": [
-            "kind"
-          ],
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": [
-                "Widget"
-              ]
-            },
-            "rounding": {
-              "description": "Rounding values for the 4 corners. Can be a single or 4 values.",
-              "anyOf": [
-                {
-                  "description": "All 4 corners are the same",
-                  "type": "number",
-                  "format": "float"
-                },
-                {
-                  "description": "All 4 corners are custom. Order: NW, NE, SW, SE",
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "float"
-                  },
-                  "maxItems": 4,
-                  "minItems": 4
-                }
-              ]
-            },
-            "style": {
-              "description": "Styles for the grouping",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "enum": [
-                    "Default"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB4O1S3"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB4O0S3"
-                  ]
-                },
-                {
-                  "description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithShadowB0O1S3"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB3O1S2"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB3O0S2"
-                  ]
-                },
-                {
-                  "description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
-                  "type": "string",
-                  "enum": [
-                    "DefaultWithGlowB0O1S2"
-                  ]
-                }
-              ]
-            },
-            "transparency_alpha": {
-              "description": "Alpha value for the color transparency [[0-255]] (default: 200)",
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          }
-        }
-      ]
-    },
-    "height": {
-      "description": "Bar height (default: 50)",
-      "type": "number",
-      "format": "float"
-    },
-    "icon_scale": {
-      "description": "Scale of the icons relative to the font_size [[1.0-2.0]]. (default: 1.4)",
-      "type": "number",
-      "format": "float"
-    },
-    "left_widgets": {
-      "description": "Left side widgets (ordered left-to-right)",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "Battery"
-            ],
-            "properties": {
-              "Battery": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Battery widget",
-                    "type": "boolean"
-                  },
-                  "hide_on_full_charge": {
-                    "description": "Hide the widget if the battery is at full charge",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Cpu"
-            ],
-            "properties": {
-              "Cpu": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Cpu widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Date"
-            ],
-            "properties": {
-              "Date": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "format"
-                ],
-                "properties": {
-                  "enable": {
-                    "description": "Enable the Date widget",
-                    "type": "boolean"
-                  },
-                  "format": {
-                    "description": "Set the Date format",
-                    "oneOf": [
-                      {
-                        "description": "Month/Date/Year format (09/08/24)",
-                        "type": "string",
-                        "enum": [
-                          "MonthDateYear"
-                        ]
-                      },
-                      {
-                        "description": "Year-Month-Date format (2024-09-08)",
-                        "type": "string",
-                        "enum": [
-                          "YearMonthDate"
-                        ]
-                      },
-                      {
-                        "description": "Date-Month-Year format (8-Sep-2024)",
-                        "type": "string",
-                        "enum": [
-                          "DateMonthYear"
-                        ]
-                      },
-                      {
-                        "description": "Day Date Month Year format (8 September 2024)",
-                        "type": "string",
-                        "enum": [
-                          "DayDateMonthYear"
-                        ]
-                      },
-                      {
-                        "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                        "type": "object",
-                        "required": [
-                          "Custom"
-                        ],
-                        "properties": {
-                          "Custom": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      {
-                        "description": "Custom format with modifiers",
-                        "type": "object",
-                        "required": [
-                          "CustomModifiers"
-                        ],
-                        "properties": {
-                          "CustomModifiers": {
-                            "description": "Custom format with additive modifiers for integer format specifiers",
-                            "type": "object",
-                            "required": [
-                              "format",
-                              "modifiers"
-                            ],
-                            "properties": {
-                              "format": {
-                                "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                                "type": "string"
-                              },
-                              "modifiers": {
-                                "description": "Additive modifiers for integer format specifiers (e.g. { \"%U\": 1 } to increment the zero-indexed week number by 1)",
-                                "type": "object",
-                                "additionalProperties": {
-                                  "type": "integer",
-                                  "format": "int32"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "timezone": {
-                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Keyboard"
-            ],
-            "properties": {
-              "Keyboard": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 1 second)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Input widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Komorebi"
-            ],
-            "properties": {
-              "Komorebi": {
-                "type": "object",
-                "properties": {
-                  "configuration_switcher": {
-                    "description": "Configure the Configuration Switcher widget",
-                    "type": "object",
-                    "required": [
-                      "configurations",
-                      "enable"
-                    ],
-                    "properties": {
-                      "configurations": {
-                        "description": "A map of display friendly name => path to configuration.json",
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "string"
-                        }
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Configurations widget",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "focused_window": {
-                    "description": "Configure the Focused Window widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the currently focused window",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Focused Window widget",
-                        "type": "boolean"
-                      },
-                      "show_icon": {
-                        "description": "DEPRECATED: use 'display' instead (Show the icon of the currently focused window)",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "layout": {
-                    "description": "Configure the Layout widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the current layout",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Layout widget",
-                        "type": "boolean"
-                      },
-                      "options": {
-                        "description": "List of layout options",
-                        "type": "array",
-                        "items": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                              "enum": [
-                                "BSP",
-                                "Columns",
-                                "Rows",
-                                "VerticalStack",
-                                "HorizontalStack",
-                                "UltrawideVerticalStack",
-                                "Grid",
-                                "RightMainVerticalStack"
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "workspace_layer": {
-                    "description": "Configure the Workspace Layer widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the current layer",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Workspace Layer widget",
-                        "type": "boolean"
-                      },
-                      "show_when_tiling": {
-                        "description": "Show the widget event if the layer is Tiling",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "workspaces": {
-                    "description": "Configure the Workspaces widget",
-                    "type": "object",
-                    "required": [
-                      "enable",
-                      "hide_empty_workspaces"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the workspace",
-                        "oneOf": [
-                          {
-                            "description": "Show all icons only",
-                            "type": "string",
-                            "enum": [
-                              "AllIcons"
-                            ]
-                          },
-                          {
-                            "description": "Show both all icons and text",
-                            "type": "string",
-                            "enum": [
-                              "AllIconsAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show all icons and text for the selected element, and all icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "AllIconsAndTextOnSelected"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "required": [
-                              "Existing"
-                            ],
-                            "properties": {
-                              "Existing": {
-                                "oneOf": [
-                                  {
-                                    "description": "Show only icon",
-                                    "type": "string",
-                                    "enum": [
-                                      "Icon"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show only text",
-                                    "type": "string",
-                                    "enum": [
-                                      "Text"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show an icon and text for the selected element, and text on the rest",
-                                    "type": "string",
-                                    "enum": [
-                                      "TextAndIconOnSelected"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show both icon and text",
-                                    "type": "string",
-                                    "enum": [
-                                      "IconAndText"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show an icon and text for the selected element, and icons on the rest",
-                                    "type": "string",
-                                    "enum": [
-                                      "IconAndTextOnSelected"
-                                    ]
-                                  }
-                                ]
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Workspaces widget",
-                        "type": "boolean"
-                      },
-                      "hide_empty_workspaces": {
-                        "description": "Hide workspaces without any windows",
-                        "type": "boolean"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Media"
-            ],
-            "properties": {
-              "Media": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "enable": {
-                    "description": "Enable the Media widget",
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Memory"
-            ],
-            "properties": {
-              "Memory": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Memory widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Network"
-            ],
-            "properties": {
-              "Network": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "show_network_activity",
-                  "show_total_data_transmitted"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Network widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "network_activity_fill_characters": {
-                    "description": "Characters to reserve for network activity data",
-                    "type": "integer",
-                    "format": "uint",
-                    "minimum": 0.0
-                  },
-                  "show_default_interface": {
-                    "description": "Show default interface",
-                    "type": "boolean"
-                  },
-                  "show_network_activity": {
-                    "description": "Show network activity",
-                    "type": "boolean"
-                  },
-                  "show_total_data_transmitted": {
-                    "description": "Show total data transmitted",
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Storage"
-            ],
-            "properties": {
-              "Storage": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Storage widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Time"
-            ],
-            "properties": {
-              "Time": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "format"
-                ],
-                "properties": {
-                  "changing_icon": {
-                    "description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
-                    "type": "boolean"
-                  },
-                  "enable": {
-                    "description": "Enable the Time widget",
-                    "type": "boolean"
-                  },
-                  "format": {
-                    "description": "Set the Time format",
-                    "oneOf": [
-                      {
-                        "description": "Twelve-hour format (with seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwelveHour"
-                        ]
-                      },
-                      {
-                        "description": "Twelve-hour format (without seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwelveHourWithoutSeconds"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format (with seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwentyFourHour"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format (without seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwentyFourHourWithoutSeconds"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
-                        "type": "string",
-                        "enum": [
-                          "BinaryCircle"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
-                        "type": "string",
-                        "enum": [
-                          "BinaryRectangle"
-                        ]
-                      },
-                      {
-                        "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                        "type": "object",
-                        "required": [
-                          "Custom"
-                        ],
-                        "properties": {
-                          "Custom": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "timezone": {
-                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Update"
-            ],
-            "properties": {
-              "Update": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 12 hours)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Update widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      }
-    },
-    "margin": {
-      "description": "Bar margin. Use one value for all sides or use a grouped margin for horizontal and/or vertical definition which can each take a single value for a symmetric margin or two values for each side, i.e.: ```json \"margin\": { \"horizontal\": 10 } ``` or: ```json \"margin\": { \"vertical\": [top, bottom] } ``` You can also set individual margin on each side like this: ```json \"margin\": { \"top\": 10, \"bottom\": 10, \"left\": 10, \"right\": 10, } ``` By default, margin is set to 0 on all sides.",
-      "anyOf": [
-        {
-          "type": "number",
-          "format": "float"
-        },
-        {
-          "type": "object",
-          "required": [
-            "bottom",
-            "left",
-            "right",
-            "top"
-          ],
-          "properties": {
-            "bottom": {
-              "type": "number",
-              "format": "float"
-            },
-            "left": {
-              "type": "number",
-              "format": "float"
-            },
-            "right": {
-              "type": "number",
-              "format": "float"
-            },
-            "top": {
-              "type": "number",
-              "format": "float"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "horizontal": {
-              "anyOf": [
-                {
-                  "type": "number",
-                  "format": "float"
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "number",
-                      "format": "float"
-                    },
-                    {
-                      "type": "number",
-                      "format": "float"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
-                }
-              ]
-            },
-            "vertical": {
-              "anyOf": [
-                {
-                  "type": "number",
-                  "format": "float"
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "number",
-                      "format": "float"
-                    },
-                    {
-                      "type": "number",
-                      "format": "float"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    "max_label_width": {
-      "description": "Max label width before text truncation (default: 400.0)",
-      "type": "number",
-      "format": "float"
-    },
-    "monitor": {
-      "description": "The monitor index or the full monitor options",
-      "anyOf": [
-        {
-          "description": "The monitor index where you want the bar to show",
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        {
-          "description": "The full monitor options with the index and an optional work_area_offset",
-          "type": "object",
-          "required": [
-            "index"
-          ],
-          "properties": {
-            "index": {
-              "description": "Komorebi monitor index of the monitor on which to render the bar",
-              "type": "integer",
-              "format": "uint",
-              "minimum": 0.0
-            },
-            "work_area_offset": {
-              "description": "Automatically apply a work area offset for this monitor to accommodate the bar",
-              "type": "object",
-              "required": [
-                "bottom",
-                "left",
-                "right",
-                "top"
-              ],
-              "properties": {
-                "bottom": {
-                  "description": "The bottom point in a Win32 Rect",
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "left": {
-                  "description": "The left point in a Win32 Rect",
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "right": {
-                  "description": "The right point in a Win32 Rect",
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "top": {
-                  "description": "The top point in a Win32 Rect",
-                  "type": "integer",
-                  "format": "int32"
-                }
-              }
-            }
-          }
-        }
-      ]
-    },
-    "padding": {
-      "description": "Bar padding. Use one value for all sides or use a grouped padding for horizontal and/or vertical definition which can each take a single value for a symmetric padding or two values for each side, i.e.: ```json \"padding\": { \"horizontal\": 10 } ``` or: ```json \"padding\": { \"horizontal\": [left, right] } ``` You can also set individual padding on each side like this: ```json \"padding\": { \"top\": 10, \"bottom\": 10, \"left\": 10, \"right\": 10, } ``` By default, padding is set to 10 on all sides.",
-      "anyOf": [
-        {
-          "type": "number",
-          "format": "float"
-        },
-        {
-          "type": "object",
-          "required": [
-            "bottom",
-            "left",
-            "right",
-            "top"
-          ],
-          "properties": {
-            "bottom": {
-              "type": "number",
-              "format": "float"
-            },
-            "left": {
-              "type": "number",
-              "format": "float"
-            },
-            "right": {
-              "type": "number",
-              "format": "float"
-            },
-            "top": {
-              "type": "number",
-              "format": "float"
-            }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "horizontal": {
-              "anyOf": [
-                {
-                  "type": "number",
-                  "format": "float"
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "number",
-                      "format": "float"
-                    },
-                    {
-                      "type": "number",
-                      "format": "float"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
-                }
-              ]
-            },
-            "vertical": {
-              "anyOf": [
-                {
-                  "type": "number",
-                  "format": "float"
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "type": "number",
-                      "format": "float"
-                    },
-                    {
-                      "type": "number",
-                      "format": "float"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
-                }
-              ]
-            }
-          }
-        }
-      ]
-    },
-    "position": {
-      "description": "Bar positioning options",
-      "type": "object",
-      "properties": {
-        "end": {
-          "description": "The desired size of the bar from the starting position (usually monitor width x desired height)",
-          "type": "object",
-          "required": [
-            "x",
-            "y"
-          ],
-          "properties": {
-            "x": {
-              "description": "X coordinate",
-              "type": "number",
-              "format": "float"
-            },
-            "y": {
-              "description": "Y coordinate",
-              "type": "number",
-              "format": "float"
-            }
-          }
-        },
-        "start": {
-          "description": "The desired starting position of the bar (0,0 = top left of the screen)",
-          "type": "object",
-          "required": [
-            "x",
-            "y"
-          ],
-          "properties": {
-            "x": {
-              "description": "X coordinate",
-              "type": "number",
-              "format": "float"
-            },
-            "y": {
-              "description": "Y coordinate",
-              "type": "number",
-              "format": "float"
-            }
-          }
-        }
-      }
-    },
-    "right_widgets": {
-      "description": "Right side widgets (ordered left-to-right)",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "required": [
-              "Battery"
-            ],
-            "properties": {
-              "Battery": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Battery widget",
-                    "type": "boolean"
-                  },
-                  "hide_on_full_charge": {
-                    "description": "Hide the widget if the battery is at full charge",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Cpu"
-            ],
-            "properties": {
-              "Cpu": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Cpu widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Date"
-            ],
-            "properties": {
-              "Date": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "format"
-                ],
-                "properties": {
-                  "enable": {
-                    "description": "Enable the Date widget",
-                    "type": "boolean"
-                  },
-                  "format": {
-                    "description": "Set the Date format",
-                    "oneOf": [
-                      {
-                        "description": "Month/Date/Year format (09/08/24)",
-                        "type": "string",
-                        "enum": [
-                          "MonthDateYear"
-                        ]
-                      },
-                      {
-                        "description": "Year-Month-Date format (2024-09-08)",
-                        "type": "string",
-                        "enum": [
-                          "YearMonthDate"
-                        ]
-                      },
-                      {
-                        "description": "Date-Month-Year format (8-Sep-2024)",
-                        "type": "string",
-                        "enum": [
-                          "DateMonthYear"
-                        ]
-                      },
-                      {
-                        "description": "Day Date Month Year format (8 September 2024)",
-                        "type": "string",
-                        "enum": [
-                          "DayDateMonthYear"
-                        ]
-                      },
-                      {
-                        "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                        "type": "object",
-                        "required": [
-                          "Custom"
-                        ],
-                        "properties": {
-                          "Custom": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      {
-                        "description": "Custom format with modifiers",
-                        "type": "object",
-                        "required": [
-                          "CustomModifiers"
-                        ],
-                        "properties": {
-                          "CustomModifiers": {
-                            "description": "Custom format with additive modifiers for integer format specifiers",
-                            "type": "object",
-                            "required": [
-                              "format",
-                              "modifiers"
-                            ],
-                            "properties": {
-                              "format": {
-                                "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                                "type": "string"
-                              },
-                              "modifiers": {
-                                "description": "Additive modifiers for integer format specifiers (e.g. { \"%U\": 1 } to increment the zero-indexed week number by 1)",
-                                "type": "object",
-                                "additionalProperties": {
-                                  "type": "integer",
-                                  "format": "int32"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "timezone": {
-                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Keyboard"
-            ],
-            "properties": {
-              "Keyboard": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 1 second)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Input widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Komorebi"
-            ],
-            "properties": {
-              "Komorebi": {
-                "type": "object",
-                "properties": {
-                  "configuration_switcher": {
-                    "description": "Configure the Configuration Switcher widget",
-                    "type": "object",
-                    "required": [
-                      "configurations",
-                      "enable"
-                    ],
-                    "properties": {
-                      "configurations": {
-                        "description": "A map of display friendly name => path to configuration.json",
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "string"
-                        }
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Configurations widget",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "focused_window": {
-                    "description": "Configure the Focused Window widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the currently focused window",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Focused Window widget",
-                        "type": "boolean"
-                      },
-                      "show_icon": {
-                        "description": "DEPRECATED: use 'display' instead (Show the icon of the currently focused window)",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "layout": {
-                    "description": "Configure the Layout widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the current layout",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Layout widget",
-                        "type": "boolean"
-                      },
-                      "options": {
-                        "description": "List of layout options",
-                        "type": "array",
-                        "items": {
-                          "anyOf": [
-                            {
-                              "type": "string",
-                              "enum": [
-                                "BSP",
-                                "Columns",
-                                "Rows",
-                                "VerticalStack",
-                                "HorizontalStack",
-                                "UltrawideVerticalStack",
-                                "Grid",
-                                "RightMainVerticalStack"
-                              ]
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "workspace_layer": {
-                    "description": "Configure the Workspace Layer widget",
-                    "type": "object",
-                    "required": [
-                      "enable"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the current layer",
-                        "oneOf": [
-                          {
-                            "description": "Show only icon",
-                            "type": "string",
-                            "enum": [
-                              "Icon"
-                            ]
-                          },
-                          {
-                            "description": "Show only text",
-                            "type": "string",
-                            "enum": [
-                              "Text"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and text on the rest",
-                            "type": "string",
-                            "enum": [
-                              "TextAndIconOnSelected"
-                            ]
-                          },
-                          {
-                            "description": "Show both icon and text",
-                            "type": "string",
-                            "enum": [
-                              "IconAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show an icon and text for the selected element, and icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "IconAndTextOnSelected"
-                            ]
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Workspace Layer widget",
-                        "type": "boolean"
-                      },
-                      "show_when_tiling": {
-                        "description": "Show the widget event if the layer is Tiling",
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "workspaces": {
-                    "description": "Configure the Workspaces widget",
-                    "type": "object",
-                    "required": [
-                      "enable",
-                      "hide_empty_workspaces"
-                    ],
-                    "properties": {
-                      "display": {
-                        "description": "Display format of the workspace",
-                        "oneOf": [
-                          {
-                            "description": "Show all icons only",
-                            "type": "string",
-                            "enum": [
-                              "AllIcons"
-                            ]
-                          },
-                          {
-                            "description": "Show both all icons and text",
-                            "type": "string",
-                            "enum": [
-                              "AllIconsAndText"
-                            ]
-                          },
-                          {
-                            "description": "Show all icons and text for the selected element, and all icons on the rest",
-                            "type": "string",
-                            "enum": [
-                              "AllIconsAndTextOnSelected"
-                            ]
-                          },
-                          {
-                            "type": "object",
-                            "required": [
-                              "Existing"
-                            ],
-                            "properties": {
-                              "Existing": {
-                                "oneOf": [
-                                  {
-                                    "description": "Show only icon",
-                                    "type": "string",
-                                    "enum": [
-                                      "Icon"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show only text",
-                                    "type": "string",
-                                    "enum": [
-                                      "Text"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show an icon and text for the selected element, and text on the rest",
-                                    "type": "string",
-                                    "enum": [
-                                      "TextAndIconOnSelected"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show both icon and text",
-                                    "type": "string",
-                                    "enum": [
-                                      "IconAndText"
-                                    ]
-                                  },
-                                  {
-                                    "description": "Show an icon and text for the selected element, and icons on the rest",
-                                    "type": "string",
-                                    "enum": [
-                                      "IconAndTextOnSelected"
-                                    ]
-                                  }
-                                ]
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        ]
-                      },
-                      "enable": {
-                        "description": "Enable the Komorebi Workspaces widget",
-                        "type": "boolean"
-                      },
-                      "hide_empty_workspaces": {
-                        "description": "Hide workspaces without any windows",
-                        "type": "boolean"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Media"
-            ],
-            "properties": {
-              "Media": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "enable": {
-                    "description": "Enable the Media widget",
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Memory"
-            ],
-            "properties": {
-              "Memory": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Memory widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Network"
-            ],
-            "properties": {
-              "Network": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "show_network_activity",
-                  "show_total_data_transmitted"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Network widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "network_activity_fill_characters": {
-                    "description": "Characters to reserve for network activity data",
-                    "type": "integer",
-                    "format": "uint",
-                    "minimum": 0.0
-                  },
-                  "show_default_interface": {
-                    "description": "Show default interface",
-                    "type": "boolean"
-                  },
-                  "show_network_activity": {
-                    "description": "Show network activity",
-                    "type": "boolean"
-                  },
-                  "show_total_data_transmitted": {
-                    "description": "Show total data transmitted",
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Storage"
-            ],
-            "properties": {
-              "Storage": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 10 seconds)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Storage widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Time"
-            ],
-            "properties": {
-              "Time": {
-                "type": "object",
-                "required": [
-                  "enable",
-                  "format"
-                ],
-                "properties": {
-                  "changing_icon": {
-                    "description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
-                    "type": "boolean"
-                  },
-                  "enable": {
-                    "description": "Enable the Time widget",
-                    "type": "boolean"
-                  },
-                  "format": {
-                    "description": "Set the Time format",
-                    "oneOf": [
-                      {
-                        "description": "Twelve-hour format (with seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwelveHour"
-                        ]
-                      },
-                      {
-                        "description": "Twelve-hour format (without seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwelveHourWithoutSeconds"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format (with seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwentyFourHour"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format (without seconds)",
-                        "type": "string",
-                        "enum": [
-                          "TwentyFourHourWithoutSeconds"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
-                        "type": "string",
-                        "enum": [
-                          "BinaryCircle"
-                        ]
-                      },
-                      {
-                        "description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
-                        "type": "string",
-                        "enum": [
-                          "BinaryRectangle"
-                        ]
-                      },
-                      {
-                        "description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
-                        "type": "object",
-                        "required": [
-                          "Custom"
-                        ],
-                        "properties": {
-                          "Custom": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  },
-                  "timezone": {
-                    "description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "Update"
-            ],
-            "properties": {
-              "Update": {
-                "type": "object",
-                "required": [
-                  "enable"
-                ],
-                "properties": {
-                  "data_refresh_interval": {
-                    "description": "Data refresh interval (default: 12 hours)",
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  },
-                  "enable": {
-                    "description": "Enable the Update widget",
-                    "type": "boolean"
-                  },
-                  "label_prefix": {
-                    "description": "Display label prefix",
-                    "oneOf": [
-                      {
-                        "description": "Show no prefix",
-                        "type": "string",
-                        "enum": [
-                          "None"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon",
-                        "type": "string",
-                        "enum": [
-                          "Icon"
-                        ]
-                      },
-                      {
-                        "description": "Show text",
-                        "type": "string",
-                        "enum": [
-                          "Text"
-                        ]
-                      },
-                      {
-                        "description": "Show an icon and text",
-                        "type": "string",
-                        "enum": [
-                          "IconAndText"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      }
-    },
-    "theme": {
-      "description": "Theme",
-      "oneOf": [
-        {
-          "description": "A theme from catppuccin-egui",
-          "type": "object",
-          "required": [
-            "name",
-            "palette"
-          ],
-          "properties": {
-            "accent": {
-              "type": "string",
-              "enum": [
-                "Rosewater",
-                "Flamingo",
-                "Pink",
-                "Mauve",
-                "Red",
-                "Maroon",
-                "Peach",
-                "Yellow",
-                "Green",
-                "Teal",
-                "Sky",
-                "Sapphire",
-                "Blue",
-                "Lavender",
-                "Text",
-                "Subtext1",
-                "Subtext0",
-                "Overlay2",
-                "Overlay1",
-                "Overlay0",
-                "Surface2",
-                "Surface1",
-                "Surface0",
-                "Base",
-                "Mantle",
-                "Crust"
-              ]
-            },
-            "name": {
-              "description": "Name of the Catppuccin theme (theme previews: https://github.com/catppuccin/catppuccin)",
-              "type": "string",
-              "enum": [
-                "Frappe",
-                "Latte",
-                "Macchiato",
-                "Mocha"
-              ]
-            },
-            "palette": {
-              "type": "string",
-              "enum": [
-                "Catppuccin"
-              ]
-            }
-          }
-        },
-        {
-          "description": "A theme from base16-egui-themes",
-          "type": "object",
-          "required": [
-            "name",
-            "palette"
-          ],
-          "properties": {
-            "accent": {
-              "type": "string",
-              "enum": [
-                "Base00",
-                "Base01",
-                "Base02",
-                "Base03",
-                "Base04",
-                "Base05",
-                "Base06",
-                "Base07",
-                "Base08",
-                "Base09",
-                "Base0A",
-                "Base0B",
-                "Base0C",
-                "Base0D",
-                "Base0E",
-                "Base0F"
-              ]
-            },
-            "name": {
-              "description": "Name of the Base16 theme (theme previews: https://tinted-theming.github.io/tinted-gallery/)",
-              "type": "string",
-              "enum": [
-                "3024",
-                "Apathy",
-                "Apprentice",
-                "Ashes",
-                "AtelierCaveLight",
-                "AtelierCave",
-                "AtelierDuneLight",
-                "AtelierDune",
-                "AtelierEstuaryLight",
-                "AtelierEstuary",
-                "AtelierForestLight",
-                "AtelierForest",
-                "AtelierHeathLight",
-                "AtelierHeath",
-                "AtelierLakesideLight",
-                "AtelierLakeside",
-                "AtelierPlateauLight",
-                "AtelierPlateau",
-                "AtelierSavannaLight",
-                "AtelierSavanna",
-                "AtelierSeasideLight",
-                "AtelierSeaside",
-                "AtelierSulphurpoolLight",
-                "AtelierSulphurpool",
-                "Atlas",
-                "AyuDark",
-                "AyuLight",
-                "AyuMirage",
-                "Aztec",
-                "Bespin",
-                "BlackMetalBathory",
-                "BlackMetalBurzum",
-                "BlackMetalDarkFuneral",
-                "BlackMetalGorgoroth",
-                "BlackMetalImmortal",
-                "BlackMetalKhold",
-                "BlackMetalMarduk",
-                "BlackMetalMayhem",
-                "BlackMetalNile",
-                "BlackMetalVenom",
-                "BlackMetal",
-                "Blueforest",
-                "Blueish",
-                "Brewer",
-                "Bright",
-                "Brogrammer",
-                "BrushtreesDark",
-                "Brushtrees",
-                "Caroline",
-                "CatppuccinFrappe",
-                "CatppuccinLatte",
-                "CatppuccinMacchiato",
-                "CatppuccinMocha",
-                "Chalk",
-                "Circus",
-                "ClassicDark",
-                "ClassicLight",
-                "Codeschool",
-                "Colors",
-                "Cupcake",
-                "Cupertino",
-                "DaOneBlack",
-                "DaOneGray",
-                "DaOneOcean",
-                "DaOnePaper",
-                "DaOneSea",
-                "DaOneWhite",
-                "DanqingLight",
-                "Danqing",
-                "Darcula",
-                "Darkmoss",
-                "Darktooth",
-                "Darkviolet",
-                "Decaf",
-                "DefaultDark",
-                "DefaultLight",
-                "Dirtysea",
-                "Dracula",
-                "EdgeDark",
-                "EdgeLight",
-                "Eighties",
-                "EmbersLight",
-                "Embers",
-                "Emil",
-                "EquilibriumDark",
-                "EquilibriumGrayDark",
-                "EquilibriumGrayLight",
-                "EquilibriumLight",
-                "Eris",
-                "Espresso",
-                "EvaDim",
-                "Eva",
-                "EvenokDark",
-                "EverforestDarkHard",
-                "Everforest",
-                "Flat",
-                "Framer",
-                "FruitSoda",
-                "Gigavolt",
-                "Github",
-                "GoogleDark",
-                "GoogleLight",
-                "Gotham",
-                "GrayscaleDark",
-                "GrayscaleLight",
-                "Greenscreen",
-                "Gruber",
-                "GruvboxDarkHard",
-                "GruvboxDarkMedium",
-                "GruvboxDarkPale",
-                "GruvboxDarkSoft",
-                "GruvboxLightHard",
-                "GruvboxLightMedium",
-                "GruvboxLightSoft",
-                "GruvboxMaterialDarkHard",
-                "GruvboxMaterialDarkMedium",
-                "GruvboxMaterialDarkSoft",
-                "GruvboxMaterialLightHard",
-                "GruvboxMaterialLightMedium",
-                "GruvboxMaterialLightSoft",
-                "Hardcore",
-                "Harmonic16Dark",
-                "Harmonic16Light",
-                "HeetchLight",
-                "Heetch",
-                "Helios",
-                "Hopscotch",
-                "HorizonDark",
-                "HorizonLight",
-                "HorizonTerminalDark",
-                "HorizonTerminalLight",
-                "HumanoidDark",
-                "HumanoidLight",
-                "IaDark",
-                "IaLight",
-                "Icy",
-                "Irblack",
-                "Isotope",
-                "Jabuti",
-                "Kanagawa",
-                "Katy",
-                "Kimber",
-                "Lime",
-                "Macintosh",
-                "Marrakesh",
-                "Materia",
-                "MaterialDarker",
-                "MaterialLighter",
-                "MaterialPalenight",
-                "MaterialVivid",
-                "Material",
-                "MeasuredDark",
-                "MeasuredLight",
-                "MellowPurple",
-                "MexicoLight",
-                "Mocha",
-                "Monokai",
-                "Moonlight",
-                "Mountain",
-                "Nebula",
-                "NordLight",
-                "Nord",
-                "Nova",
-                "Ocean",
-                "Oceanicnext",
-                "OneLight",
-                "OnedarkDark",
-                "Onedark",
-                "OutrunDark",
-                "OxocarbonDark",
-                "OxocarbonLight",
-                "Pandora",
-                "PapercolorDark",
-                "PapercolorLight",
-                "Paraiso",
-                "Pasque",
-                "Phd",
-                "Pico",
-                "Pinky",
-                "Pop",
-                "Porple",
-                "PreciousDarkEleven",
-                "PreciousDarkFifteen",
-                "PreciousLightWarm",
-                "PreciousLightWhite",
-                "PrimerDarkDimmed",
-                "PrimerDark",
-                "PrimerLight",
-                "Purpledream",
-                "Qualia",
-                "Railscasts",
-                "Rebecca",
-                "RosePineDawn",
-                "RosePineMoon",
-                "RosePine",
-                "Saga",
-                "Sagelight",
-                "Sakura",
-                "Sandcastle",
-                "SelenizedBlack",
-                "SelenizedDark",
-                "SelenizedLight",
-                "SelenizedWhite",
-                "Seti",
-                "ShadesOfPurple",
-                "ShadesmearDark",
-                "ShadesmearLight",
-                "Shapeshifter",
-                "SilkDark",
-                "SilkLight",
-                "Snazzy",
-                "SolarflareLight",
-                "Solarflare",
-                "SolarizedDark",
-                "SolarizedLight",
-                "Spaceduck",
-                "Spacemacs",
-                "Sparky",
-                "StandardizedDark",
-                "StandardizedLight",
-                "Stella",
-                "StillAlive",
-                "Summercamp",
-                "SummerfruitDark",
-                "SummerfruitLight",
-                "SynthMidnightDark",
-                "SynthMidnightLight",
-                "Tango",
-                "Tarot",
-                "Tender",
-                "TerracottaDark",
-                "Terracotta",
-                "TokyoCityDark",
-                "TokyoCityLight",
-                "TokyoCityTerminalDark",
-                "TokyoCityTerminalLight",
-                "TokyoNightDark",
-                "TokyoNightLight",
-                "TokyoNightMoon",
-                "TokyoNightStorm",
-                "TokyoNightTerminalDark",
-                "TokyoNightTerminalLight",
-                "TokyoNightTerminalStorm",
-                "TokyodarkTerminal",
-                "Tokyodark",
-                "TomorrowNightEighties",
-                "TomorrowNight",
-                "Tomorrow",
-                "Tube",
-                "Twilight",
-                "UnikittyDark",
-                "UnikittyLight",
-                "UnikittyReversible",
-                "Uwunicorn",
-                "Vesper",
-                "Vice",
-                "Vulcan",
-                "Windows10Light",
-                "Windows10",
-                "Windows95Light",
-                "Windows95",
-                "WindowsHighcontrastLight",
-                "WindowsHighcontrast",
-                "WindowsNtLight",
-                "WindowsNt",
-                "Woodland",
-                "XcodeDusk",
-                "Zenbones",
-                "Zenburn"
-              ]
-            },
-            "palette": {
-              "type": "string",
-              "enum": [
-                "Base16"
-              ]
-            }
-          }
-        }
-      ]
-    },
-    "transparency_alpha": {
-      "description": "Alpha value for the color transparency [[0-255]] (default: 200)",
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "widget_spacing": {
-      "description": "Spacing between widgets (default: 10.0)",
-      "type": "number",
-      "format": "float"
-    }
-  }
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "KomobarConfig",
+	"description": "The `komorebi.bar.json` configuration file reference for `v0.1.35`",
+	"type": "object",
+	"required": ["left_widgets", "monitor", "right_widgets"],
+	"properties": {
+		"center_widgets": {
+			"description": "Center widgets (ordered left-to-right)",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{
+						"type": "object",
+						"required": ["Battery"],
+						"properties": {
+							"Battery": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Battery widget",
+										"type": "boolean"
+									},
+									"hide_on_full_charge": {
+										"description": "Hide the widget if the battery is at full charge",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Cpu"],
+						"properties": {
+							"Cpu": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Cpu widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Date"],
+						"properties": {
+							"Date": {
+								"type": "object",
+								"required": ["enable", "format"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Date widget",
+										"type": "boolean"
+									},
+									"format": {
+										"description": "Set the Date format",
+										"oneOf": [
+											{
+												"description": "Month/Date/Year format (09/08/24)",
+												"type": "string",
+												"enum": ["MonthDateYear"]
+											},
+											{
+												"description": "Year-Month-Date format (2024-09-08)",
+												"type": "string",
+												"enum": ["YearMonthDate"]
+											},
+											{
+												"description": "Date-Month-Year format (8-Sep-2024)",
+												"type": "string",
+												"enum": ["DateMonthYear"]
+											},
+											{
+												"description": "Day Date Month Year format (8 September 2024)",
+												"type": "string",
+												"enum": ["DayDateMonthYear"]
+											},
+											{
+												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+												"type": "object",
+												"required": ["Custom"],
+												"properties": {
+													"Custom": {
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
+											},
+											{
+												"description": "Custom format with modifiers",
+												"type": "object",
+												"required": ["CustomModifiers"],
+												"properties": {
+													"CustomModifiers": {
+														"description": "Custom format with additive modifiers for integer format specifiers",
+														"type": "object",
+														"required": ["format", "modifiers"],
+														"properties": {
+															"format": {
+																"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+																"type": "string"
+															},
+															"modifiers": {
+																"description": "Additive modifiers for integer format specifiers (e.g. { \"%U\": 1 } to increment the zero-indexed week number by 1)",
+																"type": "object",
+																"additionalProperties": {
+																	"type": "integer",
+																	"format": "int32"
+																}
+															}
+														}
+													}
+												},
+												"additionalProperties": false
+											}
+										]
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"timezone": {
+										"description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+										"type": "string"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Keyboard"],
+						"properties": {
+							"Keyboard": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 1 second)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Input widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Komorebi"],
+						"properties": {
+							"Komorebi": {
+								"type": "object",
+								"properties": {
+									"configuration_switcher": {
+										"description": "Configure the Configuration Switcher widget",
+										"type": "object",
+										"required": ["configurations", "enable"],
+										"properties": {
+											"configurations": {
+												"description": "A map of display friendly name => path to configuration.json",
+												"type": "object",
+												"additionalProperties": {
+													"type": "string"
+												}
+											},
+											"enable": {
+												"description": "Enable the Komorebi Configurations widget",
+												"type": "boolean"
+											}
+										}
+									},
+									"focused_window": {
+										"description": "Configure the Focused Window widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the currently focused window",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Focused Window widget",
+												"type": "boolean"
+											},
+											"show_icon": {
+												"description": "DEPRECATED: use 'display' instead (Show the icon of the currently focused window)",
+												"type": "boolean"
+											}
+										}
+									},
+									"layout": {
+										"description": "Configure the Layout widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the current layout",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Layout widget",
+												"type": "boolean"
+											},
+											"options": {
+												"description": "List of layout options",
+												"type": "array",
+												"items": {
+													"anyOf": [
+														{
+															"type": "string",
+															"enum": [
+																"BSP",
+																"Columns",
+																"Rows",
+																"VerticalStack",
+																"HorizontalStack",
+																"UltrawideVerticalStack",
+																"Grid",
+																"RightMainVerticalStack"
+															]
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														}
+													]
+												}
+											}
+										}
+									},
+									"workspace_layer": {
+										"description": "Configure the Workspace Layer widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the current layer",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Workspace Layer widget",
+												"type": "boolean"
+											},
+											"show_when_tiling": {
+												"description": "Show the widget event if the layer is Tiling",
+												"type": "boolean"
+											}
+										}
+									},
+									"workspaces": {
+										"description": "Configure the Workspaces widget",
+										"type": "object",
+										"required": ["enable", "hide_empty_workspaces"],
+										"properties": {
+											"display": {
+												"description": "Display format of the workspace",
+												"oneOf": [
+													{
+														"description": "Show all icons only",
+														"type": "string",
+														"enum": ["AllIcons"]
+													},
+													{
+														"description": "Show both all icons and text",
+														"type": "string",
+														"enum": ["AllIconsAndText"]
+													},
+													{
+														"description": "Show all icons and text for the selected element, and all icons on the rest",
+														"type": "string",
+														"enum": ["AllIconsAndTextOnSelected"]
+													},
+													{
+														"type": "object",
+														"required": ["Existing"],
+														"properties": {
+															"Existing": {
+																"oneOf": [
+																	{
+																		"description": "Show only icon",
+																		"type": "string",
+																		"enum": ["Icon"]
+																	},
+																	{
+																		"description": "Show only text",
+																		"type": "string",
+																		"enum": ["Text"]
+																	},
+																	{
+																		"description": "Show an icon and text for the selected element, and text on the rest",
+																		"type": "string",
+																		"enum": ["TextAndIconOnSelected"]
+																	},
+																	{
+																		"description": "Show both icon and text",
+																		"type": "string",
+																		"enum": ["IconAndText"]
+																	},
+																	{
+																		"description": "Show an icon and text for the selected element, and icons on the rest",
+																		"type": "string",
+																		"enum": ["IconAndTextOnSelected"]
+																	}
+																]
+															}
+														},
+														"additionalProperties": false
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Workspaces widget",
+												"type": "boolean"
+											},
+											"hide_empty_workspaces": {
+												"description": "Hide workspaces without any windows",
+												"type": "boolean"
+											}
+										}
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Media"],
+						"properties": {
+							"Media": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Media widget",
+										"type": "boolean"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Memory"],
+						"properties": {
+							"Memory": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Memory widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["StartMenu"],
+						"properties": {
+							"StartMenu": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Network widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Network"],
+						"properties": {
+							"Network": {
+								"type": "object",
+								"required": [
+									"enable",
+									"show_network_activity",
+									"show_total_data_transmitted"
+								],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Network widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"network_activity_fill_characters": {
+										"description": "Characters to reserve for network activity data",
+										"type": "integer",
+										"format": "uint",
+										"minimum": 0.0
+									},
+									"show_default_interface": {
+										"description": "Show default interface",
+										"type": "boolean"
+									},
+									"show_network_activity": {
+										"description": "Show network activity",
+										"type": "boolean"
+									},
+									"show_total_data_transmitted": {
+										"description": "Show total data transmitted",
+										"type": "boolean"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Storage"],
+						"properties": {
+							"Storage": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Storage widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Time"],
+						"properties": {
+							"Time": {
+								"type": "object",
+								"required": ["enable", "format"],
+								"properties": {
+									"changing_icon": {
+										"description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
+										"type": "boolean"
+									},
+									"enable": {
+										"description": "Enable the Time widget",
+										"type": "boolean"
+									},
+									"format": {
+										"description": "Set the Time format",
+										"oneOf": [
+											{
+												"description": "Twelve-hour format (with seconds)",
+												"type": "string",
+												"enum": ["TwelveHour"]
+											},
+											{
+												"description": "Twelve-hour format (without seconds)",
+												"type": "string",
+												"enum": ["TwelveHourWithoutSeconds"]
+											},
+											{
+												"description": "Twenty-four-hour format (with seconds)",
+												"type": "string",
+												"enum": ["TwentyFourHour"]
+											},
+											{
+												"description": "Twenty-four-hour format (without seconds)",
+												"type": "string",
+												"enum": ["TwentyFourHourWithoutSeconds"]
+											},
+											{
+												"description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
+												"type": "string",
+												"enum": ["BinaryCircle"]
+											},
+											{
+												"description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
+												"type": "string",
+												"enum": ["BinaryRectangle"]
+											},
+											{
+												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+												"type": "object",
+												"required": ["Custom"],
+												"properties": {
+													"Custom": {
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
+											}
+										]
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"timezone": {
+										"description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+										"type": "string"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Update"],
+						"properties": {
+							"Update": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 12 hours)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Update widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					}
+				]
+			}
+		},
+		"font_family": {
+			"description": "Font family",
+			"type": "string"
+		},
+		"font_size": {
+			"description": "Font size (default: 12.5)",
+			"type": "number",
+			"format": "float"
+		},
+		"frame": {
+			"description": "Frame options (see: https://docs.rs/egui/latest/egui/containers/frame/struct.Frame.html)",
+			"type": "object",
+			"required": ["inner_margin"],
+			"properties": {
+				"inner_margin": {
+					"description": "Margin inside the painted frame",
+					"type": "object",
+					"required": ["x", "y"],
+					"properties": {
+						"x": {
+							"description": "X coordinate",
+							"type": "number",
+							"format": "float"
+						},
+						"y": {
+							"description": "Y coordinate",
+							"type": "number",
+							"format": "float"
+						}
+					}
+				}
+			}
+		},
+		"grouping": {
+			"description": "Visual grouping for widgets",
+			"oneOf": [
+				{
+					"description": "No grouping is applied",
+					"type": "object",
+					"required": ["kind"],
+					"properties": {
+						"kind": {
+							"type": "string",
+							"enum": ["None"]
+						}
+					}
+				},
+				{
+					"description": "Widgets are grouped as a whole",
+					"type": "object",
+					"required": ["kind"],
+					"properties": {
+						"kind": {
+							"type": "string",
+							"enum": ["Bar"]
+						},
+						"rounding": {
+							"description": "Rounding values for the 4 corners. Can be a single or 4 values.",
+							"anyOf": [
+								{
+									"description": "All 4 corners are the same",
+									"type": "number",
+									"format": "float"
+								},
+								{
+									"description": "All 4 corners are custom. Order: NW, NE, SW, SE",
+									"type": "array",
+									"items": {
+										"type": "number",
+										"format": "float"
+									},
+									"maxItems": 4,
+									"minItems": 4
+								}
+							]
+						},
+						"style": {
+							"description": "Styles for the grouping",
+							"oneOf": [
+								{
+									"type": "string",
+									"enum": ["Default"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB4O1S3"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB4O0S3"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB0O1S3"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB3O1S2"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB3O0S2"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB0O1S2"]
+								}
+							]
+						},
+						"transparency_alpha": {
+							"description": "Alpha value for the color transparency [[0-255]] (default: 200)",
+							"type": "integer",
+							"format": "uint8",
+							"minimum": 0.0
+						}
+					}
+				},
+				{
+					"description": "Widgets are grouped by alignment",
+					"type": "object",
+					"required": ["kind"],
+					"properties": {
+						"kind": {
+							"type": "string",
+							"enum": ["Alignment"]
+						},
+						"rounding": {
+							"description": "Rounding values for the 4 corners. Can be a single or 4 values.",
+							"anyOf": [
+								{
+									"description": "All 4 corners are the same",
+									"type": "number",
+									"format": "float"
+								},
+								{
+									"description": "All 4 corners are custom. Order: NW, NE, SW, SE",
+									"type": "array",
+									"items": {
+										"type": "number",
+										"format": "float"
+									},
+									"maxItems": 4,
+									"minItems": 4
+								}
+							]
+						},
+						"style": {
+							"description": "Styles for the grouping",
+							"oneOf": [
+								{
+									"type": "string",
+									"enum": ["Default"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB4O1S3"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB4O0S3"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB0O1S3"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB3O1S2"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB3O0S2"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB0O1S2"]
+								}
+							]
+						},
+						"transparency_alpha": {
+							"description": "Alpha value for the color transparency [[0-255]] (default: 200)",
+							"type": "integer",
+							"format": "uint8",
+							"minimum": 0.0
+						}
+					}
+				},
+				{
+					"description": "Widgets are grouped individually",
+					"type": "object",
+					"required": ["kind"],
+					"properties": {
+						"kind": {
+							"type": "string",
+							"enum": ["Widget"]
+						},
+						"rounding": {
+							"description": "Rounding values for the 4 corners. Can be a single or 4 values.",
+							"anyOf": [
+								{
+									"description": "All 4 corners are the same",
+									"type": "number",
+									"format": "float"
+								},
+								{
+									"description": "All 4 corners are custom. Order: NW, NE, SW, SE",
+									"type": "array",
+									"items": {
+										"type": "number",
+										"format": "float"
+									},
+									"maxItems": 4,
+									"minItems": 4
+								}
+							]
+						},
+						"style": {
+							"description": "Styles for the grouping",
+							"oneOf": [
+								{
+									"type": "string",
+									"enum": ["Default"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 4, offset: x-1 y-1, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB4O1S3"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 4, offset: x-0 y-0, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB4O0S3"]
+								},
+								{
+									"description": "A shadow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 3)",
+									"type": "string",
+									"enum": ["DefaultWithShadowB0O1S3"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 3, offset: x-1 y-1, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB3O1S2"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 3, offset: x-0 y-0, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB3O0S2"]
+								},
+								{
+									"description": "A glow is added under the default group. (blur: 0, offset: x-1 y-1, spread: 2)",
+									"type": "string",
+									"enum": ["DefaultWithGlowB0O1S2"]
+								}
+							]
+						},
+						"transparency_alpha": {
+							"description": "Alpha value for the color transparency [[0-255]] (default: 200)",
+							"type": "integer",
+							"format": "uint8",
+							"minimum": 0.0
+						}
+					}
+				}
+			]
+		},
+		"height": {
+			"description": "Bar height (default: 50)",
+			"type": "number",
+			"format": "float"
+		},
+		"icon_scale": {
+			"description": "Scale of the icons relative to the font_size [[1.0-2.0]]. (default: 1.4)",
+			"type": "number",
+			"format": "float"
+		},
+		"left_widgets": {
+			"description": "Left side widgets (ordered left-to-right)",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{
+						"type": "object",
+						"required": ["Battery"],
+						"properties": {
+							"Battery": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Battery widget",
+										"type": "boolean"
+									},
+									"hide_on_full_charge": {
+										"description": "Hide the widget if the battery is at full charge",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Cpu"],
+						"properties": {
+							"Cpu": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Cpu widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Date"],
+						"properties": {
+							"Date": {
+								"type": "object",
+								"required": ["enable", "format"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Date widget",
+										"type": "boolean"
+									},
+									"format": {
+										"description": "Set the Date format",
+										"oneOf": [
+											{
+												"description": "Month/Date/Year format (09/08/24)",
+												"type": "string",
+												"enum": ["MonthDateYear"]
+											},
+											{
+												"description": "Year-Month-Date format (2024-09-08)",
+												"type": "string",
+												"enum": ["YearMonthDate"]
+											},
+											{
+												"description": "Date-Month-Year format (8-Sep-2024)",
+												"type": "string",
+												"enum": ["DateMonthYear"]
+											},
+											{
+												"description": "Day Date Month Year format (8 September 2024)",
+												"type": "string",
+												"enum": ["DayDateMonthYear"]
+											},
+											{
+												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+												"type": "object",
+												"required": ["Custom"],
+												"properties": {
+													"Custom": {
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
+											},
+											{
+												"description": "Custom format with modifiers",
+												"type": "object",
+												"required": ["CustomModifiers"],
+												"properties": {
+													"CustomModifiers": {
+														"description": "Custom format with additive modifiers for integer format specifiers",
+														"type": "object",
+														"required": ["format", "modifiers"],
+														"properties": {
+															"format": {
+																"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+																"type": "string"
+															},
+															"modifiers": {
+																"description": "Additive modifiers for integer format specifiers (e.g. { \"%U\": 1 } to increment the zero-indexed week number by 1)",
+																"type": "object",
+																"additionalProperties": {
+																	"type": "integer",
+																	"format": "int32"
+																}
+															}
+														}
+													}
+												},
+												"additionalProperties": false
+											}
+										]
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"timezone": {
+										"description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+										"type": "string"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Keyboard"],
+						"properties": {
+							"Keyboard": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 1 second)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Input widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Komorebi"],
+						"properties": {
+							"Komorebi": {
+								"type": "object",
+								"properties": {
+									"configuration_switcher": {
+										"description": "Configure the Configuration Switcher widget",
+										"type": "object",
+										"required": ["configurations", "enable"],
+										"properties": {
+											"configurations": {
+												"description": "A map of display friendly name => path to configuration.json",
+												"type": "object",
+												"additionalProperties": {
+													"type": "string"
+												}
+											},
+											"enable": {
+												"description": "Enable the Komorebi Configurations widget",
+												"type": "boolean"
+											}
+										}
+									},
+									"focused_window": {
+										"description": "Configure the Focused Window widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the currently focused window",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Focused Window widget",
+												"type": "boolean"
+											},
+											"show_icon": {
+												"description": "DEPRECATED: use 'display' instead (Show the icon of the currently focused window)",
+												"type": "boolean"
+											}
+										}
+									},
+									"layout": {
+										"description": "Configure the Layout widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the current layout",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Layout widget",
+												"type": "boolean"
+											},
+											"options": {
+												"description": "List of layout options",
+												"type": "array",
+												"items": {
+													"anyOf": [
+														{
+															"type": "string",
+															"enum": [
+																"BSP",
+																"Columns",
+																"Rows",
+																"VerticalStack",
+																"HorizontalStack",
+																"UltrawideVerticalStack",
+																"Grid",
+																"RightMainVerticalStack"
+															]
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														}
+													]
+												}
+											}
+										}
+									},
+									"workspace_layer": {
+										"description": "Configure the Workspace Layer widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the current layer",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Workspace Layer widget",
+												"type": "boolean"
+											},
+											"show_when_tiling": {
+												"description": "Show the widget event if the layer is Tiling",
+												"type": "boolean"
+											}
+										}
+									},
+									"workspaces": {
+										"description": "Configure the Workspaces widget",
+										"type": "object",
+										"required": ["enable", "hide_empty_workspaces"],
+										"properties": {
+											"display": {
+												"description": "Display format of the workspace",
+												"oneOf": [
+													{
+														"description": "Show all icons only",
+														"type": "string",
+														"enum": ["AllIcons"]
+													},
+													{
+														"description": "Show both all icons and text",
+														"type": "string",
+														"enum": ["AllIconsAndText"]
+													},
+													{
+														"description": "Show all icons and text for the selected element, and all icons on the rest",
+														"type": "string",
+														"enum": ["AllIconsAndTextOnSelected"]
+													},
+													{
+														"type": "object",
+														"required": ["Existing"],
+														"properties": {
+															"Existing": {
+																"oneOf": [
+																	{
+																		"description": "Show only icon",
+																		"type": "string",
+																		"enum": ["Icon"]
+																	},
+																	{
+																		"description": "Show only text",
+																		"type": "string",
+																		"enum": ["Text"]
+																	},
+																	{
+																		"description": "Show an icon and text for the selected element, and text on the rest",
+																		"type": "string",
+																		"enum": ["TextAndIconOnSelected"]
+																	},
+																	{
+																		"description": "Show both icon and text",
+																		"type": "string",
+																		"enum": ["IconAndText"]
+																	},
+																	{
+																		"description": "Show an icon and text for the selected element, and icons on the rest",
+																		"type": "string",
+																		"enum": ["IconAndTextOnSelected"]
+																	}
+																]
+															}
+														},
+														"additionalProperties": false
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Workspaces widget",
+												"type": "boolean"
+											},
+											"hide_empty_workspaces": {
+												"description": "Hide workspaces without any windows",
+												"type": "boolean"
+											}
+										}
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Media"],
+						"properties": {
+							"Media": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Media widget",
+										"type": "boolean"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Memory"],
+						"properties": {
+							"Memory": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Memory widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Network"],
+						"properties": {
+							"Network": {
+								"type": "object",
+								"required": [
+									"enable",
+									"show_network_activity",
+									"show_total_data_transmitted"
+								],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Network widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"network_activity_fill_characters": {
+										"description": "Characters to reserve for network activity data",
+										"type": "integer",
+										"format": "uint",
+										"minimum": 0.0
+									},
+									"show_default_interface": {
+										"description": "Show default interface",
+										"type": "boolean"
+									},
+									"show_network_activity": {
+										"description": "Show network activity",
+										"type": "boolean"
+									},
+									"show_total_data_transmitted": {
+										"description": "Show total data transmitted",
+										"type": "boolean"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["StartMenu"],
+						"properties": {
+							"StartMenu": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Network widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Storage"],
+						"properties": {
+							"Storage": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Storage widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Time"],
+						"properties": {
+							"Time": {
+								"type": "object",
+								"required": ["enable", "format"],
+								"properties": {
+									"changing_icon": {
+										"description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
+										"type": "boolean"
+									},
+									"enable": {
+										"description": "Enable the Time widget",
+										"type": "boolean"
+									},
+									"format": {
+										"description": "Set the Time format",
+										"oneOf": [
+											{
+												"description": "Twelve-hour format (with seconds)",
+												"type": "string",
+												"enum": ["TwelveHour"]
+											},
+											{
+												"description": "Twelve-hour format (without seconds)",
+												"type": "string",
+												"enum": ["TwelveHourWithoutSeconds"]
+											},
+											{
+												"description": "Twenty-four-hour format (with seconds)",
+												"type": "string",
+												"enum": ["TwentyFourHour"]
+											},
+											{
+												"description": "Twenty-four-hour format (without seconds)",
+												"type": "string",
+												"enum": ["TwentyFourHourWithoutSeconds"]
+											},
+											{
+												"description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
+												"type": "string",
+												"enum": ["BinaryCircle"]
+											},
+											{
+												"description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
+												"type": "string",
+												"enum": ["BinaryRectangle"]
+											},
+											{
+												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+												"type": "object",
+												"required": ["Custom"],
+												"properties": {
+													"Custom": {
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
+											}
+										]
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"timezone": {
+										"description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+										"type": "string"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Update"],
+						"properties": {
+							"Update": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 12 hours)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Update widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					}
+				]
+			}
+		},
+		"margin": {
+			"description": "Bar margin. Use one value for all sides or use a grouped margin for horizontal and/or vertical definition which can each take a single value for a symmetric margin or two values for each side, i.e.: ```json \"margin\": { \"horizontal\": 10 } ``` or: ```json \"margin\": { \"vertical\": [top, bottom] } ``` You can also set individual margin on each side like this: ```json \"margin\": { \"top\": 10, \"bottom\": 10, \"left\": 10, \"right\": 10, } ``` By default, margin is set to 0 on all sides.",
+			"anyOf": [
+				{
+					"type": "number",
+					"format": "float"
+				},
+				{
+					"type": "object",
+					"required": ["bottom", "left", "right", "top"],
+					"properties": {
+						"bottom": {
+							"type": "number",
+							"format": "float"
+						},
+						"left": {
+							"type": "number",
+							"format": "float"
+						},
+						"right": {
+							"type": "number",
+							"format": "float"
+						},
+						"top": {
+							"type": "number",
+							"format": "float"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"properties": {
+						"horizontal": {
+							"anyOf": [
+								{
+									"type": "number",
+									"format": "float"
+								},
+								{
+									"type": "array",
+									"items": [
+										{
+											"type": "number",
+											"format": "float"
+										},
+										{
+											"type": "number",
+											"format": "float"
+										}
+									],
+									"maxItems": 2,
+									"minItems": 2
+								}
+							]
+						},
+						"vertical": {
+							"anyOf": [
+								{
+									"type": "number",
+									"format": "float"
+								},
+								{
+									"type": "array",
+									"items": [
+										{
+											"type": "number",
+											"format": "float"
+										},
+										{
+											"type": "number",
+											"format": "float"
+										}
+									],
+									"maxItems": 2,
+									"minItems": 2
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		"max_label_width": {
+			"description": "Max label width before text truncation (default: 400.0)",
+			"type": "number",
+			"format": "float"
+		},
+		"monitor": {
+			"description": "The monitor index or the full monitor options",
+			"anyOf": [
+				{
+					"description": "The monitor index where you want the bar to show",
+					"type": "integer",
+					"format": "uint",
+					"minimum": 0.0
+				},
+				{
+					"description": "The full monitor options with the index and an optional work_area_offset",
+					"type": "object",
+					"required": ["index"],
+					"properties": {
+						"index": {
+							"description": "Komorebi monitor index of the monitor on which to render the bar",
+							"type": "integer",
+							"format": "uint",
+							"minimum": 0.0
+						},
+						"work_area_offset": {
+							"description": "Automatically apply a work area offset for this monitor to accommodate the bar",
+							"type": "object",
+							"required": ["bottom", "left", "right", "top"],
+							"properties": {
+								"bottom": {
+									"description": "The bottom point in a Win32 Rect",
+									"type": "integer",
+									"format": "int32"
+								},
+								"left": {
+									"description": "The left point in a Win32 Rect",
+									"type": "integer",
+									"format": "int32"
+								},
+								"right": {
+									"description": "The right point in a Win32 Rect",
+									"type": "integer",
+									"format": "int32"
+								},
+								"top": {
+									"description": "The top point in a Win32 Rect",
+									"type": "integer",
+									"format": "int32"
+								}
+							}
+						}
+					}
+				}
+			]
+		},
+		"padding": {
+			"description": "Bar padding. Use one value for all sides or use a grouped padding for horizontal and/or vertical definition which can each take a single value for a symmetric padding or two values for each side, i.e.: ```json \"padding\": { \"horizontal\": 10 } ``` or: ```json \"padding\": { \"horizontal\": [left, right] } ``` You can also set individual padding on each side like this: ```json \"padding\": { \"top\": 10, \"bottom\": 10, \"left\": 10, \"right\": 10, } ``` By default, padding is set to 10 on all sides.",
+			"anyOf": [
+				{
+					"type": "number",
+					"format": "float"
+				},
+				{
+					"type": "object",
+					"required": ["bottom", "left", "right", "top"],
+					"properties": {
+						"bottom": {
+							"type": "number",
+							"format": "float"
+						},
+						"left": {
+							"type": "number",
+							"format": "float"
+						},
+						"right": {
+							"type": "number",
+							"format": "float"
+						},
+						"top": {
+							"type": "number",
+							"format": "float"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"properties": {
+						"horizontal": {
+							"anyOf": [
+								{
+									"type": "number",
+									"format": "float"
+								},
+								{
+									"type": "array",
+									"items": [
+										{
+											"type": "number",
+											"format": "float"
+										},
+										{
+											"type": "number",
+											"format": "float"
+										}
+									],
+									"maxItems": 2,
+									"minItems": 2
+								}
+							]
+						},
+						"vertical": {
+							"anyOf": [
+								{
+									"type": "number",
+									"format": "float"
+								},
+								{
+									"type": "array",
+									"items": [
+										{
+											"type": "number",
+											"format": "float"
+										},
+										{
+											"type": "number",
+											"format": "float"
+										}
+									],
+									"maxItems": 2,
+									"minItems": 2
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		"position": {
+			"description": "Bar positioning options",
+			"type": "object",
+			"properties": {
+				"end": {
+					"description": "The desired size of the bar from the starting position (usually monitor width x desired height)",
+					"type": "object",
+					"required": ["x", "y"],
+					"properties": {
+						"x": {
+							"description": "X coordinate",
+							"type": "number",
+							"format": "float"
+						},
+						"y": {
+							"description": "Y coordinate",
+							"type": "number",
+							"format": "float"
+						}
+					}
+				},
+				"start": {
+					"description": "The desired starting position of the bar (0,0 = top left of the screen)",
+					"type": "object",
+					"required": ["x", "y"],
+					"properties": {
+						"x": {
+							"description": "X coordinate",
+							"type": "number",
+							"format": "float"
+						},
+						"y": {
+							"description": "Y coordinate",
+							"type": "number",
+							"format": "float"
+						}
+					}
+				}
+			}
+		},
+		"right_widgets": {
+			"description": "Right side widgets (ordered left-to-right)",
+			"type": "array",
+			"items": {
+				"oneOf": [
+					{
+						"type": "object",
+						"required": ["Battery"],
+						"properties": {
+							"Battery": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Battery widget",
+										"type": "boolean"
+									},
+									"hide_on_full_charge": {
+										"description": "Hide the widget if the battery is at full charge",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Cpu"],
+						"properties": {
+							"Cpu": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Cpu widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Date"],
+						"properties": {
+							"Date": {
+								"type": "object",
+								"required": ["enable", "format"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Date widget",
+										"type": "boolean"
+									},
+									"format": {
+										"description": "Set the Date format",
+										"oneOf": [
+											{
+												"description": "Month/Date/Year format (09/08/24)",
+												"type": "string",
+												"enum": ["MonthDateYear"]
+											},
+											{
+												"description": "Year-Month-Date format (2024-09-08)",
+												"type": "string",
+												"enum": ["YearMonthDate"]
+											},
+											{
+												"description": "Date-Month-Year format (8-Sep-2024)",
+												"type": "string",
+												"enum": ["DateMonthYear"]
+											},
+											{
+												"description": "Day Date Month Year format (8 September 2024)",
+												"type": "string",
+												"enum": ["DayDateMonthYear"]
+											},
+											{
+												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+												"type": "object",
+												"required": ["Custom"],
+												"properties": {
+													"Custom": {
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
+											},
+											{
+												"description": "Custom format with modifiers",
+												"type": "object",
+												"required": ["CustomModifiers"],
+												"properties": {
+													"CustomModifiers": {
+														"description": "Custom format with additive modifiers for integer format specifiers",
+														"type": "object",
+														"required": ["format", "modifiers"],
+														"properties": {
+															"format": {
+																"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+																"type": "string"
+															},
+															"modifiers": {
+																"description": "Additive modifiers for integer format specifiers (e.g. { \"%U\": 1 } to increment the zero-indexed week number by 1)",
+																"type": "object",
+																"additionalProperties": {
+																	"type": "integer",
+																	"format": "int32"
+																}
+															}
+														}
+													}
+												},
+												"additionalProperties": false
+											}
+										]
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"timezone": {
+										"description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Date\": { \"enable\": true, \"format\": { \"Custom\": \"%D %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+										"type": "string"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Keyboard"],
+						"properties": {
+							"Keyboard": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 1 second)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Input widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Komorebi"],
+						"properties": {
+							"Komorebi": {
+								"type": "object",
+								"properties": {
+									"configuration_switcher": {
+										"description": "Configure the Configuration Switcher widget",
+										"type": "object",
+										"required": ["configurations", "enable"],
+										"properties": {
+											"configurations": {
+												"description": "A map of display friendly name => path to configuration.json",
+												"type": "object",
+												"additionalProperties": {
+													"type": "string"
+												}
+											},
+											"enable": {
+												"description": "Enable the Komorebi Configurations widget",
+												"type": "boolean"
+											}
+										}
+									},
+									"focused_window": {
+										"description": "Configure the Focused Window widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the currently focused window",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Focused Window widget",
+												"type": "boolean"
+											},
+											"show_icon": {
+												"description": "DEPRECATED: use 'display' instead (Show the icon of the currently focused window)",
+												"type": "boolean"
+											}
+										}
+									},
+									"layout": {
+										"description": "Configure the Layout widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the current layout",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Layout widget",
+												"type": "boolean"
+											},
+											"options": {
+												"description": "List of layout options",
+												"type": "array",
+												"items": {
+													"anyOf": [
+														{
+															"type": "string",
+															"enum": [
+																"BSP",
+																"Columns",
+																"Rows",
+																"VerticalStack",
+																"HorizontalStack",
+																"UltrawideVerticalStack",
+																"Grid",
+																"RightMainVerticalStack"
+															]
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														},
+														{
+															"type": "null"
+														}
+													]
+												}
+											}
+										}
+									},
+									"workspace_layer": {
+										"description": "Configure the Workspace Layer widget",
+										"type": "object",
+										"required": ["enable"],
+										"properties": {
+											"display": {
+												"description": "Display format of the current layer",
+												"oneOf": [
+													{
+														"description": "Show only icon",
+														"type": "string",
+														"enum": ["Icon"]
+													},
+													{
+														"description": "Show only text",
+														"type": "string",
+														"enum": ["Text"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and text on the rest",
+														"type": "string",
+														"enum": ["TextAndIconOnSelected"]
+													},
+													{
+														"description": "Show both icon and text",
+														"type": "string",
+														"enum": ["IconAndText"]
+													},
+													{
+														"description": "Show an icon and text for the selected element, and icons on the rest",
+														"type": "string",
+														"enum": ["IconAndTextOnSelected"]
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Workspace Layer widget",
+												"type": "boolean"
+											},
+											"show_when_tiling": {
+												"description": "Show the widget event if the layer is Tiling",
+												"type": "boolean"
+											}
+										}
+									},
+									"workspaces": {
+										"description": "Configure the Workspaces widget",
+										"type": "object",
+										"required": ["enable", "hide_empty_workspaces"],
+										"properties": {
+											"display": {
+												"description": "Display format of the workspace",
+												"oneOf": [
+													{
+														"description": "Show all icons only",
+														"type": "string",
+														"enum": ["AllIcons"]
+													},
+													{
+														"description": "Show both all icons and text",
+														"type": "string",
+														"enum": ["AllIconsAndText"]
+													},
+													{
+														"description": "Show all icons and text for the selected element, and all icons on the rest",
+														"type": "string",
+														"enum": ["AllIconsAndTextOnSelected"]
+													},
+													{
+														"type": "object",
+														"required": ["Existing"],
+														"properties": {
+															"Existing": {
+																"oneOf": [
+																	{
+																		"description": "Show only icon",
+																		"type": "string",
+																		"enum": ["Icon"]
+																	},
+																	{
+																		"description": "Show only text",
+																		"type": "string",
+																		"enum": ["Text"]
+																	},
+																	{
+																		"description": "Show an icon and text for the selected element, and text on the rest",
+																		"type": "string",
+																		"enum": ["TextAndIconOnSelected"]
+																	},
+																	{
+																		"description": "Show both icon and text",
+																		"type": "string",
+																		"enum": ["IconAndText"]
+																	},
+																	{
+																		"description": "Show an icon and text for the selected element, and icons on the rest",
+																		"type": "string",
+																		"enum": ["IconAndTextOnSelected"]
+																	}
+																]
+															}
+														},
+														"additionalProperties": false
+													}
+												]
+											},
+											"enable": {
+												"description": "Enable the Komorebi Workspaces widget",
+												"type": "boolean"
+											},
+											"hide_empty_workspaces": {
+												"description": "Hide workspaces without any windows",
+												"type": "boolean"
+											}
+										}
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Media"],
+						"properties": {
+							"Media": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Media widget",
+										"type": "boolean"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Memory"],
+						"properties": {
+							"Memory": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Memory widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Network"],
+						"properties": {
+							"Network": {
+								"type": "object",
+								"required": [
+									"enable",
+									"show_network_activity",
+									"show_total_data_transmitted"
+								],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Network widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"network_activity_fill_characters": {
+										"description": "Characters to reserve for network activity data",
+										"type": "integer",
+										"format": "uint",
+										"minimum": 0.0
+									},
+									"show_default_interface": {
+										"description": "Show default interface",
+										"type": "boolean"
+									},
+									"show_network_activity": {
+										"description": "Show network activity",
+										"type": "boolean"
+									},
+									"show_total_data_transmitted": {
+										"description": "Show total data transmitted",
+										"type": "boolean"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["StartMenu"],
+						"properties": {
+							"StartMenu": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"enable": {
+										"description": "Enable the Network widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Storage"],
+						"properties": {
+							"Storage": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 10 seconds)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Storage widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Time"],
+						"properties": {
+							"Time": {
+								"type": "object",
+								"required": ["enable", "format"],
+								"properties": {
+									"changing_icon": {
+										"description": "Change the icon depending on the time. The default icon is used between 8:30 and 12:00. (default: false)",
+										"type": "boolean"
+									},
+									"enable": {
+										"description": "Enable the Time widget",
+										"type": "boolean"
+									},
+									"format": {
+										"description": "Set the Time format",
+										"oneOf": [
+											{
+												"description": "Twelve-hour format (with seconds)",
+												"type": "string",
+												"enum": ["TwelveHour"]
+											},
+											{
+												"description": "Twelve-hour format (without seconds)",
+												"type": "string",
+												"enum": ["TwelveHourWithoutSeconds"]
+											},
+											{
+												"description": "Twenty-four-hour format (with seconds)",
+												"type": "string",
+												"enum": ["TwentyFourHour"]
+											},
+											{
+												"description": "Twenty-four-hour format (without seconds)",
+												"type": "string",
+												"enum": ["TwentyFourHourWithoutSeconds"]
+											},
+											{
+												"description": "Twenty-four-hour format displayed as a binary clock with circles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
+												"type": "string",
+												"enum": ["BinaryCircle"]
+											},
+											{
+												"description": "Twenty-four-hour format displayed as a binary clock with rectangles (with seconds) (https://en.wikipedia.org/wiki/Binary_clock)",
+												"type": "string",
+												"enum": ["BinaryRectangle"]
+											},
+											{
+												"description": "Custom format (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)",
+												"type": "object",
+												"required": ["Custom"],
+												"properties": {
+													"Custom": {
+														"type": "string"
+													}
+												},
+												"additionalProperties": false
+											}
+										]
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									},
+									"timezone": {
+										"description": "TimeZone (https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html)\n\nUse a custom format to display additional information, i.e.: ```json { \"Time\": { \"enable\": true, \"format\": { \"Custom\": \"%T %Z (Tokyo)\" }, \"timezone\": \"Asia/Tokyo\" } } ```",
+										"type": "string"
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					},
+					{
+						"type": "object",
+						"required": ["Update"],
+						"properties": {
+							"Update": {
+								"type": "object",
+								"required": ["enable"],
+								"properties": {
+									"data_refresh_interval": {
+										"description": "Data refresh interval (default: 12 hours)",
+										"type": "integer",
+										"format": "uint64",
+										"minimum": 0.0
+									},
+									"enable": {
+										"description": "Enable the Update widget",
+										"type": "boolean"
+									},
+									"label_prefix": {
+										"description": "Display label prefix",
+										"oneOf": [
+											{
+												"description": "Show no prefix",
+												"type": "string",
+												"enum": ["None"]
+											},
+											{
+												"description": "Show an icon",
+												"type": "string",
+												"enum": ["Icon"]
+											},
+											{
+												"description": "Show text",
+												"type": "string",
+												"enum": ["Text"]
+											},
+											{
+												"description": "Show an icon and text",
+												"type": "string",
+												"enum": ["IconAndText"]
+											}
+										]
+									}
+								}
+							}
+						},
+						"additionalProperties": false
+					}
+				]
+			}
+		},
+		"theme": {
+			"description": "Theme",
+			"oneOf": [
+				{
+					"description": "A theme from catppuccin-egui",
+					"type": "object",
+					"required": ["name", "palette"],
+					"properties": {
+						"accent": {
+							"type": "string",
+							"enum": [
+								"Rosewater",
+								"Flamingo",
+								"Pink",
+								"Mauve",
+								"Red",
+								"Maroon",
+								"Peach",
+								"Yellow",
+								"Green",
+								"Teal",
+								"Sky",
+								"Sapphire",
+								"Blue",
+								"Lavender",
+								"Text",
+								"Subtext1",
+								"Subtext0",
+								"Overlay2",
+								"Overlay1",
+								"Overlay0",
+								"Surface2",
+								"Surface1",
+								"Surface0",
+								"Base",
+								"Mantle",
+								"Crust"
+							]
+						},
+						"name": {
+							"description": "Name of the Catppuccin theme (theme previews: https://github.com/catppuccin/catppuccin)",
+							"type": "string",
+							"enum": ["Frappe", "Latte", "Macchiato", "Mocha"]
+						},
+						"palette": {
+							"type": "string",
+							"enum": ["Catppuccin"]
+						}
+					}
+				},
+				{
+					"description": "A theme from base16-egui-themes",
+					"type": "object",
+					"required": ["name", "palette"],
+					"properties": {
+						"accent": {
+							"type": "string",
+							"enum": [
+								"Base00",
+								"Base01",
+								"Base02",
+								"Base03",
+								"Base04",
+								"Base05",
+								"Base06",
+								"Base07",
+								"Base08",
+								"Base09",
+								"Base0A",
+								"Base0B",
+								"Base0C",
+								"Base0D",
+								"Base0E",
+								"Base0F"
+							]
+						},
+						"name": {
+							"description": "Name of the Base16 theme (theme previews: https://tinted-theming.github.io/tinted-gallery/)",
+							"type": "string",
+							"enum": [
+								"3024",
+								"Apathy",
+								"Apprentice",
+								"Ashes",
+								"AtelierCaveLight",
+								"AtelierCave",
+								"AtelierDuneLight",
+								"AtelierDune",
+								"AtelierEstuaryLight",
+								"AtelierEstuary",
+								"AtelierForestLight",
+								"AtelierForest",
+								"AtelierHeathLight",
+								"AtelierHeath",
+								"AtelierLakesideLight",
+								"AtelierLakeside",
+								"AtelierPlateauLight",
+								"AtelierPlateau",
+								"AtelierSavannaLight",
+								"AtelierSavanna",
+								"AtelierSeasideLight",
+								"AtelierSeaside",
+								"AtelierSulphurpoolLight",
+								"AtelierSulphurpool",
+								"Atlas",
+								"AyuDark",
+								"AyuLight",
+								"AyuMirage",
+								"Aztec",
+								"Bespin",
+								"BlackMetalBathory",
+								"BlackMetalBurzum",
+								"BlackMetalDarkFuneral",
+								"BlackMetalGorgoroth",
+								"BlackMetalImmortal",
+								"BlackMetalKhold",
+								"BlackMetalMarduk",
+								"BlackMetalMayhem",
+								"BlackMetalNile",
+								"BlackMetalVenom",
+								"BlackMetal",
+								"Blueforest",
+								"Blueish",
+								"Brewer",
+								"Bright",
+								"Brogrammer",
+								"BrushtreesDark",
+								"Brushtrees",
+								"Caroline",
+								"CatppuccinFrappe",
+								"CatppuccinLatte",
+								"CatppuccinMacchiato",
+								"CatppuccinMocha",
+								"Chalk",
+								"Circus",
+								"ClassicDark",
+								"ClassicLight",
+								"Codeschool",
+								"Colors",
+								"Cupcake",
+								"Cupertino",
+								"DaOneBlack",
+								"DaOneGray",
+								"DaOneOcean",
+								"DaOnePaper",
+								"DaOneSea",
+								"DaOneWhite",
+								"DanqingLight",
+								"Danqing",
+								"Darcula",
+								"Darkmoss",
+								"Darktooth",
+								"Darkviolet",
+								"Decaf",
+								"DefaultDark",
+								"DefaultLight",
+								"Dirtysea",
+								"Dracula",
+								"EdgeDark",
+								"EdgeLight",
+								"Eighties",
+								"EmbersLight",
+								"Embers",
+								"Emil",
+								"EquilibriumDark",
+								"EquilibriumGrayDark",
+								"EquilibriumGrayLight",
+								"EquilibriumLight",
+								"Eris",
+								"Espresso",
+								"EvaDim",
+								"Eva",
+								"EvenokDark",
+								"EverforestDarkHard",
+								"Everforest",
+								"Flat",
+								"Framer",
+								"FruitSoda",
+								"Gigavolt",
+								"Github",
+								"GoogleDark",
+								"GoogleLight",
+								"Gotham",
+								"GrayscaleDark",
+								"GrayscaleLight",
+								"Greenscreen",
+								"Gruber",
+								"GruvboxDarkHard",
+								"GruvboxDarkMedium",
+								"GruvboxDarkPale",
+								"GruvboxDarkSoft",
+								"GruvboxLightHard",
+								"GruvboxLightMedium",
+								"GruvboxLightSoft",
+								"GruvboxMaterialDarkHard",
+								"GruvboxMaterialDarkMedium",
+								"GruvboxMaterialDarkSoft",
+								"GruvboxMaterialLightHard",
+								"GruvboxMaterialLightMedium",
+								"GruvboxMaterialLightSoft",
+								"Hardcore",
+								"Harmonic16Dark",
+								"Harmonic16Light",
+								"HeetchLight",
+								"Heetch",
+								"Helios",
+								"Hopscotch",
+								"HorizonDark",
+								"HorizonLight",
+								"HorizonTerminalDark",
+								"HorizonTerminalLight",
+								"HumanoidDark",
+								"HumanoidLight",
+								"IaDark",
+								"IaLight",
+								"Icy",
+								"Irblack",
+								"Isotope",
+								"Jabuti",
+								"Kanagawa",
+								"Katy",
+								"Kimber",
+								"Lime",
+								"Macintosh",
+								"Marrakesh",
+								"Materia",
+								"MaterialDarker",
+								"MaterialLighter",
+								"MaterialPalenight",
+								"MaterialVivid",
+								"Material",
+								"MeasuredDark",
+								"MeasuredLight",
+								"MellowPurple",
+								"MexicoLight",
+								"Mocha",
+								"Monokai",
+								"Moonlight",
+								"Mountain",
+								"Nebula",
+								"NordLight",
+								"Nord",
+								"Nova",
+								"Ocean",
+								"Oceanicnext",
+								"OneLight",
+								"OnedarkDark",
+								"Onedark",
+								"OutrunDark",
+								"OxocarbonDark",
+								"OxocarbonLight",
+								"Pandora",
+								"PapercolorDark",
+								"PapercolorLight",
+								"Paraiso",
+								"Pasque",
+								"Phd",
+								"Pico",
+								"Pinky",
+								"Pop",
+								"Porple",
+								"PreciousDarkEleven",
+								"PreciousDarkFifteen",
+								"PreciousLightWarm",
+								"PreciousLightWhite",
+								"PrimerDarkDimmed",
+								"PrimerDark",
+								"PrimerLight",
+								"Purpledream",
+								"Qualia",
+								"Railscasts",
+								"Rebecca",
+								"RosePineDawn",
+								"RosePineMoon",
+								"RosePine",
+								"Saga",
+								"Sagelight",
+								"Sakura",
+								"Sandcastle",
+								"SelenizedBlack",
+								"SelenizedDark",
+								"SelenizedLight",
+								"SelenizedWhite",
+								"Seti",
+								"ShadesOfPurple",
+								"ShadesmearDark",
+								"ShadesmearLight",
+								"Shapeshifter",
+								"SilkDark",
+								"SilkLight",
+								"Snazzy",
+								"SolarflareLight",
+								"Solarflare",
+								"SolarizedDark",
+								"SolarizedLight",
+								"Spaceduck",
+								"Spacemacs",
+								"Sparky",
+								"StandardizedDark",
+								"StandardizedLight",
+								"Stella",
+								"StillAlive",
+								"Summercamp",
+								"SummerfruitDark",
+								"SummerfruitLight",
+								"SynthMidnightDark",
+								"SynthMidnightLight",
+								"Tango",
+								"Tarot",
+								"Tender",
+								"TerracottaDark",
+								"Terracotta",
+								"TokyoCityDark",
+								"TokyoCityLight",
+								"TokyoCityTerminalDark",
+								"TokyoCityTerminalLight",
+								"TokyoNightDark",
+								"TokyoNightLight",
+								"TokyoNightMoon",
+								"TokyoNightStorm",
+								"TokyoNightTerminalDark",
+								"TokyoNightTerminalLight",
+								"TokyoNightTerminalStorm",
+								"TokyodarkTerminal",
+								"Tokyodark",
+								"TomorrowNightEighties",
+								"TomorrowNight",
+								"Tomorrow",
+								"Tube",
+								"Twilight",
+								"UnikittyDark",
+								"UnikittyLight",
+								"UnikittyReversible",
+								"Uwunicorn",
+								"Vesper",
+								"Vice",
+								"Vulcan",
+								"Windows10Light",
+								"Windows10",
+								"Windows95Light",
+								"Windows95",
+								"WindowsHighcontrastLight",
+								"WindowsHighcontrast",
+								"WindowsNtLight",
+								"WindowsNt",
+								"Woodland",
+								"XcodeDusk",
+								"Zenbones",
+								"Zenburn"
+							]
+						},
+						"palette": {
+							"type": "string",
+							"enum": ["Base16"]
+						}
+					}
+				}
+			]
+		},
+		"transparency_alpha": {
+			"description": "Alpha value for the color transparency [[0-255]] (default: 200)",
+			"type": "integer",
+			"format": "uint8",
+			"minimum": 0.0
+		},
+		"widget_spacing": {
+			"description": "Spacing between widgets (default: 10.0)",
+			"type": "number",
+			"format": "float"
+		}
+	}
 }


### PR DESCRIPTION
This commit adds new `StartMenu`  widget to Komorebi-bar allowing user to invoke Windows start menu by clicking on a dedicated button on the Komorebi-bar.

![image](https://github.com/user-attachments/assets/fabcd2cb-99eb-449e-a623-4d8f4edcd6e7)
