### PR TITLE
feat(wm): floating over monocle

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -500,7 +500,11 @@ impl WindowManager {
                                 }
                             }
 
-                            if !monocle_window_event && monocle_container.is_some() {
+                            let workspace = self.focused_workspace()?;
+                            if !(monocle_window_event
+                                || workspace.layer() != &WorkspaceLayer::Tiling)
+                                && monocle_container.is_some()
+                            {
                                 window.hide();
                             }
                         }


### PR DESCRIPTION
Allows for having floating windows on the "Floating Layer" over a monocle. When toggling back to the tiling layer it hides the floating windows again.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
