### PR TITLE
fix(border): release resources before destroying window

### DIFF
--- a/komorebi/src/border_manager/border.rs
+++ b/komorebi/src/border_manager/border.rs
@@ -548,7 +548,12 @@ impl Border {
                     LRESULT(0)
                 }
                 WM_DESTROY => {
-                    SetWindowLongPtrW(window, GWLP_USERDATA, 0);
+                    let border_pointer: *mut Border = GetWindowLongPtrW(window, GWLP_USERDATA) as _;
+                    if !border_pointer.is_null() {
+                        (*border_pointer).render_target = None;
+                        (*border_pointer).brushes.clear();
+                        SetWindowLongPtrW(window, GWLP_USERDATA, 0);
+                    }
                     PostQuitMessage(0);
                     LRESULT(0)
                 }

--- a/komorebi/src/border_manager/mod.rs
+++ b/komorebi/src/border_manager/mod.rs
@@ -767,12 +767,6 @@ fn remove_border(
 fn destroy_border(border: Box<Border>) -> color_eyre::Result<()> {
     let raw_pointer = Box::into_raw(border);
     unsafe {
-        // release d2d resources **BEFORE** destroying window
-        // this drops render_target and brushes while HWND is still valid
-        // prevents EndDraw() from accessing freed HWND resources
-        (*raw_pointer).render_target = None;
-        (*raw_pointer).brushes.clear();
-
         // Now safe to destroy window
         (*raw_pointer).destroy()?;
     }


### PR DESCRIPTION
This PR add two‑layer shutdown for border windows
We invalidate the window user-pointer on close, and defer Direct2D resource release to WM_DESTROY on the window thread. Should hopefully also prevent use‑after‑free and cross‑thread COM release crashes.

Since commit bdef1448e1b1ec73b8928ce7ad1c4fe1e55b3cc5 I started encountering crashes with exception 0xc000041d, whereas I did not before it. So I just started trying out things to see what helped.

Could you (@LGUG2Z) maybe see if you can reproduce your crashes with this PR? On my end, it stopped crashing, but that's just a sample size of one that didn't encounter issues beforehand, so it's hard to tell for me if this proposal is actually helpful in your case, too, or if it just ends up reintroducing the previous behavior. 😓 

For reference, this was reported in the following discord thread: https://discord.com/channels/898554690126630914/1459645640362426572/1461475346514710722