### PR TITLE
feature/custom themes

### DIFF
--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -177,9 +177,10 @@ impl Monitor {
 
     pub fn load_focused_workspace(&mut self, mouse_follows_focus: bool) -> Result<()> {
         let focused_idx = self.focused_workspace_idx();
+        let hmonitor = self.id();
         for (i, workspace) in self.workspaces_mut().iter_mut().enumerate() {
             if i == focused_idx {
-                workspace.restore(mouse_follows_focus)?;
+                workspace.restore(mouse_follows_focus, hmonitor)?;
             } else {
                 workspace.hide(None);
             }

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -21,6 +21,7 @@ use crate::workspace::WorkspaceLayer;
 use crate::DefaultLayout;
 use crate::Layout;
 use crate::OperationDirection;
+use crate::Wallpaper;
 use crate::WindowsApi;
 use crate::DEFAULT_CONTAINER_PADDING;
 use crate::DEFAULT_WORKSPACE_PADDING;
@@ -60,6 +61,8 @@ pub struct Monitor {
     pub container_padding: Option<i32>,
     #[getset(get_copy = "pub", set = "pub")]
     pub workspace_padding: Option<i32>,
+    #[getset(get = "pub", get_mut = "pub", set = "pub")]
+    pub wallpaper: Option<Wallpaper>,
 }
 
 impl_ring_elements!(Monitor, Workspace);
@@ -115,6 +118,7 @@ pub fn new(
         workspace_names: HashMap::default(),
         container_padding: None,
         workspace_padding: None,
+        wallpaper: None,
     }
 }
 
@@ -156,6 +160,7 @@ impl Monitor {
             workspace_names: Default::default(),
             container_padding: None,
             workspace_padding: None,
+            wallpaper: None,
         }
     }
 
@@ -178,9 +183,10 @@ impl Monitor {
     pub fn load_focused_workspace(&mut self, mouse_follows_focus: bool) -> Result<()> {
         let focused_idx = self.focused_workspace_idx();
         let hmonitor = self.id();
+        let monitor_wp = self.wallpaper.clone();
         for (i, workspace) in self.workspaces_mut().iter_mut().enumerate() {
             if i == focused_idx {
-                workspace.restore(mouse_follows_focus, hmonitor)?;
+                workspace.restore(mouse_follows_focus, hmonitor, &monitor_wp)?;
             } else {
                 workspace.hide(None);
             }

--- a/komorebi/src/monitor_reconciliator/mod.rs
+++ b/komorebi/src/monitor_reconciliator/mod.rs
@@ -553,6 +553,7 @@ where
                                     workspace_names: cached.workspace_names.clone(),
                                     container_padding: cached.container_padding,
                                     workspace_padding: cached.workspace_padding,
+                                    wallpaper: cached.wallpaper.clone(),
                                 };
 
                                 let focused_workspace_idx = m.focused_workspace_idx();

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1678,6 +1678,8 @@ impl StaticConfig {
 
         for i in 0..monitor_count {
             wm.update_focused_workspace_by_monitor_idx(i)?;
+            let ws_idx = wm.focused_workspace_idx_for_monitor_idx(i)?;
+            wm.apply_wallpaper_for_monitor_workspace(i, ws_idx)?;
         }
 
         Ok(())

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -326,6 +326,9 @@ pub struct MonitorConfig {
     /// Workspace padding (default: global)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_padding: Option<i32>,
+    /// Specify a wallpaper for this workspace
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wallpaper: Option<Wallpaper>,
 }
 
 impl From<&Monitor> for MonitorConfig {
@@ -361,6 +364,7 @@ impl From<&Monitor> for MonitorConfig {
             window_based_work_area_offset_limit: Some(value.window_based_work_area_offset_limit()),
             container_padding,
             workspace_padding,
+            wallpaper: value.wallpaper().clone(),
         }
     }
 }
@@ -1357,6 +1361,7 @@ impl StaticConfig {
                 );
                 monitor.set_container_padding(monitor_config.container_padding);
                 monitor.set_workspace_padding(monitor_config.workspace_padding);
+                monitor.set_wallpaper(monitor_config.wallpaper.clone());
 
                 monitor.update_workspaces_globals(offset);
                 for (j, ws) in monitor.workspaces_mut().iter_mut().enumerate() {

--- a/komorebi/src/theme_manager.rs
+++ b/komorebi/src/theme_manager.rs
@@ -295,7 +295,7 @@ pub fn handle_notifications() -> color_eyre::Result<()> {
 
         CURRENT_THEME.store(Some(notification.0));
 
-        border_manager::send_notification(None);
+        border_manager::send_force_update();
         stackbar_manager::send_notification();
     }
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1014,6 +1014,7 @@ impl WindowManager {
             let focused_workspace_idx = monitor.focused_workspace_idx();
             monitor.update_workspace_globals(focused_workspace_idx, offset);
 
+            let hmonitor = monitor.id();
             let workspace = monitor
                 .focused_workspace_mut()
                 .ok_or_else(|| anyhow!("there is no workspace"))?;
@@ -1022,6 +1023,12 @@ impl WindowManager {
             if !preserve_resize_dimensions {
                 for resize in workspace.resize_dimensions_mut() {
                     *resize = None;
+                }
+            }
+
+            if workspace.wallpaper().is_some() {
+                if let Err(error) = workspace.apply_wallpaper(hmonitor) {
+                    tracing::error!("failed to apply wallpaper: {}", error);
                 }
             }
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1715,6 +1715,29 @@ impl WindowManager {
         Ok(())
     }
 
+    /// Check for an existing wallpaper definition on the workspace/monitor index pair and apply it
+    /// if it exists
+    #[tracing::instrument(skip(self))]
+    pub fn apply_wallpaper_for_monitor_workspace(
+        &mut self,
+        monitor_idx: usize,
+        workspace_idx: usize,
+    ) -> Result<()> {
+        let monitor = self
+            .monitors_mut()
+            .get_mut(monitor_idx)
+            .ok_or_else(|| anyhow!("there is no monitor"))?;
+
+        let hmonitor = monitor.id();
+
+        let workspace = monitor
+            .workspaces()
+            .get(workspace_idx)
+            .ok_or_else(|| anyhow!("there is no workspace"))?;
+
+        workspace.apply_wallpaper(hmonitor)
+    }
+
     pub fn update_focused_workspace_by_monitor_idx(&mut self, idx: usize) -> Result<()> {
         let offset = self.work_area_offset;
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -359,6 +359,7 @@ impl From<&WindowManager> for State {
                 workspace_names: monitor.workspace_names.clone(),
                 container_padding: monitor.container_padding,
                 workspace_padding: monitor.workspace_padding,
+                wallpaper: monitor.wallpaper.clone(),
             })
             .collect::<VecDeque<_>>();
         stripped_monitors.focus(wm.monitors.focused_idx());
@@ -1015,6 +1016,7 @@ impl WindowManager {
             monitor.update_workspace_globals(focused_workspace_idx, offset);
 
             let hmonitor = monitor.id();
+            let monitor_wp = monitor.wallpaper.clone();
             let workspace = monitor
                 .focused_workspace_mut()
                 .ok_or_else(|| anyhow!("there is no workspace"))?;
@@ -1026,8 +1028,8 @@ impl WindowManager {
                 }
             }
 
-            if workspace.wallpaper().is_some() {
-                if let Err(error) = workspace.apply_wallpaper(hmonitor) {
+            if workspace.wallpaper().is_some() || monitor_wp.is_some() {
+                if let Err(error) = workspace.apply_wallpaper(hmonitor, &monitor_wp) {
                     tracing::error!("failed to apply wallpaper: {}", error);
                 }
             }
@@ -1729,13 +1731,14 @@ impl WindowManager {
             .ok_or_else(|| anyhow!("there is no monitor"))?;
 
         let hmonitor = monitor.id();
+        let monitor_wp = monitor.wallpaper.clone();
 
         let workspace = monitor
             .workspaces()
             .get(workspace_idx)
             .ok_or_else(|| anyhow!("there is no workspace"))?;
 
-        workspace.apply_wallpaper(hmonitor)
+        workspace.apply_wallpaper(hmonitor, &monitor_wp)
     }
 
     pub fn update_focused_workspace_by_monitor_idx(&mut self, idx: usize) -> Result<()> {

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -1385,4 +1385,23 @@ impl WindowsApi {
         }
         Ok(())
     }
+
+    pub fn get_wallpaper(hmonitor: isize) -> Result<String> {
+        let wallpaper: IDesktopWallpaper =
+            unsafe { CoCreateInstance(&DesktopWallpaper, None, CLSCTX_ALL)? };
+
+        let monitor_id = if let Some(path) = Self::monitor_device_path(hmonitor) {
+            PCWSTR::from_raw(HSTRING::from(path).as_ptr())
+        } else {
+            PCWSTR::null()
+        };
+
+        // Set the wallpaper
+        unsafe {
+            wallpaper
+                .GetWallpaper(monitor_id)
+                .and_then(|pwstr| pwstr.to_string().map_err(|e| e.into()))
+        }
+        .process()
+    }
 }

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -94,6 +94,7 @@ pub struct Workspace {
     pub window_container_behaviour_rules: Option<Vec<(usize, WindowContainerBehaviour)>>,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     pub float_override: Option<bool>,
+    #[serde(skip)]
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     pub globals: WorkspaceGlobals,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -302,9 +302,9 @@ impl Workspace {
         }
     }
 
-    pub fn apply_wallpaper(&self) -> Result<()> {
+    pub fn apply_wallpaper(&self, hmonitor: isize) -> Result<()> {
         if let Some(wallpaper) = &self.wallpaper {
-            if let Err(error) = WindowsApi::set_wallpaper(&wallpaper.path) {
+            if let Err(error) = WindowsApi::set_wallpaper(&wallpaper.path, hmonitor) {
                 tracing::error!("failed to set wallpaper: {error}");
             }
 
@@ -419,12 +419,12 @@ impl Workspace {
         Ok(())
     }
 
-    pub fn restore(&mut self, mouse_follows_focus: bool) -> Result<()> {
+    pub fn restore(&mut self, mouse_follows_focus: bool, hmonitor: isize) -> Result<()> {
         if let Some(container) = self.monocle_container() {
             if let Some(window) = container.focused_window() {
                 container.restore();
                 window.focus(mouse_follows_focus)?;
-                return self.apply_wallpaper();
+                return self.apply_wallpaper(hmonitor);
             }
         }
 
@@ -468,7 +468,7 @@ impl Workspace {
             floating_window.focus(mouse_follows_focus)?;
         }
 
-        self.apply_wallpaper()
+        self.apply_wallpaper(hmonitor)
     }
 
     pub fn update(&mut self) -> Result<()> {


### PR DESCRIPTION
- Apply wallpaper only on the workspace monitor
- Properly update border colors
- Add option for setting wallpaper per-monitor
- Read the current wallpaper on each monitor on startup and set that monitor's `wallpaper` to a new `Wallpaper` with that path and `generate_theme` set to `false`
   - This however has the downside that the `generate_theme` behaves as if it was `false` by default, since if you don't set it on the workspace nor on the monitor it will use the default one from the start which is `false`

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
