### PR TITLE
fix(cli): restart bar on replace-configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ dependencies = [
  "os_info",
  "parking_lot",
  "paste",
+ "powershell_script",
  "regex",
  "reqwest",
  "schemars",

--- a/komorebi-bar/src/widgets/komorebi.rs
+++ b/komorebi-bar/src/widgets/komorebi.rs
@@ -472,55 +472,25 @@ impl BarWidget for Komorebi {
                 for (name, location) in configuration_switcher.configurations.iter() {
                     let path = PathBuf::from(location);
                     if path.is_file() {
-                        config.apply_on_widget(false, ui,|ui|{
-                    if SelectableFrame::new(false).show(ui, |ui|{
-                          ui.add(Label::new(name).selectable(false))
-                            })
-                            .clicked()
-                        {
-                            let canonicalized = dunce::canonicalize(path.clone()).unwrap_or(path);
-                            let mut proceed = true;
-                            if komorebi_client::send_message(&SocketMessage::ReplaceConfiguration(
-                                canonicalized,
-                            ))
-                            .is_err()
+                        config.apply_on_widget(false, ui, |ui| {
+                            if SelectableFrame::new(false)
+                                .show(ui, |ui| ui.add(Label::new(name).selectable(false)))
+                                .clicked()
                             {
-                                tracing::error!(
-                                    "could not send message to komorebi: ReplaceConfiguration"
-                                );
-                                proceed = false;
-                            }
+                                let canonicalized =
+                                    dunce::canonicalize(path.clone()).unwrap_or(path);
 
-                            if let Some(rect) = komorebi_notification_state.work_area_offset {
-                                if proceed {
-                                    match komorebi_client::send_query(&SocketMessage::Query(
-                                        komorebi_client::StateQuery::FocusedMonitorIndex,
-                                    )) {
-                                        Ok(idx) => {
-                                            if let Ok(monitor_idx) = idx.parse::<usize>() {
-                                                if komorebi_client::send_message(
-                                                    &SocketMessage::MonitorWorkAreaOffset(
-                                                        monitor_idx,
-                                                        rect,
-                                                    ),
-                                                )
-                                                .is_err()
-                                                {
-                                                    tracing::error!(
-                                                    "could not send message to komorebi: MonitorWorkAreaOffset"
-                                                );
-                                                }
-                                            }
-                                        }
-                                        Err(_) => {
-                                            tracing::error!(
-                                                "could not send message to komorebi: Query"
-                                            );
-                                        }
-                                    }
+                                if komorebi_client::send_message(
+                                    &SocketMessage::ReplaceConfiguration(canonicalized),
+                                )
+                                .is_err()
+                                {
+                                    tracing::error!(
+                                        "could not send message to komorebi: ReplaceConfiguration"
+                                    );
                                 }
                             }
-                        }});
+                        });
                     }
                 }
             }

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -27,6 +27,7 @@ net2 = "0.2"
 os_info = "3.10"
 parking_lot = "0.12"
 paste = { workspace = true }
+powershell_script = "1.0"
 regex = "1"
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }


### PR DESCRIPTION
This commit ensures that the replace-configuration command also replaces bars.

Already running bars are stopped and new bars are started using the new configuration.