### PR TITLE
feat(wm): add config option to set tiling

### DIFF
--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -230,6 +230,9 @@ pub struct WorkspaceConfig {
     /// Enable or disable float override, which makes it so every new window opens in floating mode (default: false)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub float_override: Option<bool>,
+    /// Enable or disable tiling for the workspace (default: true)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tile: Option<bool>,
     /// Specify an axis on which to flip the selected layout (default: None)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layout_flip: Option<Axis>,
@@ -278,6 +281,8 @@ impl From<&Workspace> for WorkspaceConfig {
             }
         });
 
+        let tile = if *value.tile() { None } else { Some(false) };
+
         Self {
             name: value
                 .name()
@@ -314,6 +319,7 @@ impl From<&Workspace> for WorkspaceConfig {
             window_container_behaviour: *value.window_container_behaviour(),
             window_container_behaviour_rules: Option::from(window_container_behaviour_rules),
             float_override: *value.float_override(),
+            tile,
             layout_flip: value.layout_flip(),
             floating_layer_behaviour: value.floating_layer_behaviour(),
             wallpaper: None,

--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -205,18 +205,16 @@ impl Workspace {
 
         if let Some(layout) = &config.layout {
             self.layout = Layout::Default(*layout);
-            self.tile = true;
         }
 
         if let Some(pathbuf) = &config.custom_layout {
             let layout = CustomLayout::from_path(pathbuf)?;
             self.layout = Layout::Custom(layout);
-            self.tile = true;
         }
 
-        if config.custom_layout.is_none() && config.layout.is_none() {
-            self.tile = false;
-        }
+        self.tile =
+            !(config.custom_layout.is_none() && config.layout.is_none() && config.tile.is_none()
+                || config.tile.is_some_and(|tile| !tile));
 
         let mut all_layout_rules = vec![];
         if let Some(layout_rules) = &config.layout_rules {


### PR DESCRIPTION
This commit adds the option to set whether a workspace should be tiled or not by default. It retains the default behaviour of komorebi, but adds the option to set a workspace to not be tiled by default, but still be able to change the default layout for that workspace.

|  | tile set | tile not set |
| --- | --- | --- |
| layout set | layout.val, tile.val | layout.val, true |
| layout not set| BSP, tile.val | BSP, false |