### PR TITLE
Add compile time optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "komorebic-no-console",
     "komorebi-bar",
     "komorebi-themes",
-    "komorebi-shortcuts"
+    "komorebi-shortcuts",
 ]
 
 [workspace.dependencies]
@@ -52,7 +52,7 @@ features = [
     "Win32_Devices",
     "Win32_Devices_Display",
     "Win32_System_Com",
-    "Win32_UI_Shell_Common", # for IObjectArray
+    "Win32_UI_Shell_Common",           # for IObjectArray
     "Win32_Foundation",
     "Win32_Globalization",
     "Win32_Graphics_Dwm",
@@ -73,10 +73,10 @@ features = [
     "Win32_System_SystemServices",
     "Win32_System_WindowsProgramming",
     "Media",
-    "Media_Control"
+    "Media_Control",
 ]
 
-[profile.release]
+[profile.release-opt]
 lto = true
 panic = "abort"
 codegen-units = 1


### PR DESCRIPTION
This enables a few more compile time optimizations, and I don't think it increases compile time too much. On my i3 laptop, it actually compiled faster with these optimizations enabled (yes, I did a clean build with and without these optimizations for comparison). Though, results may vary.

This results in binary size reduction and performance gains for free.