### PR TITLE
docs: update troubleshooting.md with Nvidia GPU workaround for bar transparency

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -148,6 +148,3 @@ To solve this the user can do the following:
 8. Restart the Komorebi Bar with "komorebic stop --bar; komorebic start --bar"
 
 This should resolve the issue and your Komorebi Bar should render with the proper transparency.
-  
-
-

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,3 +132,22 @@ running `komorebic stop` and `komorebic start`.
    We can see the _komorebi_ state is no longer associated with the previous
    device: `null`, suggesting an issue when the display resumes from a suspended
    state.
+
+## Komorebi Bar does not render transparency on Nvidia GPUs
+
+Users with Nvidia GPUs may have issues with transparency on the Komorebi Bar.
+
+To solve this the user can do the following:
+1. Open the Nvidia Control Panel
+2. On the left menu tree, under "3D Settings", select "Manage 3D Settings"
+3. Select the "Program Settings" tab
+4. Press the "Add" button and select "komorebi-bar"
+5. Under "3. Specify the settings for this program:", find the feature labelled, "OpenGL GDI compatibility"
+6. Change the setting to "Prefer compatibility"
+7. At the bottom of the window select "Apply"
+8. Restart the Komorebi Bar with "komorebic stop --bar; komorebic start --bar"
+
+This should resolve the issue and your Komorebi Bar should render with the proper transparency.
+  
+
+


### PR DESCRIPTION
Updated troubleshooting.md with the workaround for an issue where the Komorebi Bar does not render transparency properly with Nvidia GPUs. I hope this can help other. It was shared with me by @CtByte on #1391. Seems like he was found this on a [discord](url) post 
