### PR TITLE
fix: disabled borders remove width + offset

### DIFF
--- a/docs/common-workflows/remove-gaps.md
+++ b/docs/common-workflows/remove-gaps.md
@@ -8,12 +8,8 @@ configuration file.
 ```json
 {
   "default_workspace_padding": 0,
-  "default_container_padding": 0,
-  "border_width": 0,
-  "border_offset": -1
+  "default_container_padding": -1,
 }
 ```
-
-A restart of `komorebi` is required after changing these settings.
 
 [![Watch the tutorial video](https://img.youtube.com/vi/6QYLao953XE/hqdefault.jpg)](https://www.youtube.com/watch?v=6QYLao953XE)

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -12,11 +12,15 @@ use getset::Setters;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::border_manager::BORDER_ENABLED;
+use crate::border_manager::BORDER_OFFSET;
+use crate::border_manager::BORDER_WIDTH;
 use crate::core::Rect;
 
 use crate::container::Container;
 use crate::ring::Ring;
 use crate::workspace::Workspace;
+use crate::workspace::WorkspaceGlobals;
 use crate::workspace::WorkspaceLayer;
 use crate::DefaultLayout;
 use crate::Layout;
@@ -203,18 +207,32 @@ impl Monitor {
         let workspace_padding = self
             .workspace_padding()
             .or(Some(DEFAULT_WORKSPACE_PADDING.load(Ordering::SeqCst)));
+        let (border_width, border_offset) = {
+            let border_enabled = BORDER_ENABLED.load(Ordering::SeqCst);
+            if border_enabled {
+                let border_width = BORDER_WIDTH.load(Ordering::SeqCst);
+                let border_offset = BORDER_OFFSET.load(Ordering::SeqCst);
+                (border_width, border_offset)
+            } else {
+                (0, 0)
+            }
+        };
         let work_area = *self.work_area_size();
-        let offset = self.work_area_offset.or(offset);
+        let work_area_offset = self.work_area_offset.or(offset);
         let window_based_work_area_offset = self.window_based_work_area_offset();
-        let limit = self.window_based_work_area_offset_limit();
+        let window_based_work_area_offset_limit = self.window_based_work_area_offset_limit();
 
         for workspace in self.workspaces_mut() {
-            workspace.globals_mut().container_padding = container_padding;
-            workspace.globals_mut().workspace_padding = workspace_padding;
-            workspace.globals_mut().work_area = work_area;
-            workspace.globals_mut().work_area_offset = offset;
-            workspace.globals_mut().window_based_work_area_offset = window_based_work_area_offset;
-            workspace.globals_mut().window_based_work_area_offset_limit = limit;
+            workspace.globals = WorkspaceGlobals {
+                container_padding,
+                workspace_padding,
+                border_width,
+                border_offset,
+                work_area,
+                work_area_offset,
+                window_based_work_area_offset,
+                window_based_work_area_offset_limit,
+            }
         }
     }
 
@@ -226,18 +244,32 @@ impl Monitor {
         let workspace_padding = self
             .workspace_padding()
             .or(Some(DEFAULT_WORKSPACE_PADDING.load(Ordering::SeqCst)));
+        let (border_width, border_offset) = {
+            let border_enabled = BORDER_ENABLED.load(Ordering::SeqCst);
+            if border_enabled {
+                let border_width = BORDER_WIDTH.load(Ordering::SeqCst);
+                let border_offset = BORDER_OFFSET.load(Ordering::SeqCst);
+                (border_width, border_offset)
+            } else {
+                (0, 0)
+            }
+        };
         let work_area = *self.work_area_size();
-        let offset = self.work_area_offset.or(offset);
+        let work_area_offset = self.work_area_offset.or(offset);
         let window_based_work_area_offset = self.window_based_work_area_offset();
-        let limit = self.window_based_work_area_offset_limit();
+        let window_based_work_area_offset_limit = self.window_based_work_area_offset_limit();
 
         if let Some(workspace) = self.workspaces_mut().get_mut(workspace_idx) {
-            workspace.globals_mut().container_padding = container_padding;
-            workspace.globals_mut().workspace_padding = workspace_padding;
-            workspace.globals_mut().work_area = work_area;
-            workspace.globals_mut().work_area_offset = offset;
-            workspace.globals_mut().window_based_work_area_offset = window_based_work_area_offset;
-            workspace.globals_mut().window_based_work_area_offset_limit = limit;
+            workspace.globals = WorkspaceGlobals {
+                container_padding,
+                workspace_padding,
+                border_width,
+                border_offset,
+                work_area,
+                work_area_offset,
+                window_based_work_area_offset,
+                window_based_work_area_offset_limit,
+            }
         }
     }
 

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -966,10 +966,7 @@ impl StaticConfig {
 
         border_manager::BORDER_WIDTH.store(self.border_width.unwrap_or(8), Ordering::SeqCst);
         border_manager::BORDER_OFFSET.store(self.border_offset.unwrap_or(-1), Ordering::SeqCst);
-
-        if let Some(enabled) = &self.border {
-            border_manager::BORDER_ENABLED.store(*enabled, Ordering::SeqCst);
-        }
+        border_manager::BORDER_ENABLED.store(self.border.unwrap_or(true), Ordering::SeqCst);
 
         if let Some(colours) = &self.border_colours {
             if let Some(single) = colours.single {

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -437,7 +437,7 @@ pub struct StaticConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "active_window_border_offset")]
     pub border_offset: Option<i32>,
-    /// Display an active window border (default: false)
+    /// Display an active window border (default: true)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "active_window_border")]
     pub border: Option<bool>,

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -8,8 +8,6 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::Ordering;
 
 use crate::border_manager;
-use crate::border_manager::BORDER_OFFSET;
-use crate::border_manager::BORDER_WIDTH;
 use crate::container::Container;
 use crate::core::Axis;
 use crate::core::CustomLayout;
@@ -188,6 +186,8 @@ pub enum WorkspaceWindowLocation {
 pub struct WorkspaceGlobals {
     pub container_padding: Option<i32>,
     pub workspace_padding: Option<i32>,
+    pub border_width: i32,
+    pub border_offset: i32,
     pub work_area: Rect,
     pub work_area_offset: Option<Rect>,
     pub window_based_work_area_offset: Option<Rect>,
@@ -488,6 +488,8 @@ impl Workspace {
             .workspace_padding()
             .or(self.globals().workspace_padding)
             .unwrap_or_default();
+        let border_width = self.globals().border_width;
+        let border_offset = self.globals().border_offset;
         let work_area = self.globals().work_area;
         let work_area_offset = self.globals().work_area_offset;
         let window_based_work_area_offset = self.globals().window_based_work_area_offset;
@@ -560,12 +562,8 @@ impl Workspace {
             if let Some(container) = self.monocle_container_mut() {
                 if let Some(window) = container.focused_window_mut() {
                     adjusted_work_area.add_padding(container_padding);
-                    {
-                        let border_offset = BORDER_OFFSET.load(Ordering::SeqCst);
-                        adjusted_work_area.add_padding(border_offset);
-                        let width = BORDER_WIDTH.load(Ordering::SeqCst);
-                        adjusted_work_area.add_padding(width);
-                    }
+                    adjusted_work_area.add_padding(border_offset);
+                    adjusted_work_area.add_padding(border_width);
                     window.set_position(&adjusted_work_area, true)?;
                 };
             } else if let Some(window) = self.maximized_window_mut() {
@@ -593,13 +591,8 @@ impl Workspace {
                     let window_count = container.windows().len();
 
                     if let Some(layout) = layouts.get_mut(i) {
-                        {
-                            let border_offset = BORDER_OFFSET.load(Ordering::SeqCst);
-                            layout.add_padding(border_offset);
-
-                            let width = BORDER_WIDTH.load(Ordering::SeqCst);
-                            layout.add_padding(width);
-                        }
+                        layout.add_padding(border_offset);
+                        layout.add_padding(border_width);
 
                         if stackbar_manager::should_have_stackbar(window_count) {
                             let tab_height = STACKBAR_TAB_HEIGHT.load(Ordering::SeqCst);

--- a/schema.json
+++ b/schema.json
@@ -153,7 +153,7 @@
       }
     },
     "border": {
-      "description": "Display an active window border (default: false)",
+      "description": "Display an active window border (default: true)",
       "type": "boolean"
     },
     "border_colours": {


### PR DESCRIPTION
- Fix wrong docs info, borders are enabled by default but the docs said they were disabled by default.
- Disabling the borders now also ignores the `border_width` and `border_offset`. Previously you would have to set them to 0 after disabling the borders or they would still count for the containers gap. Now if the borders are disabled they are no longer taken into account.
- Setting `"border": false` and then removing that line completely will re-enable the borders as it should since the default is to have them enabled.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
