### PR TITLE
fix(wm): notify subscribers on floating window focus change (update the focus index of floating windows)

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -346,6 +346,7 @@ impl WindowManager {
                     Some(idx) => {
                         if let Some(_window) = workspace.floating_windows().get(idx) {
                             workspace.set_layer(WorkspaceLayer::Floating);
+                            workspace.floating_windows.focus(idx);
                         }
                     }
                 }


### PR DESCRIPTION
**Issue discovered during testing #1465:**

When more than two floating windows are present, switching focus between floating windows does not update the Komorebi bar status - meaning the bar keeps showing the previously focused floating window as active, instead of updating to the new focused window.

**Root cause:**

We did not notify subscribers about floating window focus changes, because the current focused floating window index in the workspace was not updated on focus change, so `has_been_modified` didn’t detect a state change.

The PR adds code to update the focused floating window in the current workspace before notifying subscribers. As a result, notifications about floating window focus changes are now correctly sent to all subscribers, and the Komorebi bar updates as expected.

## How to reproduce (before fix):
- Open 2+ floating windows.
- Switch focus between them.
- Notice that the Komorebi bar does not reflect the focus change.


https://github.com/user-attachments/assets/e1641b57-dd5d-44ea-8c72-1d7a60f1480d

## How to test (after fix):
- Repeat the steps above: the Komorebi bar now updates when focus changes between floating windows.


