### PR TITLE
fix(wm): promoting a container shouldn't change their sizes

### DIFF
--- a/komorebi/src/workspace.rs
+++ b/komorebi/src/workspace.rs
@@ -825,9 +825,10 @@ impl Workspace {
     }
 
     pub fn promote_container(&mut self) -> eyre::Result<()> {
-        let resize = self.resize_dimensions.remove(0);
+        let focused_idx = self.focused_container_idx();
         let container = self
-            .remove_focused_container()
+            .containers_mut()
+            .remove_respecting_locks(focused_idx)
             .ok_or_eyre("there is no container")?;
 
         let primary_idx = match &self.layout {
@@ -839,9 +840,10 @@ impl Workspace {
             ),
         };
 
-        let insertion_idx = self.insert_container_at_idx(primary_idx, container);
-        self.resize_dimensions[insertion_idx] = resize;
-        self.focus_container(primary_idx);
+        let insertion_idx = self
+            .containers_mut()
+            .insert_respecting_locks(primary_idx, container);
+        self.focus_container(insertion_idx);
 
         Ok(())
     }


### PR DESCRIPTION
- When promoting a container it is using the `remove_focused_container()` and `insert_container_at_idx` functions which will remove the focused container size from `resize_dimensions` and then add the new container with size `None`. Then it was adding the previously stored size of the main container back to the first one. However this would result in at least 3 issues:
    1. We were removing the size from index 0, however when inserting it back on the primary_idx we might not add it to index 0, specially now that there could be locked containers so if container 0 is locked we would be adding it to the next container, which would result in the main container having no size information which would result in a recalculation on the next update and it would revert back to default, so if a user had resized their containers that information would be lost.
    2. We were removing the size from index 0. Then on `remove_focused_container` it would remove the size from the focused container index, but since we had already removed one size from the `resize_dimensions` that index would no longer match the actual focused container, so once again we would be losing information.
    3. Since we were removing the size of the focused container idx from `resize_dimensions` (albeit the wrong one as stated above), this would mean that the container that moved to that position would have no resize information so it would show up as if the main container was taking up half width of the area, ignoring any user resize, until the next workspace update was triggered.
- This commit completely ignores the `resize_dimensions` since promoting a container simply means moving one container from one position to the main one (usually index 0) and then shift all the rest to the "right". The existing `resize_dimensions` should be kept untouched. To do this we use the functions `remove_respecting_locks` and `insert_respecting_locks` on the containers themselves, which simply move the container and shifts the others which is precisely what we want.

This PR was a result of this conversation on discord: https://discord.com/channels/898554690126630914/1440500893782114455

BTW @LGUG2Z, this left me wondering should the `promote_container` obey the locked containers?! As far as I understood the main reasoning being the locked containers was so that you could keep some container in place even when adding new containers/windows that would otherwise move it, however when you use the `komorebic promote` command it is because you _**want**_ to move the focused container into the "main spot", however if that was locked that won't happen, it will move it to the next one... Is this the intended behavior? I personally am totally fine with leaving it as is, since if you locked the main container it is probably because you _**really**_ don't want it to be moved, otherwise I don't see the need to lock the main container since new windows should never move that one.

<!--
  Please follow the Conventional Commits specification.

  If you need to update your PR with changes from `master`, please run `git rebase master`.

  By opening this PR, you confirm that you have read and understood this project's `CONTRIBUTING.md`.
-->
