### PR TITLE
refactor(animations): improve resize behaviour of apps

### DIFF
--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -41,6 +41,7 @@ use windows::Win32::Graphics::Gdi::MonitorFromPoint;
 use windows::Win32::Graphics::Gdi::MonitorFromWindow;
 use windows::Win32::Graphics::Gdi::Rectangle;
 use windows::Win32::Graphics::Gdi::RoundRect;
+use windows::Win32::Graphics::Gdi::UpdateWindow;
 use windows::Win32::Graphics::Gdi::HBRUSH;
 use windows::Win32::Graphics::Gdi::HDC;
 use windows::Win32::Graphics::Gdi::HMONITOR;
@@ -100,6 +101,7 @@ use windows::Win32::UI::WindowsAndMessaging::PostMessageW;
 use windows::Win32::UI::WindowsAndMessaging::RealGetWindowClassW;
 use windows::Win32::UI::WindowsAndMessaging::RegisterClassW;
 use windows::Win32::UI::WindowsAndMessaging::RegisterDeviceNotificationW;
+use windows::Win32::UI::WindowsAndMessaging::SendMessageW;
 use windows::Win32::UI::WindowsAndMessaging::SetCursorPos;
 use windows::Win32::UI::WindowsAndMessaging::SetForegroundWindow;
 use windows::Win32::UI::WindowsAndMessaging::SetLayeredWindowAttributes;
@@ -139,6 +141,8 @@ use windows::Win32::UI::WindowsAndMessaging::SYSTEM_PARAMETERS_INFO_ACTION;
 use windows::Win32::UI::WindowsAndMessaging::SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS;
 use windows::Win32::UI::WindowsAndMessaging::WINDOW_LONG_PTR_INDEX;
 use windows::Win32::UI::WindowsAndMessaging::WM_CLOSE;
+use windows::Win32::UI::WindowsAndMessaging::WM_ENTERSIZEMOVE;
+use windows::Win32::UI::WindowsAndMessaging::WM_EXITSIZEMOVE;
 use windows::Win32::UI::WindowsAndMessaging::WNDCLASSW;
 use windows::Win32::UI::WindowsAndMessaging::WNDENUMPROC;
 use windows::Win32::UI::WindowsAndMessaging::WS_DISABLED;
@@ -1358,6 +1362,24 @@ impl WindowsApi {
     pub fn invalidate_rect(hwnd: isize, rect: Option<&Rect>, erase: bool) -> bool {
         let rect = rect.map(|rect| &rect.rect() as *const RECT);
         unsafe { InvalidateRect(Option::from(HWND(as_ptr!(hwnd))), rect, erase) }.as_bool()
+    }
+
+    pub fn send_enter_size_move(hwnd: isize) -> Result<()> {
+        unsafe {
+            SendMessageW(HWND(as_ptr!(hwnd)), WM_ENTERSIZEMOVE, None, None);
+            Ok(())
+        }
+    }
+
+    pub fn send_exit_size_move(hwnd: isize) -> Result<()> {
+        unsafe {
+            SendMessageW(HWND(as_ptr!(hwnd)), WM_EXITSIZEMOVE, None, None);
+            Ok(())
+        }
+    }
+
+    pub fn update_window(hwnd: isize) -> bool {
+        unsafe { UpdateWindow(HWND(as_ptr!(hwnd))) }.as_bool()
     }
 
     pub fn alt_is_pressed() -> bool {


### PR DESCRIPTION
This commit improves move windows animation by adding win32 api calls to force app to rerender window after each frame 