### PR TITLE
fix(wm): add unfocused locked color

### DIFF
--- a/komorebi-gui/src/main.rs
+++ b/komorebi-gui/src/main.rs
@@ -41,7 +41,9 @@ struct BorderColours {
     single: Color32,
     stack: Color32,
     monocle: Color32,
+    floating: Color32,
     unfocused: Color32,
+    unfocused_locked: Color32,
 }
 
 struct BorderConfig {
@@ -154,7 +156,9 @@ impl KomorebiGui {
             single: colour32(global_state.border_colours.single),
             stack: colour32(global_state.border_colours.stack),
             monocle: colour32(global_state.border_colours.monocle),
+            floating: colour32(global_state.border_colours.floating),
             unfocused: colour32(global_state.border_colours.unfocused),
+            unfocused_locked: colour32(global_state.border_colours.unfocused_locked),
         };
 
         let border_config = BorderConfig {
@@ -377,6 +381,22 @@ impl eframe::App for KomorebiGui {
                             }
                         });
 
+                        ui.collapsing("Floating", |ui| {
+                            if egui::color_picker::color_picker_color32(
+                                ui,
+                                &mut self.border_config.border_colours.floating,
+                                Alpha::Opaque,
+                            ) {
+                                komorebi_client::send_message(&SocketMessage::BorderColour(
+                                    WindowKind::Floating,
+                                    self.border_config.border_colours.floating.r() as u32,
+                                    self.border_config.border_colours.floating.g() as u32,
+                                    self.border_config.border_colours.floating.b() as u32,
+                                ))
+                                .unwrap();
+                            }
+                        });
+
                         ui.collapsing("Unfocused", |ui| {
                             if egui::color_picker::color_picker_color32(
                                 ui,
@@ -388,6 +408,22 @@ impl eframe::App for KomorebiGui {
                                     self.border_config.border_colours.unfocused.r() as u32,
                                     self.border_config.border_colours.unfocused.g() as u32,
                                     self.border_config.border_colours.unfocused.b() as u32,
+                                ))
+                                .unwrap();
+                            }
+                        });
+
+                        ui.collapsing("Unfocused Locked", |ui| {
+                            if egui::color_picker::color_picker_color32(
+                                ui,
+                                &mut self.border_config.border_colours.unfocused_locked,
+                                Alpha::Opaque,
+                            ) {
+                                komorebi_client::send_message(&SocketMessage::BorderColour(
+                                    WindowKind::UnfocusedLocked,
+                                    self.border_config.border_colours.unfocused_locked.r() as u32,
+                                    self.border_config.border_colours.unfocused_locked.g() as u32,
+                                    self.border_config.border_colours.unfocused_locked.b() as u32,
                                 ))
                                 .unwrap();
                             }

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -119,6 +119,9 @@ pub struct BorderColours {
     /// Border colour when the container is unfocused
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unfocused: Option<Colour>,
+    /// Border colour when the container is unfocused and locked
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unfocused_locked: Option<Colour>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -700,6 +703,9 @@ impl From<&WindowManager> for StaticConfig {
                 unfocused: Option::from(Colour::from(
                     border_manager::UNFOCUSED.load(Ordering::SeqCst),
                 )),
+                unfocused_locked: Option::from(Colour::from(
+                    border_manager::UNFOCUSED_LOCKED.load(Ordering::SeqCst),
+                )),
             })
         };
 
@@ -880,6 +886,11 @@ impl StaticConfig {
 
             if let Some(unfocused) = colours.unfocused {
                 border_manager::UNFOCUSED.store(u32::from(unfocused), Ordering::SeqCst);
+            }
+
+            if let Some(unfocused_locked) = colours.unfocused_locked {
+                border_manager::UNFOCUSED_LOCKED
+                    .store(u32::from(unfocused_locked), Ordering::SeqCst);
             }
         }
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -248,6 +248,9 @@ impl Default for GlobalState {
                 unfocused: Option::from(Colour::Rgb(Rgb::from(
                     border_manager::UNFOCUSED.load(Ordering::SeqCst),
                 ))),
+                unfocused_locked: Option::from(Colour::Rgb(Rgb::from(
+                    border_manager::UNFOCUSED_LOCKED.load(Ordering::SeqCst),
+                ))),
             },
             border_style: STYLE.load(),
             border_offset: border_manager::BORDER_OFFSET.load(Ordering::SeqCst),


### PR DESCRIPTION
Adds the `unfocused_locked` border color to `border_colours` so that users that don't use themes can still customize that color like they do the others.

It also adds that color and the `floating` border color to the `komorebi-gui`.
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
