### PR TITLE
Apply state socketmessage

### DIFF
--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -15,6 +15,7 @@ use strum::EnumString;
 
 use crate::KomorebiTheme;
 use crate::animation::prefix::AnimationPrefix;
+use crate::state::State;
 
 // Re-export everything from komorebi-layouts
 pub use komorebi_layouts::Arrangement;
@@ -256,6 +257,8 @@ pub enum SocketMessage {
     StaticConfigSchema,
     GenerateStaticConfig,
     DebugWindow(isize),
+    // low level commands
+    ApplyState(State),
 }
 
 impl SocketMessage {

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -2296,6 +2296,9 @@ if (!(Get-Process komorebi-bar -ErrorAction SilentlyContinue))
             SocketMessage::Theme(ref theme) => {
                 theme_manager::send_notification(*theme.clone());
             }
+            SocketMessage::ApplyState(ref state) => {
+                self.apply_state(state.clone());
+            }
             // Deprecated commands
             SocketMessage::AltFocusHack(_)
             | SocketMessage::IdentifyBorderOverflowApplication(_, _) => {}

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -239,23 +239,28 @@ impl WindowManager {
             let mouse_follows_focus = self.mouse_follows_focus;
             for (monitor_idx, monitor) in self.monitors_mut().iter_mut().enumerate() {
                 let mut focused_workspace = 0;
-                for (workspace_idx, workspace) in monitor.workspaces_mut().iter_mut().enumerate() {
-                    if let Some(state_monitor) = state.monitors.elements().get(monitor_idx)
-                        && let Some(state_workspace) = state_monitor.workspaces().get(workspace_idx)
-                    {
-                        // to make sure padding and layout_options changes get applied for users after a quick restart
-                        let container_padding = workspace.container_padding;
-                        let workspace_padding = workspace.workspace_padding;
-                        let layout_options = workspace.layout_options;
+                if let Some(state_monitor) = state.monitors.elements().get(monitor_idx) {
+                    monitor
+                        .workspaces_mut()
+                        .resize(state_monitor.workspaces().len(), Workspace::default());
 
-                        *workspace = state_workspace.clone();
+                    for (workspace_idx, workspace) in monitor.workspaces_mut().iter_mut().enumerate() {
+                        if let Some(state_workspace) = state_monitor.workspaces().get(workspace_idx)
+                        {
+                            // to make sure padding and layout_options changes get applied for users after a quick restart
+                            let container_padding = workspace.container_padding;
+                            let workspace_padding = workspace.workspace_padding;
+                            let layout_options = workspace.layout_options;
 
-                        workspace.container_padding = container_padding;
-                        workspace.workspace_padding = workspace_padding;
-                        workspace.layout_options = layout_options;
+                            *workspace = state_workspace.clone();
 
-                        if state_monitor.focused_workspace_idx() == workspace_idx {
-                            focused_workspace = workspace_idx;
+                            workspace.container_padding = container_padding;
+                            workspace.workspace_padding = workspace_padding;
+                            workspace.layout_options = layout_options;
+
+                            if state_monitor.focused_workspace_idx() == workspace_idx {
+                                focused_workspace = workspace_idx;
+                            }
                         }
                     }
                 }

--- a/schema.bar.json
+++ b/schema.bar.json
@@ -2346,6 +2346,147 @@
         }
       ]
     },
+    "Column": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "column": {
+              "type": "string",
+              "const": "Primary"
+            },
+            "configuration": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ColumnWidth"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "column",
+            "configuration"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "column": {
+              "type": "string",
+              "const": "Secondary"
+            },
+            "configuration": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ColumnSplitWithCapacity"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "column",
+            "configuration"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "column": {
+              "type": "string",
+              "const": "Tertiary"
+            },
+            "configuration": {
+              "$ref": "#/$defs/ColumnSplit"
+            }
+          },
+          "required": [
+            "column",
+            "configuration"
+          ]
+        }
+      ]
+    },
+    "ColumnSplit": {
+      "type": "string",
+      "enum": [
+        "Horizontal",
+        "Vertical"
+      ]
+    },
+    "ColumnSplitWithCapacity": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "Horizontal": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Horizontal"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Vertical": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Vertical"
+          ]
+        }
+      ]
+    },
+    "ColumnWidth": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "WidthPercentage": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "WidthPercentage"
+          ]
+        }
+      ]
+    },
+    "Container": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "locked": {
+          "type": "boolean",
+          "default": false
+        },
+        "windows": {
+          "$ref": "#/$defs/Ring4"
+        }
+      },
+      "required": [
+        "id",
+        "windows"
+      ]
+    },
     "CpuConfig": {
       "description": "CPU widget configuration",
       "type": "object",
@@ -2389,6 +2530,12 @@
       "required": [
         "enable"
       ]
+    },
+    "CustomLayout": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Column"
+      }
     },
     "CustomModifiers": {
       "description": "Custom format with additive modifiers for integer format specifiers",
@@ -2615,6 +2762,21 @@
         }
       ]
     },
+    "FloatingLayerBehaviour": {
+      "description": "Floating layer behaviour when a new window is opened",
+      "oneOf": [
+        {
+          "description": "Tile new windows (unless they match a float rule or float override is active)",
+          "type": "string",
+          "const": "Tile"
+        },
+        {
+          "description": "Float new windows",
+          "type": "string",
+          "const": "Float"
+        }
+      ]
+    },
     "FocusFollowsMouseImplementation": {
       "description": "Focus follows mouse implementation",
       "oneOf": [
@@ -2641,6 +2803,21 @@
       },
       "required": [
         "inner_margin"
+      ]
+    },
+    "GridLayoutOptions": {
+      "description": "Options for the Grid layout",
+      "type": "object",
+      "properties": {
+        "rows": {
+          "description": "Maximum number of rows per grid column",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "rows"
       ]
     },
     "GroupedSpacingConfig": {
@@ -2911,6 +3088,35 @@
           "type": "string",
           "const": "Cloak"
         }
+      ]
+    },
+    "IdWithIdentifier": {
+      "description": "Rule for matching applications",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Target identifier",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind of identifier to target",
+          "$ref": "#/$defs/ApplicationIdentifier"
+        },
+        "matching_strategy": {
+          "description": "Matching strategy to use",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MatchingStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "kind",
+        "id"
       ]
     },
     "IndividualSpacingConfig": {
@@ -3949,6 +4155,112 @@
         }
       ]
     },
+    "Layout": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "Default": {
+              "$ref": "#/$defs/DefaultLayout"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Default"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Custom": {
+              "$ref": "#/$defs/CustomLayout"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Custom"
+          ]
+        }
+      ]
+    },
+    "LayoutOptions": {
+      "description": "Options for specific layouts",
+      "type": "object",
+      "properties": {
+        "column_ratios": {
+          "description": "Column width ratios (up to MAX_RATIOS values between 0.1 and 0.9)\n\n- Used by Columns layout: ratios for each column width\n- Used by Grid layout: ratios for column widths\n- Used by BSP, VerticalStack, RightMainVerticalStack: column_ratios[0] as primary split ratio\n- Used by HorizontalStack: column_ratios[0] as primary split ratio (top area height)\n- Used by UltrawideVerticalStack: column_ratios[0] as center ratio, column_ratios[1] as left ratio\n\nColumns without a ratio share remaining space equally.\nExample: `[0.3, 0.4, 0.3]` for 30%-40%-30% columns",
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "items": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "float"
+          },
+          "maxItems": 5,
+          "minItems": 5
+        },
+        "grid": {
+          "description": "Options related to the Grid layout",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GridLayoutOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "row_ratios": {
+          "description": "Row height ratios (up to MAX_RATIOS values between 0.1 and 0.9)\n\n- Used by Rows layout: ratios for each row height\n- Used by Grid layout: ratios for row heights\n\nRows without a ratio share remaining space equally.\nExample: `[0.5, 0.5]` for 50%-50% rows",
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "items": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "float"
+          },
+          "maxItems": 5,
+          "minItems": 5
+        },
+        "scrolling": {
+          "description": "Options related to the Scrolling layout",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ScrollingLayoutOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "MatchingRule": {
+      "description": "Rule for matching applications",
+      "anyOf": [
+        {
+          "description": "Simple matching rule which must evaluate to true",
+          "$ref": "#/$defs/IdWithIdentifier"
+        },
+        {
+          "description": "Composite matching rule where all conditions must evaluate to true",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IdWithIdentifier"
+          }
+        }
+      ]
+    },
     "MatchingStrategy": {
       "description": "Strategy for matching identifiers",
       "oneOf": [
@@ -4110,6 +4422,125 @@
       },
       "required": [
         "enable"
+      ]
+    },
+    "Monitor": {
+      "type": "object",
+      "properties": {
+        "container_padding": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "device": {
+          "type": "string"
+        },
+        "device_id": {
+          "type": "string"
+        },
+        "floating_layer_behaviour": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FloatingLayerBehaviour"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "type": "integer",
+          "format": "int"
+        },
+        "last_focused_workspace": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "name": {
+          "type": "string"
+        },
+        "serial_number_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "size": {
+          "$ref": "#/$defs/Rect"
+        },
+        "wallpaper": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Wallpaper"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "window_based_work_area_offset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Rect"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "window_based_work_area_offset_limit": {
+          "type": "integer",
+          "format": "int"
+        },
+        "work_area_offset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Rect"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "work_area_size": {
+          "$ref": "#/$defs/Rect"
+        },
+        "workspace_names": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^\\d+$": {
+              "type": "string"
+            }
+          }
+        },
+        "workspace_padding": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "workspaces": {
+          "$ref": "#/$defs/Ring2"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "device",
+        "device_id",
+        "size",
+        "work_area_size",
+        "window_based_work_area_offset_limit",
+        "workspaces",
+        "workspace_names"
       ]
     },
     "MonitorConfig": {
@@ -4574,6 +5005,86 @@
         "b"
       ]
     },
+    "Ring": {
+      "type": "object",
+      "properties": {
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Monitor"
+          }
+        },
+        "focused": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "elements",
+        "focused"
+      ]
+    },
+    "Ring2": {
+      "type": "object",
+      "properties": {
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Workspace"
+          }
+        },
+        "focused": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "elements",
+        "focused"
+      ]
+    },
+    "Ring3": {
+      "type": "object",
+      "properties": {
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Container"
+          }
+        },
+        "focused": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "elements",
+        "focused"
+      ]
+    },
+    "Ring4": {
+      "type": "object",
+      "properties": {
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Window"
+          }
+        },
+        "focused": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "elements",
+        "focused"
+      ]
+    },
     "RoundingConfig": {
       "description": "Rounding configuration",
       "anyOf": [
@@ -4592,6 +5103,28 @@
           "maxItems": 4,
           "minItems": 4
         }
+      ]
+    },
+    "ScrollingLayoutOptions": {
+      "description": "Options for the Scrolling layout",
+      "type": "object",
+      "properties": {
+        "center_focused_column": {
+          "description": "With an odd number of visible columns, keep the focused window column centered",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "columns": {
+          "description": "Desired number of visible columns (default: 3)",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "columns"
       ]
     },
     "Sizing": {
@@ -8156,6 +8689,22 @@
             "type",
             "content"
           ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "content": {
+              "$ref": "#/$defs/State"
+            },
+            "type": {
+              "type": "string",
+              "const": "ApplyState"
+            }
+          },
+          "required": [
+            "type",
+            "content"
+          ]
         }
       ]
     },
@@ -8210,6 +8759,94 @@
           "type": "string",
           "const": "OnStack"
         }
+      ]
+    },
+    "State": {
+      "type": "object",
+      "properties": {
+        "cross_monitor_move_behaviour": {
+          "$ref": "#/$defs/MoveBehaviour"
+        },
+        "float_override": {
+          "type": "boolean"
+        },
+        "focus_follows_mouse": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FocusFollowsMouseImplementation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "has_pending_raise_op": {
+          "type": "boolean"
+        },
+        "is_paused": {
+          "type": "boolean"
+        },
+        "monitor_usr_idx_map": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^\\d+$": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          }
+        },
+        "monitors": {
+          "$ref": "#/$defs/Ring"
+        },
+        "mouse_follows_focus": {
+          "type": "boolean"
+        },
+        "new_window_behaviour": {
+          "$ref": "#/$defs/WindowContainerBehaviour"
+        },
+        "resize_delta": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "unmanaged_window_operation_behaviour": {
+          "$ref": "#/$defs/OperationBehaviour"
+        },
+        "virtual_desktop_id": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "integer",
+            "format": "uint8",
+            "maximum": 255,
+            "minimum": 0
+          }
+        },
+        "work_area_offset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Rect"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "monitors",
+        "monitor_usr_idx_map",
+        "is_paused",
+        "resize_delta",
+        "new_window_behaviour",
+        "float_override",
+        "cross_monitor_move_behaviour",
+        "unmanaged_window_operation_behaviour",
+        "mouse_follows_focus",
+        "has_pending_raise_op"
       ]
     },
     "StateQuery": {
@@ -8418,6 +9055,159 @@
         "enable"
       ]
     },
+    "ThemeOptions": {
+      "description": "Theme options",
+      "type": "object",
+      "properties": {
+        "bar_accent": {
+          "description": "Komorebi status bar accent",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base0D"
+        },
+        "floating_border": {
+          "description": "Border colour when the window is floating",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base09"
+        },
+        "monocle_border": {
+          "description": "Border colour when the container is in monocle mode",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base0F"
+        },
+        "single_border": {
+          "description": "Border colour when the container contains a single window",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base0D"
+        },
+        "stack_border": {
+          "description": "Border colour when the container contains multiple windows",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base0B"
+        },
+        "stackbar_background": {
+          "description": "Stackbar tab background colour",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base01"
+        },
+        "stackbar_focused_text": {
+          "description": "Stackbar focused tab text colour",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base0B"
+        },
+        "stackbar_unfocused_text": {
+          "description": "Stackbar unfocused tab text colour",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base05"
+        },
+        "theme_variant": {
+          "description": "Specify Light or Dark variant for theme generation",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ThemeVariant"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Dark"
+        },
+        "unfocused_border": {
+          "description": "Border colour when the container is unfocused",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base01"
+        },
+        "unfocused_locked_border": {
+          "description": "Border colour when the container is unfocused and locked",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Base16Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Base08"
+        }
+      }
+    },
+    "ThemeVariant": {
+      "description": "Theme variant",
+      "oneOf": [
+        {
+          "description": "Dark variant",
+          "type": "string",
+          "const": "Dark"
+        },
+        {
+          "description": "Light variant",
+          "type": "string",
+          "const": "Light"
+        }
+      ]
+    },
     "TimeConfig": {
       "description": "Time widget configuration",
       "type": "object",
@@ -8542,6 +9332,39 @@
       },
       "required": [
         "enable"
+      ]
+    },
+    "Wallpaper": {
+      "description": "Wallpaper configuration",
+      "type": "object",
+      "properties": {
+        "generate_theme": {
+          "description": "Generate and apply Base16 theme for this wallpaper",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": true
+        },
+        "path": {
+          "description": "Path to the wallpaper image file",
+          "$ref": "#/$defs/PathBuf"
+        },
+        "theme_options": {
+          "description": "Specify Light or Dark variant for theme generation",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ThemeOptions"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Dark"
+        }
+      },
+      "required": [
+        "path"
       ]
     },
     "WidgetConfig": {
@@ -8731,6 +9554,33 @@
         }
       ]
     },
+    "Window": {
+      "type": "object",
+      "properties": {
+        "hwnd": {
+          "type": "integer",
+          "format": "int"
+        }
+      },
+      "required": [
+        "hwnd"
+      ]
+    },
+    "WindowContainerBehaviour": {
+      "description": "Window container behaviour when a new window is opened",
+      "oneOf": [
+        {
+          "description": "Create a new container for each new window",
+          "type": "string",
+          "const": "Create"
+        },
+        {
+          "description": "Append new windows to the focused window container",
+          "type": "string",
+          "const": "Append"
+        }
+      ]
+    },
     "WindowKind": {
       "description": "Window kind",
       "oneOf": [
@@ -8764,6 +9614,490 @@
           "type": "string",
           "const": "Floating"
         }
+      ]
+    },
+    "Workspace": {
+      "type": "object",
+      "properties": {
+        "apply_window_based_work_area_offset": {
+          "type": "boolean"
+        },
+        "container_padding": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "containers": {
+          "$ref": "#/$defs/Ring3"
+        },
+        "float_override": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "floating_layer_behaviour": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FloatingLayerBehaviour"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "floating_windows": {
+          "$ref": "#/$defs/Ring4"
+        },
+        "latest_layout": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Rect"
+          }
+        },
+        "layer": {
+          "$ref": "#/$defs/WorkspaceLayer"
+        },
+        "layout": {
+          "$ref": "#/$defs/Layout"
+        },
+        "layout_flip": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Axis"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout_options": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LayoutOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout_rules": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              {
+                "$ref": "#/$defs/Layout"
+              }
+            ]
+          }
+        },
+        "maximized_window": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Window"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maximized_window_restore_idx": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "monocle_container": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Container"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "monocle_container_restore_idx": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "preselected_container_idx": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "promotion_swap_container_idx": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0
+        },
+        "resize_dimensions": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Rect"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "tile": {
+          "type": "boolean"
+        },
+        "wallpaper": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Wallpaper"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "window_container_behaviour": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WindowContainerBehaviour"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "window_container_behaviour_rules": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              {
+                "$ref": "#/$defs/WindowContainerBehaviour"
+              }
+            ]
+          }
+        },
+        "work_area_offset": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Rect"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "work_area_offset_rules": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              {
+                "$ref": "#/$defs/Rect"
+              }
+            ]
+          }
+        },
+        "workspace_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WorkspaceConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "workspace_padding": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        }
+      },
+      "required": [
+        "containers",
+        "floating_windows",
+        "layout",
+        "layout_rules",
+        "work_area_offset_rules",
+        "latest_layout",
+        "resize_dimensions",
+        "tile",
+        "apply_window_based_work_area_offset",
+        "layer"
+      ]
+    },
+    "WorkspaceConfig": {
+      "description": "Workspace configuration",
+      "type": "object",
+      "properties": {
+        "apply_window_based_work_area_offset": {
+          "description": "Apply this monitor's window-based work area offset",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": true
+        },
+        "container_padding": {
+          "description": "Container padding (default: global)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "custom_layout": {
+          "description": "END OF LIFE FEATURE: Custom Layout",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PathBuf"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "deprecated": true
+        },
+        "custom_layout_rules": {
+          "description": "END OF LIFE FEATURE: Custom layout rules",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "deprecated": true,
+          "patternProperties": {
+            "^\\d+$": {
+              "type": "string"
+            }
+          }
+        },
+        "float_override": {
+          "description": "Enable or disable float override, which makes it so every new window opens in floating mode",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": false
+        },
+        "floating_layer_behaviour": {
+          "description": "Determine what happens to a new window when the Floating workspace layer is active",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FloatingLayerBehaviour"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Tile"
+        },
+        "initial_workspace_rules": {
+          "description": "Initial workspace application rules",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/MatchingRule"
+          }
+        },
+        "layout": {
+          "description": "Layout",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DefaultLayout"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "BSP"
+        },
+        "layout_flip": {
+          "description": "Specify an axis on which to flip the selected layout",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Axis"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout_options": {
+          "description": "Layout-specific options",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LayoutOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout_rules": {
+          "description": "Layout rules in the format of threshold => layout",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^\\d+$": {
+              "$ref": "#/$defs/DefaultLayout"
+            }
+          }
+        },
+        "name": {
+          "description": "Name",
+          "type": "string"
+        },
+        "tile": {
+          "description": "Enable or disable tiling for the workspace",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": true
+        },
+        "wallpaper": {
+          "description": "Specify a wallpaper for this workspace",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Wallpaper"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "window_container_behaviour": {
+          "description": "Determine what happens when a new window is opened",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WindowContainerBehaviour"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "Create"
+        },
+        "window_container_behaviour_rules": {
+          "description": "Window container behaviour rules in the format of threshold => behaviour",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^\\d+$": {
+              "$ref": "#/$defs/WindowContainerBehaviour"
+            }
+          }
+        },
+        "work_area_offset": {
+          "description": "Workspace specific work area offset",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Rect"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "work_area_offset_rules": {
+          "description": "Work area offset rules in the format of threshold => Rect (default: None)",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^\\d+$": {
+              "$ref": "#/$defs/Rect"
+            }
+          }
+        },
+        "workspace_padding": {
+          "description": "Workspace padding (default: global)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "workspace_rules": {
+          "description": "Permanent workspace application rules",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/MatchingRule"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "WorkspaceLayer": {
+      "type": "string",
+      "enum": [
+        "Tiling",
+        "Floating"
       ]
     },
     "WorkspacesDisplayFormat": {


### PR DESCRIPTION
This is an attempt at a maybe low-level socket which could be helpful for a client connecting to komorebi.
It opens the ability to modify the data, but only needs one update, which means we only lock per display. 
This is good for people wanting to configure komorebi with a scripting language. They can create a state and only send one state to komorebi for applying, which should be faster than using the socket message available right now. 

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
