### PR TITLE
fix(wm): cloak off-screen windows in scrolling layout on multi-monito…

### DIFF
--- a/komorebi/src/lib.rs
+++ b/komorebi/src/lib.rs
@@ -35,6 +35,7 @@ pub mod workspace;
 use lazy_static::lazy_static;
 use monitor_reconciliator::MonitorNotification;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::Write;
@@ -80,6 +81,8 @@ use winreg::enums::HKEY_CURRENT_USER;
 
 lazy_static! {
     static ref HIDDEN_HWNDS: Arc<Mutex<Vec<isize>>> = Arc::new(Mutex::new(vec![]));
+    pub static ref SCROLLING_CLOAKED_HWNDS: Arc<Mutex<HashSet<isize>>> = Arc::new(Mutex::new(HashSet::new()));
+
     static ref LAYERED_WHITELIST: Arc<Mutex<Vec<MatchingRule>>> = Arc::new(Mutex::new(vec![
         MatchingRule::Simple(IdWithIdentifier {
             kind: ApplicationIdentifier::Exe,

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1344,8 +1344,6 @@ impl StaticConfig {
         workspace_matching_rules.clear();
         drop(workspace_matching_rules);
 
-        let monitor_count = wm.monitors().len();
-
         let offset = wm.work_area_offset;
         for (i, monitor) in wm.monitors_mut().iter_mut().enumerate() {
             let preferred_config_idx = {
@@ -1394,15 +1392,6 @@ impl StaticConfig {
                 monitor.update_workspaces_globals(offset);
                 for (j, ws) in monitor.workspaces_mut().iter_mut().enumerate() {
                     if let Some(workspace_config) = monitor_config.workspaces.get_mut(j) {
-                        if monitor_count > 1
-                            && matches!(workspace_config.layout, Some(DefaultLayout::Scrolling))
-                        {
-                            tracing::warn!(
-                                "scrolling layout is only supported for a single monitor; falling back to columns layout"
-                            );
-                            workspace_config.layout = Some(DefaultLayout::Columns);
-                        }
-
                         ws.load_static_config(workspace_config)?;
                     }
                 }

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -3170,15 +3170,7 @@ impl WindowManager {
     pub fn change_workspace_layout_default(&mut self, layout: DefaultLayout) -> eyre::Result<()> {
         tracing::info!("changing layout");
 
-        let monitor_count = self.monitors().len();
         let workspace = self.focused_workspace_mut()?;
-
-        if monitor_count > 1 && matches!(layout, DefaultLayout::Scrolling) {
-            tracing::warn!(
-                "scrolling layout is only supported for a single monitor; not changing layout"
-            );
-            return Ok(());
-        }
 
         match &workspace.layout {
             Layout::Default(_) => {}


### PR DESCRIPTION
> This is an experimental approach to the scrolling layout behaviour on multiple monitor setups. Feedback is appreciated

…r setups

The scrolling layout calculates positions for all windows including those outside the visible viewport. On multi-monitor setups, off-screen windows would overflow onto adjacent monitors because there was no boundary enforcement in the positioning pipeline.

This adds DWM cloaking to off-screen windows during the workspace update. When the layout is calculated, each container is checked for horizontal intersection with the work area. Containers outside the visible region are cloaked and have their borders hidden, while containers that scroll back into view are uncloaked and repositioned normally. A global tracking set is used to manage the cloaked window handles, and the resulting ObjectUncloaked WinEvents are consumed in the event handler to prevent re-management of those windows.

The multi-monitor restriction that previously forced the scrolling layout to fall back to columns has been removed, both at config load time and at runtime layout changes, since the cloaking mechanism now handles the overflow correctly.
