### PR TITLE
fix(client): re-export `FloatingLayerBehaviour`

### DIFF
--- a/komorebi-client/src/lib.rs
+++ b/komorebi-client/src/lib.rs
@@ -29,6 +29,7 @@ pub use komorebi::core::CustomLayout;
 pub use komorebi::core::CycleDirection;
 pub use komorebi::core::DefaultLayout;
 pub use komorebi::core::Direction;
+pub use komorebi::core::FloatingLayerBehaviour;
 pub use komorebi::core::FocusFollowsMouseImplementation;
 pub use komorebi::core::HidingBehaviour;
 pub use komorebi::core::Layout;


### PR DESCRIPTION
@LGUG2Z We might want to start doing something like `pub use komorebi::core::*`, otherwise things sort of things will always be forgotten until someone needs it. Is there something on `komorebi::core` that shouldn't be exported through the client?

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
