### PR TITLE
feat(shortcuts): show all hotkey bindings and improve UI

### DIFF
--- a/komorebi-shortcuts/src/main.rs
+++ b/komorebi-shortcuts/src/main.rs
@@ -58,21 +58,19 @@ impl eframe::App for Quicklook {
                             ui.label("Filter");
                             ui.add(
                                 eframe::egui::text_edit::TextEdit::singleline(&mut self.filter)
+                                    .hint_text("Filter by command...")
                                     .background_color(ctx.style().visuals.faint_bg_color),
                             );
                             ui.end_row();
-                            ui.end_row();
 
                             for binding in &whkdrc.bindings {
-                                if is_komorebic_binding(binding) {
-                                    let keys = binding.keys.join(" + ");
-                                    if self.filter.is_empty()
-                                        || binding.command.contains(&self.filter)
-                                    {
-                                        ui.label(keys);
-                                        ui.label(&binding.command);
-                                        ui.end_row();
-                                    }
+                                let keys = binding.keys.join(" + ");
+                                if self.filter.is_empty() 
+                                    || binding.command.contains(&self.filter) 
+                                {
+                                    ui.label(keys);
+                                    ui.label(&binding.command);
+                                    ui.end_row();
                                 }
                             }
                         }
@@ -99,8 +97,4 @@ fn main() {
         Box::new(|cc| Ok(Box::new(Quicklook::new(cc)))),
     )
     .unwrap();
-}
-
-fn is_komorebic_binding(binding: &HotkeyBinding) -> bool {
-    binding.command.starts_with("komorebic")
 }


### PR DESCRIPTION
- Removed command filtering logic from the shortcuts UI.
- All hotkey bindings are now shown regardless of command.
- Improved UI with hint text for the filter input.