### PR TITLE
feat(wm): implement Clone for State, Notification and NotificationEvent

### DIFF
--- a/komorebi/src/lib.rs
+++ b/komorebi/src/lib.rs
@@ -306,7 +306,7 @@ pub fn current_virtual_desktop() -> Option<Vec<u8>> {
     current
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum NotificationEvent {
@@ -323,7 +323,7 @@ pub enum VirtualDesktopNotification {
     LeftAssociatedVirtualDesktop,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Notification {
     pub event: NotificationEvent,

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -126,7 +126,7 @@ pub struct WindowManager {
 }
 
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct State {
     pub monitors: Ring<Monitor>,


### PR DESCRIPTION
This implements Clone for State, Notification and NotificationEvent to allow for the use of these types in Rhai scripts.
