### PR TITLE
feat(cli): query focused-workspace-layout

### DIFF
--- a/docs/cli/query.md
+++ b/docs/cli/query.md
@@ -7,7 +7,7 @@ Usage: komorebic.exe query <STATE_QUERY>
 
 Arguments:
   <STATE_QUERY>
-          [possible values: focused-monitor-index, focused-workspace-index, focused-container-index, focused-window-index, focused-workspace-name]
+          [possible values: focused-monitor-index, focused-workspace-index, focused-container-index, focused-window-index, focused-workspace-name, focused-workspace-layout]
 
 Options:
   -h, --help

--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -329,6 +329,7 @@ pub enum StateQuery {
     FocusedContainerIndex,
     FocusedWindowIndex,
     FocusedWorkspaceName,
+    FocusedWorkspaceLayout,
     Version,
 }
 

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -165,6 +165,16 @@ impl Monitor {
             .unwrap_or(None)
     }
 
+    pub fn focused_workspace_layout(&self) -> Option<Layout> {
+        self.focused_workspace().and_then(|workspace| {
+            if *workspace.tile() {
+                Some(workspace.layout().clone())
+            } else {
+                None
+            }
+        })
+    }
+
     pub fn load_focused_workspace(&mut self, mouse_follows_focus: bool) -> Result<()> {
         let focused_idx = self.focused_workspace_idx();
         for (i, workspace) in self.workspaces_mut().iter_mut().enumerate() {

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1378,6 +1378,19 @@ impl WindowManager {
                             .unwrap_or_else(|| focused_monitor.focused_workspace_idx().to_string())
                     }
                     StateQuery::Version => build::RUST_VERSION.to_string(),
+                    StateQuery::FocusedWorkspaceLayout => {
+                        let focused_monitor = self
+                            .focused_monitor()
+                            .ok_or_else(|| anyhow!("there is no monitor"))?;
+
+                        focused_monitor.focused_workspace_layout().map_or_else(
+                            || "None".to_string(),
+                            |layout| match layout {
+                                Layout::Default(default_layout) => default_layout.to_string(),
+                                Layout::Custom(_) => "Custom".to_string(),
+                            },
+                        )
+                    }
                 };
 
                 reply.write_all(response.as_bytes())?;


### PR DESCRIPTION
<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->

### This PR adds the `focused-workspace-layout` value for komorebic query:

- for DefaultLayout: returns enum name.to_string, 
- for CustomLayout: returns "Custom" 
- for floating workspaces: returns "None"

Initially I hoped this could return values in snake case fashion so it would be chainable with `komorebic change-layout`, but I do think that these should not be tied by default, whoever wants to tinker with this (me 😄) should handle it some other way.

This is my first Rust ever so I hope everything is according to the correct practices. 


