### PR TITLE
feat(wm): add the ability to set work-area-offset per workspace

### DIFF
--- a/komorebi/src/core/mod.rs
+++ b/komorebi/src/core/mod.rs
@@ -202,6 +202,7 @@ pub enum SocketMessage {
     StackbarFontFamily(Option<String>),
     WorkAreaOffset(Rect),
     MonitorWorkAreaOffset(usize, Rect),
+    WorkspaceWorkAreaOffset(usize, usize, Rect),
     ToggleWindowBasedWorkAreaOffset,
     ResizeDelta(i32),
     InitialWorkspaceRule(ApplicationIdentifier, String, usize, usize),

--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -1886,6 +1886,14 @@ if (!(Get-Process komorebi-bar -ErrorAction SilentlyContinue))
                     self.retile_all(false)?;
                 }
             }
+            SocketMessage::WorkspaceWorkAreaOffset(monitor_idx, workspace_idx, rect) => {
+                if let Some(monitor) = self.monitors_mut().get_mut(monitor_idx) {
+                    if let Some(workspace) = monitor.workspaces_mut().get_mut(workspace_idx) {
+                        workspace.set_work_area_offset(Option::from(rect));
+                        self.retile_all(false)?
+                    }
+                }
+            }
             SocketMessage::ToggleWindowBasedWorkAreaOffset => {
                 let workspace = self.focused_workspace_mut()?;
                 workspace.set_apply_window_based_work_area_offset(

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -218,6 +218,9 @@ pub struct WorkspaceConfig {
     /// Permanent workspace application rules
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_rules: Option<Vec<MatchingRule>>,
+    /// Workspace specific work area offset (default: None)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_area_offset: Option<Rect>,
     /// Apply this monitor's window-based work area offset (default: true)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub apply_window_based_work_area_offset: Option<bool>,
@@ -310,6 +313,7 @@ impl From<&Workspace> for WorkspaceConfig {
                 .workspace_config()
                 .as_ref()
                 .and_then(|c| c.workspace_rules.clone()),
+            work_area_offset: value.work_area_offset(),
             apply_window_based_work_area_offset: Some(value.apply_window_based_work_area_offset()),
             window_container_behaviour: *value.window_container_behaviour(),
             window_container_behaviour_rules: Option::from(window_container_behaviour_rules),

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -337,6 +337,7 @@ impl From<&WindowManager> for State {
                             latest_layout: workspace.latest_layout.clone(),
                             resize_dimensions: workspace.resize_dimensions.clone(),
                             tile: workspace.tile,
+                            work_area_offset: workspace.work_area_offset,
                             apply_window_based_work_area_offset: workspace
                                 .apply_window_based_work_area_offset,
                             window_container_behaviour: workspace.window_container_behaviour,

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -87,6 +87,8 @@ pub struct Workspace {
     #[getset(get = "pub", set = "pub")]
     pub tile: bool,
     #[getset(get_copy = "pub", set = "pub")]
+    pub work_area_offset: Option<Rect>,
+    #[getset(get_copy = "pub", set = "pub")]
     pub apply_window_based_work_area_offset: bool,
     #[getset(get = "pub", get_mut = "pub", set = "pub")]
     pub window_container_behaviour: Option<WindowContainerBehaviour>,
@@ -147,6 +149,7 @@ impl Default for Workspace {
             latest_layout: vec![],
             resize_dimensions: vec![],
             tile: true,
+            work_area_offset: None,
             apply_window_based_work_area_offset: true,
             window_container_behaviour: None,
             window_container_behaviour_rules: None,
@@ -240,6 +243,8 @@ impl Workspace {
             self.tile = true;
             self.set_layout_rules(all_layout_rules);
         }
+
+        self.set_work_area_offset(config.work_area_offset);
 
         self.set_apply_window_based_work_area_offset(
             config.apply_window_based_work_area_offset.unwrap_or(true),
@@ -496,7 +501,7 @@ impl Workspace {
         let border_width = self.globals().border_width;
         let border_offset = self.globals().border_offset;
         let work_area = self.globals().work_area;
-        let work_area_offset = self.globals().work_area_offset;
+        let work_area_offset = self.work_area_offset().or(self.globals().work_area_offset);
         let window_based_work_area_offset = self.globals().window_based_work_area_offset;
         let window_based_work_area_offset_limit =
             self.globals().window_based_work_area_offset_limit;

--- a/komorebic.lib.ahk
+++ b/komorebic.lib.ahk
@@ -184,6 +184,10 @@ MonitorWorkAreaOffset(monitor, left, top, right, bottom) {
     RunWait("komorebic.exe monitor-work-area-offset " monitor " " left " " top " " right " " bottom, , "Hide")
 }
 
+WorkspaceWorkAreaOffset(monitor, workspace, left, top, right, bottom) {
+    RunWait("komorebic.exe workspace-work-area-offset " monitor " "workspace" " left " " top " " right " " bottom, , "Hide")
+}
+
 AdjustContainerPadding(sizing, adjustment) {
     RunWait("komorebic.exe adjust-container-padding " sizing " " adjustment, , "Hide")
 }

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -429,6 +429,22 @@ struct MonitorWorkAreaOffset {
 }
 
 #[derive(Parser)]
+struct WorkspaceWorkAreaOffset {
+    /// Monitor index (zero-indexed)
+    monitor: usize,
+    /// Workspace index (zero-indexed)
+    workspace: usize,
+    /// Size of the left work area offset (set right to left * 2 to maintain right padding)
+    left: i32,
+    /// Size of the top work area offset (set bottom to the same value to maintain bottom padding)
+    top: i32,
+    /// Size of the right work area offset
+    right: i32,
+    /// Size of the bottom work area offset
+    bottom: i32,
+}
+
+#[derive(Parser)]
 struct MonitorIndexPreference {
     /// Preferred monitor index (zero-indexed)
     index_preference: usize,
@@ -1188,6 +1204,9 @@ enum SubCommand {
     /// Set offsets for a monitor to exclude parts of the work area from tiling
     #[clap(arg_required_else_help = true)]
     MonitorWorkAreaOffset(MonitorWorkAreaOffset),
+    /// Set offsets for a workspace to exclude parts of the work area from tiling
+    #[clap(arg_required_else_help = true)]
+    WorkspaceWorkAreaOffset(WorkspaceWorkAreaOffset),
     /// Toggle application of the window-based work area offset for the focused workspace
     ToggleWindowBasedWorkAreaOffset,
     /// Set container padding on the focused workspace
@@ -1938,6 +1957,20 @@ fn main() -> Result<()> {
                 bottom: arg.bottom,
             }))?;
         }
+
+        SubCommand::WorkspaceWorkAreaOffset(arg) => {
+            send_message(&SocketMessage::WorkspaceWorkAreaOffset(
+                arg.monitor,
+                arg.workspace,
+                Rect {
+                    left: arg.left,
+                    top: arg.top,
+                    right: arg.right,
+                    bottom: arg.bottom,
+                },
+            ))?;
+        }
+
         SubCommand::ToggleWindowBasedWorkAreaOffset => {
             send_message(&SocketMessage::ToggleWindowBasedWorkAreaOffset)?;
         }


### PR DESCRIPTION
This commit adds the option to set 'work_area_offset' per workspace. If no workspace work area offset is set for that workspace it will instead use the value of the globals.work_area_offset for that workspace.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
