### PR TITLE
docs: update multiple-bar-instances.md to mention the --bar option

### DIFF
--- a/docs/common-workflows/multiple-bar-instances.md
+++ b/docs/common-workflows/multiple-bar-instances.md
@@ -16,4 +16,5 @@ array in your `komorebi.json` configuration file.
 You may also use `$Env:USERPROFILE` or `$Env:KOMOREBI_CONFIG_HOME` when specifying the paths.
 
 The main difference between different `komorebi.bar.json` files will be the value of `monitor.index` which is used to
-target the monitor for each instance of `komorebi-bar`.
+target the monitor for each instance of `komorebi-bar`. `komorebi` will need to be started with the `--bar` option by 
+running `komorebic start --bar` for this to take effect.


### PR DESCRIPTION
I am NOT certain that this is required, but as a new user I only managed to get komorebi to create a second instance of the bar on my own setup after running `komorebic start --bar` and this doesn't seem to be mentioned anywhere. Please just close this if I am wrong.