### PR TITLE
docs/cli: Fix typo in the toggle-pause

### DIFF
--- a/docs/cli/toggle-pause.md
+++ b/docs/cli/toggle-pause.md
@@ -1,7 +1,7 @@
 # toggle-pause
 
 ```
-Toggle window tiling on the focused workspace
+Toggle the paused state for all window tiling
 
 Usage: komorebic.exe toggle-pause
 


### PR DESCRIPTION
I wasn't able to find any issue/pr about this so I created one, lmk if this already exists.

There was a small typo in docs, I just changed it nothing more, probably a small copy/paste mistake.