### PR TITLE
refactor(container + bm): use `Arc<str>` and `WsElementId` for Workspace Element IDs

### DIFF
--- a/komorebi/src/border_manager/border.rs
+++ b/komorebi/src/border_manager/border.rs
@@ -1,6 +1,7 @@
 use crate::border_manager::window_kind_colour;
 use crate::border_manager::RenderTarget;
 use crate::border_manager::WindowKind;
+use crate::border_manager::WsElementId;
 use crate::border_manager::BORDER_OFFSET;
 use crate::border_manager::BORDER_WIDTH;
 use crate::border_manager::STYLE;
@@ -114,7 +115,7 @@ pub extern "system" fn border_hwnds(hwnd: HWND, lparam: LPARAM) -> BOOL {
 #[derive(Debug, Clone)]
 pub struct Border {
     pub hwnd: isize,
-    pub id: String,
+    pub id: WsElementId,
     pub monitor_idx: Option<usize>,
     pub render_target: Option<RenderTarget>,
     pub tracking_hwnd: isize,
@@ -132,7 +133,7 @@ impl From<isize> for Border {
     fn from(value: isize) -> Self {
         Self {
             hwnd: value,
-            id: String::new(),
+            id: WsElementId::from(value),
             monitor_idx: None,
             render_target: None,
             tracking_hwnd: 0,
@@ -154,7 +155,7 @@ impl Border {
     }
 
     pub fn create(
-        id: &str,
+        id: &WsElementId,
         tracking_hwnd: isize,
         monitor_idx: usize,
     ) -> color_eyre::Result<Box<Self>> {
@@ -176,7 +177,7 @@ impl Border {
         let (border_sender, border_receiver) = mpsc::channel();
 
         let instance = h_module.0 as isize;
-        let container_id = id.to_owned();
+        let container_id = id.clone();
         std::thread::spawn(move || -> color_eyre::Result<()> {
             let mut border = Self {
                 hwnd: 0,

--- a/komorebi/src/stackbar_manager/mod.rs
+++ b/komorebi/src/stackbar_manager/mod.rs
@@ -34,9 +34,9 @@ pub static STACKBAR_MODE: AtomicCell<StackbarMode> = AtomicCell::new(StackbarMod
 pub static STACKBAR_TEMPORARILY_DISABLED: AtomicBool = AtomicBool::new(false);
 
 lazy_static! {
-    pub static ref STACKBAR_STATE: Mutex<HashMap<String, Stackbar>> = Mutex::new(HashMap::new());
+    pub static ref STACKBAR_STATE: Mutex<HashMap<Arc<str>, Stackbar>> = Mutex::new(HashMap::new());
     pub static ref STACKBAR_FONT_FAMILY: Mutex<Option<String>> = Mutex::new(None);
-    static ref STACKBARS_MONITORS: Mutex<HashMap<String, usize>> = Mutex::new(HashMap::new());
+    static ref STACKBARS_MONITORS: Mutex<HashMap<Arc<str>, usize>> = Mutex::new(HashMap::new());
     static ref STACKBARS_CONTAINERS: Mutex<HashMap<isize, Container>> = Mutex::new(HashMap::new());
 }
 


### PR DESCRIPTION
This pull request switches to `Arc<str>` for container IDs and replaces plain strings with the `WsElementId` enum for workspace elements in the `Border` structure.

## Motivation

- Replacing `String` with `Arc<str>` for container IDs makes all cloning cheap.
- The `WsElementId` enum eliminates heap allocation for floating window IDs in the `Border` structure.

## Benefits

- Lower memory usage and faster cloning of container/workspace state.
- Stricter type checks to ensure correctness.
- Cleaner API.

## Notes

Deserialization from legacy JSON (string IDs) is preserved by custom (de)serializers.