### PR TITLE
feat(wm): float placement configs

### DIFF
--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -457,10 +457,13 @@ impl Placement {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum,
+)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum MoveBehaviour {
     /// Swap the window container with the window container at the edge of the adjacent monitor
+    #[default]
     Swap,
     /// Insert the window container into the focused workspace on the adjacent monitor
     Insert,
@@ -468,12 +471,15 @@ pub enum MoveBehaviour {
     NoOp,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq)]
+#[derive(
+    Clone, Copy, Debug, Default, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq,
+)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum CrossBoundaryBehaviour {
     /// Attempt to perform actions across a workspace boundary
     Workspace,
     /// Attempt to perform actions across a monitor boundary
+    #[default]
     Monitor,
 }
 
@@ -488,10 +494,13 @@ pub enum HidingBehaviour {
     Cloak,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum)]
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum,
+)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum OperationBehaviour {
     /// Process komorebic commands on temporarily unmanaged/floated windows
+    #[default]
     Op,
     /// Ignore komorebic commands on temporarily unmanaged/floated windows
     NoOp,

--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -377,6 +377,21 @@ pub struct WindowManagementBehaviour {
     /// that can be later toggled to tiled, when false it will default to
     /// `current_behaviour` again.
     pub float_override: bool,
+    /// Determines if a new window should be spawned floating when on the floating layer and the
+    /// floating layer behaviour is set to float. This value is always calculated when checking for
+    /// the management behaviour on a specific workspace.
+    pub floating_layer_override: bool,
+    /// The floating layer behaviour to be used if the float override is being used
+    pub floating_layer_behaviour: FloatingLayerBehaviour,
+    /// The `Placement` to be used when toggling a window to float
+    pub toggle_float_placement: Placement,
+    /// The `Placement` to be used when spawning a window on the floating layer with the
+    /// `FloatingLayerBehaviour` set to `FloatingLayerBehaviour::Float`
+    pub floating_layer_placement: Placement,
+    /// The `Placement` to be used when spawning a window with float override active
+    pub float_override_placement: Placement,
+    /// The `Placement` to be used when spawning a window that matches a 'floating_applications' rule
+    pub float_rule_placement: Placement,
 }
 
 #[derive(
@@ -396,11 +411,50 @@ pub enum WindowContainerBehaviour {
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum FloatingLayerBehaviour {
-    /// Tile new windows (unless they match a float rule)
+    /// Tile new windows (unless they match a float rule or float override is active)
     #[default]
     Tile,
     /// Float new windows
     Float,
+}
+
+#[derive(
+    Clone, Copy, Debug, Default, Serialize, Deserialize, Display, EnumString, ValueEnum, PartialEq,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum Placement {
+    /// Does not change the size or position of the window
+    #[default]
+    None,
+    /// Center the window without changing the size
+    Center,
+    /// Center the window and resize it according to the `AspectRatio`
+    CenterAndResize,
+}
+
+impl FloatingLayerBehaviour {
+    pub fn should_float(&self) -> bool {
+        match self {
+            FloatingLayerBehaviour::Tile => false,
+            FloatingLayerBehaviour::Float => true,
+        }
+    }
+}
+
+impl Placement {
+    pub fn should_center(&self) -> bool {
+        match self {
+            Placement::None => false,
+            Placement::Center | Placement::CenterAndResize => true,
+        }
+    }
+
+    pub fn should_resize(&self) -> bool {
+        match self {
+            Placement::None | Placement::Center => false,
+            Placement::CenterAndResize => true,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Display, EnumString, ValueEnum)]

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1659,42 +1659,12 @@ impl StaticConfig {
 
         wm.enforce_workspace_rules()?;
 
-        if let Some(enabled) = value.border {
-            border_manager::BORDER_ENABLED.store(enabled, Ordering::SeqCst);
-        }
-
-        if let Some(val) = value.window_container_behaviour {
-            wm.window_management_behaviour.current_behaviour = val;
-        }
-
-        if let Some(val) = value.float_override {
-            wm.window_management_behaviour.float_override = val;
-        }
-
-        if let Some(val) = value.floating_layer_behaviour {
-            wm.window_management_behaviour.floating_layer_behaviour = val;
-        }
-
-        if let Some(val) = value.cross_monitor_move_behaviour {
-            wm.cross_monitor_move_behaviour = val;
-        }
-
-        if let Some(val) = value.cross_boundary_behaviour {
-            wm.cross_boundary_behaviour = val;
-        }
-
-        if let Some(val) = value.unmanaged_window_operation_behaviour {
-            wm.unmanaged_window_operation_behaviour = val;
-        }
-
-        if let Some(val) = value.resize_delta {
-            wm.resize_delta = val;
-        }
-
-        if let Some(val) = value.mouse_follows_focus {
-            wm.mouse_follows_focus = val;
-        }
-
+        border_manager::BORDER_ENABLED.store(value.border.unwrap_or(true), Ordering::SeqCst);
+        wm.window_management_behaviour.current_behaviour =
+            value.window_container_behaviour.unwrap_or_default();
+        wm.window_management_behaviour.float_override = value.float_override.unwrap_or_default();
+        wm.window_management_behaviour.floating_layer_behaviour =
+            value.floating_layer_behaviour.unwrap_or_default();
         wm.window_management_behaviour.toggle_float_placement = value
             .toggle_float_placement
             .unwrap_or(Placement::CenterAndResize);
@@ -1704,17 +1674,23 @@ impl StaticConfig {
             value.float_override_placement.unwrap_or(Placement::None);
         wm.window_management_behaviour.float_rule_placement =
             value.float_rule_placement.unwrap_or(Placement::None);
+        wm.cross_monitor_move_behaviour = value.cross_monitor_move_behaviour.unwrap_or_default();
+        wm.cross_boundary_behaviour = value.cross_boundary_behaviour.unwrap_or_default();
+        wm.unmanaged_window_operation_behaviour = value
+            .unmanaged_window_operation_behaviour
+            .unwrap_or_default();
+        wm.resize_delta = value.resize_delta.unwrap_or(50);
+        wm.mouse_follows_focus = value.mouse_follows_focus.unwrap_or(true);
         wm.work_area_offset = value.global_work_area_offset;
+        wm.focus_follows_mouse = value.focus_follows_mouse;
 
-        match value.focus_follows_mouse {
+        match wm.focus_follows_mouse {
             None => WindowsApi::disable_focus_follows_mouse()?,
             Some(FocusFollowsMouseImplementation::Windows) => {
                 WindowsApi::enable_focus_follows_mouse()?;
             }
             Some(FocusFollowsMouseImplementation::Komorebi) => {}
         };
-
-        wm.focus_follows_mouse = value.focus_follows_mouse;
 
         let monitor_count = wm.monitors().len();
 

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -411,12 +411,18 @@ impl Window {
         Ok(())
     }
 
-    pub fn center(&mut self, work_area: &Rect) -> Result<()> {
-        let (aspect_ratio_width, aspect_ratio_height) = FLOATING_WINDOW_TOGGLE_ASPECT_RATIO
-            .lock()
-            .width_and_height();
-        let target_height = work_area.bottom / 2;
-        let target_width = (target_height * aspect_ratio_width) / aspect_ratio_height;
+    pub fn center(&mut self, work_area: &Rect, resize: bool) -> Result<()> {
+        let (target_width, target_height) = if resize {
+            let (aspect_ratio_width, aspect_ratio_height) = FLOATING_WINDOW_TOGGLE_ASPECT_RATIO
+                .lock()
+                .width_and_height();
+            let target_height = work_area.bottom / 2;
+            let target_width = (target_height * aspect_ratio_width) / aspect_ratio_height;
+            (target_width, target_height)
+        } else {
+            let current_rect = WindowsApi::window_rect(self.hwnd)?;
+            (current_rect.right, current_rect.bottom)
+        };
 
         let x = work_area.left + ((work_area.right - target_width) / 2);
         let y = work_area.top + ((work_area.bottom - target_height) / 2);

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -438,7 +438,7 @@ impl WindowManager {
             work_area_offset: None,
             window_management_behaviour: WindowManagementBehaviour::default(),
             cross_monitor_move_behaviour: MoveBehaviour::Swap,
-            cross_boundary_behaviour: CrossBoundaryBehaviour::Workspace,
+            cross_boundary_behaviour: CrossBoundaryBehaviour::Monitor,
             unmanaged_window_operation_behaviour: OperationBehaviour::Op,
             resize_delta: 50,
             focus_follows_mouse: None,


### PR DESCRIPTION
Since it has been asked, here it is! MOAR Configs! 😄 

This commit adds a few more options to combine with the `FloatingLayerBehaviour` which are the multiple situations placement options. Which are the following:
- `"toggle_float_placement"`: the placement to be used by a floating window when it is forced to float with the `toggle-float` command.
- `"floating_layer_placement"`: the placement to be used by a floating window when it is spawned on the floating layer and the user has the floating layer behaviour set to float.
- `"float_override_placement"`: the placement to be used by a window that is spawned when float override is active.
- `"float_rule_placement"`: the placement to be used by a window that matches a 'floating_applications' rule.

Each `Placement` can be one of the following types:
- `"None"`: windows are spawned wherever Windows positions them with whatever size they had. Komorebi does not change its size or position.
- `"Center"`: windows are centered without changing their size.
- `"CenterAndResize"`: windows are centered and resized according to the defined aspect ratio.

By default the placements are as follows:
- `"toggle_float_placement"`: `"CenterAndResize"`
- `"floating_layer_placement"`: `"Center"`
- `"float_override_placement"`: `"None"`
- `"float_rule_placement"`: `"None"`

This commit also adds the `floating_layer_behaviour` as a global config.

@LGUG2Z Let me know what you think about this and if we should change the defaults or not?

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
