### PR TITLE
feat: workspace switch animation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
  "clipboard-win",
  "image 0.25.9",
  "log",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -430,7 +430,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -461,7 +461,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "event-listener",
  "futures-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -487,7 +487,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "futures-core",
  "futures-io",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -755,7 +755,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -864,7 +864,7 @@ checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
  "bitflags 2.11.0",
  "polling",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "slab",
  "tracing",
 ]
@@ -888,7 +888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
  "calloop 0.14.4",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-client",
 ]
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -1502,14 +1502,14 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]
@@ -2276,7 +2276,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -2409,7 +2409,7 @@ dependencies = [
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "libloading",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
@@ -3112,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.87"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3180,7 +3180,9 @@ dependencies = [
  "which",
  "win32-display-data",
  "windows 0.62.2",
+ "windows-capture",
  "windows-core 0.62.2",
+ "windows-future 0.3.2",
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
  "windows-numerics 0.3.1",
@@ -3419,14 +3421,14 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "redox_syscall 0.7.2",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.23"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
 dependencies = [
  "cc",
  "libc",
@@ -3448,9 +3450,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -4134,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -4164,7 +4166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
  "bitflags 2.11.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation 0.3.1",
@@ -4190,7 +4192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17614fdcd9b411e6ff1117dfb1d0150f908ba83a7df81b1f118005fe0a8ea15d"
 dependencies = [
  "bitflags 2.11.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.1",
 ]
 
@@ -4223,7 +4225,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291fbbf7d29287518e8686417cf7239c74700fd4b607623140a7d4a3c834329d"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.1",
 ]
 
@@ -4237,7 +4239,7 @@ dependencies = [
  "block2 0.6.2",
  "dispatch2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -4248,7 +4250,7 @@ checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -4271,7 +4273,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b3dc0cc4386b6ccf21c157591b34a7f44c8e75b064f85502901ab2188c007e"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.1",
 ]
 
@@ -4293,7 +4295,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac0f75792558aa9d618443bbb5db7426a7a0b6fddf96903f86ef9ad02e135740"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.1",
 ]
 
@@ -4325,7 +4327,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -4346,7 +4348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
 dependencies = [
  "bitflags 2.11.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -4394,7 +4396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ffb6a0cd5f182dc964334388560b12a57f7b74b3e2dec5e2722aa2dfb2ccd5"
 dependencies = [
  "bitflags 2.11.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
 ]
@@ -4406,7 +4408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1f8e0ef3ab66b08c42644dcb34dba6ec0a574bbd8adbb8bdbdc7a2779731a44"
 dependencies = [
  "bitflags 2.11.0",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -4429,7 +4431,7 @@ dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
  "libc",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-security",
 ]
@@ -4463,7 +4465,7 @@ checksum = "25b1312ad7bc8a0e92adae17aa10f90aae1fb618832f9b993b022b591027daed"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-cloud-kit 0.3.1",
  "objc2-core-data 0.3.1",
  "objc2-core-foundation",
@@ -4505,7 +4507,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3f5ec77a81d9e0c5a0b32159b0cb143d7086165e79708351e02bf37dfc65cd"
 dependencies = [
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.1",
 ]
 
@@ -4629,7 +4631,7 @@ dependencies = [
  "android_system_properties",
  "log",
  "nix",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.1",
  "objc2-ui-kit 0.3.1",
  "serde",
@@ -4647,9 +4649,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "palette"
@@ -4947,7 +4949,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5345,9 +5347,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5419,9 +5421,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "renderdoc-sys"
@@ -5473,9 +5475,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
 ]
@@ -5542,22 +5544,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -5814,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64",
  "chrono",
@@ -5833,9 +5835,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6048,7 +6050,7 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "thiserror 2.0.18",
  "wayland-backend",
  "wayland-client",
@@ -6307,14 +6309,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6333,7 +6335,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 
@@ -6948,9 +6950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.110"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -6961,9 +6963,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.60"
+version = "0.4.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
 dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
@@ -6975,9 +6977,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.110"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6985,9 +6987,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.110"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6998,9 +7000,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.110"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]
@@ -7047,7 +7049,7 @@ checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -7060,7 +7062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
 dependencies = [
  "bitflags 2.11.0",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7082,7 +7084,7 @@ version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5864c4b5b6064b06b1e8b74ead4a98a6c45a285fe7a0e784d24735f011fdb078"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "wayland-client",
  "xcursor",
 ]
@@ -7176,9 +7178,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.87"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7204,7 +7206,7 @@ dependencies = [
  "jni",
  "log",
  "ndk-context",
- "objc2 0.6.3",
+ "objc2 0.6.4",
  "objc2-foundation 0.3.1",
  "url",
  "web-sys",
@@ -7374,7 +7376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "winsafe",
 ]
 
@@ -7502,6 +7504,19 @@ dependencies = [
  "windows-core 0.62.2",
  "windows-future 0.3.2",
  "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-capture"
+version = "2.0.0-alpha.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dcd037f0a621bbbb3d6a6b895ddd5b0d691b008b2f9d6980e2d367b16ab5bf6"
+dependencies = [
+ "parking_lot",
+ "rayon",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+ "windows-future 0.3.2",
 ]
 
 [[package]]
@@ -8387,7 +8402,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -8468,9 +8483,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.13.2"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -8488,7 +8503,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
@@ -8527,9 +8542,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.13.2"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8690,9 +8705,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.9.2"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
 dependencies = [
  "endi",
  "enumflags2",
@@ -8704,9 +8719,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.9.2"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ which = "8"
 version = "0.62"
 features = [
   "Foundation_Numerics",
+    "Graphics_Capture",
+    "Graphics_DirectX_Direct3D11",
   "Win32_Devices",
   "Win32_Devices_Display",
   "Win32_System_Com",
@@ -61,6 +63,12 @@ features = [
   "Win32_Graphics_Direct2D",
   "Win32_Graphics_Direct2D_Common",
   "Win32_Graphics_Dxgi_Common",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Direct3D",
+    "Win32_Graphics_Direct3D11",
+    "Win32_System_WinRT_Direct3D11",
+    "Win32_System_WinRT_Graphics_Capture",
+        "Win32_Graphics_DirectComposition",
   "Win32_System_LibraryLoader",
   "Win32_System_Power",
   "Win32_System_RemoteDesktop",

--- a/komorebi/Cargo.toml
+++ b/komorebi/Cargo.toml
@@ -53,6 +53,8 @@ windows-interface = { workspace = true }
 winput = "0.2"
 winreg = "0.55"
 serde_with = { version = "3.12", features = ["schemars_1"] }
+windows-capture = "2.0.0-alpha.7"
+windows-future = "0.3.2"
 
 [build-dependencies]
 shadow-rs = { workspace = true }

--- a/komorebi/src/animation/engine.rs
+++ b/komorebi/src/animation/engine.rs
@@ -6,10 +6,10 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
 
-use super::RenderDispatcher;
 use super::ANIMATION_DURATION_GLOBAL;
 use super::ANIMATION_FPS;
 use super::ANIMATION_MANAGER;
+use super::RenderDispatcher;
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/komorebi/src/animation/engine.rs
+++ b/komorebi/src/animation/engine.rs
@@ -6,10 +6,10 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
 
+use super::RenderDispatcher;
 use super::ANIMATION_DURATION_GLOBAL;
 use super::ANIMATION_FPS;
 use super::ANIMATION_MANAGER;
-use super::RenderDispatcher;
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -55,7 +55,7 @@ impl AnimationEngine {
 
     #[allow(clippy::cast_precision_loss)]
     pub fn animate(
-        render_dispatcher: impl RenderDispatcher + Send + 'static,
+        mut render_dispatcher: impl RenderDispatcher + Send + 'static,
         duration: Duration,
     ) -> eyre::Result<()> {
         std::thread::spawn(move || {
@@ -84,6 +84,7 @@ impl AnimationEngine {
                     .lock()
                     .is_cancelled(animation_key.as_str())
                 {
+                    render_dispatcher.on_cancle();
                     // cancel animation
                     ANIMATION_MANAGER.lock().cancel(animation_key.as_str());
                     return Ok(());

--- a/komorebi/src/animation/mod.rs
+++ b/komorebi/src/animation/mod.rs
@@ -4,9 +4,9 @@ use crate::core::animation::AnimationStyle;
 use lazy_static::lazy_static;
 use prefix::AnimationPrefix;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
 
 use parking_lot::Mutex;
 

--- a/komorebi/src/animation/mod.rs
+++ b/komorebi/src/animation/mod.rs
@@ -4,9 +4,9 @@ use crate::core::animation::AnimationStyle;
 use lazy_static::lazy_static;
 use prefix::AnimationPrefix;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 use parking_lot::Mutex;
 
@@ -18,6 +18,7 @@ pub mod prefix;
 pub mod render_dispatcher;
 pub use render_dispatcher::RenderDispatcher;
 pub mod style;
+pub mod workspace_switch;
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/komorebi/src/animation/prefix.rs
+++ b/komorebi/src/animation/prefix.rs
@@ -14,6 +14,7 @@ use strum::EnumString;
 pub enum AnimationPrefix {
     Movement,
     Transparency,
+    WrokspaceSwitch,
 }
 
 pub fn new_animation_key(prefix: AnimationPrefix, key: String) -> String {

--- a/komorebi/src/animation/render_dispatcher.rs
+++ b/komorebi/src/animation/render_dispatcher.rs
@@ -2,7 +2,8 @@ use color_eyre::eyre;
 
 pub trait RenderDispatcher {
     fn get_animation_key(&self) -> String;
-    fn pre_render(&self) -> eyre::Result<()>;
-    fn render(&self, delta: f64) -> eyre::Result<()>;
-    fn post_render(&self) -> eyre::Result<()>;
+    fn pre_render(&mut self) -> eyre::Result<()>;
+    fn render(&mut self, delta: f64) -> eyre::Result<()>;
+    fn post_render(&mut self) -> eyre::Result<()>;
+    fn on_cancle(&mut self);
 }

--- a/komorebi/src/animation/workspace_switch.rs
+++ b/komorebi/src/animation/workspace_switch.rs
@@ -1,0 +1,1026 @@
+use crate::as_ptr;
+use crate::monitor::Monitor;
+use crate::windows_api;
+use crate::workspace::Workspace;
+use crate::WindowManager;
+use crate::WindowsApi;
+
+use komorebi_layouts::Rect;
+use windows::Win32::Foundation::HMODULE;
+use windows::Win32::Foundation::POINT;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_OPTIONS_CANNOT_DRAW;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_OPTIONS_TARGET;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_PROPERTIES1;
+use windows::Win32::Graphics::Direct2D::D2D1_DEVICE_CONTEXT_OPTIONS_NONE;
+use windows::Win32::Graphics::Direct2D::ID2D1Bitmap1;
+use windows::Win32::Graphics::Direct2D::ID2D1Device;
+use windows::Win32::Graphics::Direct2D::ID2D1DeviceContext;
+use windows::Win32::Graphics::Direct2D::ID2D1Factory1;
+use windows::Win32::Graphics::Direct2D::ID2D1Factory2;
+use windows::Win32::Graphics::Direct2D::ID2D1RenderTarget;
+use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
+use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL;
+use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_10_0;
+use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_10_1;
+use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_0;
+use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_1;
+use windows::Win32::Graphics::Direct3D11::D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+use windows::Win32::Graphics::Direct3D11::D3D11_CREATE_DEVICE_DEBUG;
+use windows::Win32::Graphics::Direct3D11::D3D11_SDK_VERSION;
+use windows::Win32::Graphics::Direct3D11::D3D11CreateDevice;
+use windows::Win32::Graphics::Direct3D11::ID3D11DeviceContext;
+use windows::Win32::Graphics::DirectComposition::DCompositionCreateDevice2;
+use windows::Win32::Graphics::DirectComposition::IDCompositionDevice;
+use windows::Win32::Graphics::DirectComposition::IDCompositionSurface;
+use windows::Win32::Graphics::DirectComposition::IDCompositionTarget;
+use windows::Win32::Graphics::DirectComposition::IDCompositionVisual;
+use windows::Win32::Graphics::Dxgi::Common::DXGI_ALPHA_MODE_PREMULTIPLIED;
+use windows::Win32::Graphics::Dxgi::IDXGIDevice;
+use windows_future::AsyncActionCompletedHandler;
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+use windows::Graphics::DirectX::Direct3D11::IDirect3DSurface;
+use windows::Win32::Foundation::S_FALSE;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_PROPERTIES;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAPSOURCE_INTERPOLATION_MODE;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAPSOURCE_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
+use windows::Win32::Graphics::Direct2D::D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
+use windows::Win32::Graphics::Direct3D11::D3D11_RESOURCE_MISC_SHARED;
+use windows::Win32::Graphics::Direct3D11::D3D11_TEXTURE2D_DESC;
+use windows::Win32::Graphics::Direct3D11::D3D11_USAGE_DEFAULT;
+use windows::Win32::Graphics::Direct3D11::ID3D11Device;
+use windows::Win32::Graphics::Direct3D11::ID3D11Texture2D;
+use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R8G8B8A8_UNORM;
+use windows::Win32::Graphics::Dxgi::IDXGIResource;
+use windows::Win32::System::Com::CoIncrementMTAUsage;
+use windows::Win32::System::Threading::GetCurrentThreadId;
+use windows::Win32::System::WinRT::CreateDispatcherQueueController;
+use windows::Win32::System::WinRT::DQTAT_COM_NONE;
+use windows::Win32::System::WinRT::DQTYPE_THREAD_CURRENT;
+use windows::Win32::System::WinRT::DispatcherQueueOptions;
+use windows::Win32::System::WinRT::RO_INIT_MULTITHREADED;
+use windows::Win32::System::WinRT::RoInitialize;
+use windows_capture::capture::CaptureControl;
+use windows_capture::capture::Context;
+use windows_capture::capture::GraphicsCaptureApiError;
+use windows_capture::graphics_capture_api::GraphicsCaptureApi;
+use windows_capture::settings::GraphicsCaptureItemType;
+use windows_capture::window::Window;
+use std::collections::HashMap;
+use std::io;
+use std::io::Write;
+use std::ops::Deref;
+use std::os::raw::c_void;
+use std::os::windows::raw::HANDLE;
+use std::ptr::null_mut;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::time::Instant;
+use windows::Win32::Foundation::FALSE;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::Foundation::LPARAM;
+use windows::Win32::Foundation::LRESULT;
+use windows::Win32::Foundation::TRUE;
+use windows::Win32::Foundation::WPARAM;
+use windows::Win32::Graphics::Direct2D::Common::D2D1_ALPHA_MODE_PREMULTIPLIED;
+use windows::Win32::Graphics::Direct2D::Common::D2D1_COLOR_F;
+use windows::Win32::Graphics::Direct2D::Common::D2D1_PIXEL_FORMAT;
+use windows::Win32::Graphics::Direct2D::Common::D2D_RECT_F;
+use windows::Win32::Graphics::Direct2D::Common::D2D_SIZE_U;
+use windows::Win32::Graphics::Direct2D::D2D1CreateFactory;
+use windows::Win32::Graphics::Direct2D::ID2D1Bitmap;
+use windows::Win32::Graphics::Direct2D::ID2D1Factory;
+use windows::Win32::Graphics::Direct2D::ID2D1HwndRenderTarget;
+use windows::Win32::Graphics::Direct2D::ID2D1SolidColorBrush;
+use windows::Win32::Graphics::Direct2D::D2D1_ANTIALIAS_MODE_PER_PRIMITIVE;
+use windows::Win32::Graphics::Direct2D::D2D1_BRUSH_PROPERTIES;
+use windows::Win32::Graphics::Direct2D::D2D1_FACTORY_TYPE_MULTI_THREADED;
+use windows::Win32::Graphics::Direct2D::D2D1_HWND_RENDER_TARGET_PROPERTIES;
+use windows::Win32::Graphics::Direct2D::D2D1_PRESENT_OPTIONS_IMMEDIATELY;
+use windows::Win32::Graphics::Direct2D::D2D1_RENDER_TARGET_PROPERTIES;
+use windows::Win32::Graphics::Direct2D::D2D1_RENDER_TARGET_TYPE_DEFAULT;
+use windows::Win32::Graphics::Dwm::DwmEnableBlurBehindWindow;
+use windows::Win32::Graphics::Dwm::DWM_BB_BLURREGION;
+use windows::Win32::Graphics::Dwm::DWM_BB_ENABLE;
+use windows::Win32::Graphics::Dwm::DWM_BLURBEHIND;
+use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_UNKNOWN;
+use windows::Win32::Graphics::Dxgi::IDXGISurface;
+use windows::Win32::Graphics::Gdi::CreateRectRgn;
+use windows::Win32::Graphics::Gdi::ValidateRect;
+use windows::Win32::UI::WindowsAndMessaging::DefWindowProcW;
+use windows::Win32::UI::WindowsAndMessaging::DestroyWindow;
+use windows::Win32::UI::WindowsAndMessaging::DispatchMessageW;
+use windows::Win32::UI::WindowsAndMessaging::GetMessageW;
+use windows::Win32::UI::WindowsAndMessaging::GetSystemMetrics;
+use windows::Win32::UI::WindowsAndMessaging::GetWindowLongPtrW;
+use windows::Win32::UI::WindowsAndMessaging::PostQuitMessage;
+use windows::Win32::UI::WindowsAndMessaging::SetWindowLongPtrW;
+use windows::Win32::UI::WindowsAndMessaging::ShowWindow;
+use windows::Win32::UI::WindowsAndMessaging::TranslateMessage;
+use windows::Win32::UI::WindowsAndMessaging::CREATESTRUCTW;
+use windows::Win32::UI::WindowsAndMessaging::GWLP_USERDATA;
+use windows::Win32::UI::WindowsAndMessaging::MSG;
+use windows::Win32::UI::WindowsAndMessaging::SM_CXVIRTUALSCREEN;
+use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
+use windows::Win32::UI::WindowsAndMessaging::SW_MAXIMIZE;
+use windows::Win32::UI::WindowsAndMessaging::SW_MINIMIZE;
+use windows::Win32::UI::WindowsAndMessaging::WM_CREATE;
+use windows::Win32::UI::WindowsAndMessaging::WM_DESTROY;
+use windows::Win32::UI::WindowsAndMessaging::WM_PAINT;
+use windows::Win32::UI::WindowsAndMessaging::WM_SETCURSOR;
+use windows::Win32::UI::WindowsAndMessaging::WNDCLASSW;
+use windows_capture::capture::GraphicsCaptureApiHandler;
+use windows_capture::settings::Settings;
+use windows_core::Interface;
+use windows_core::PCWSTR;
+use windows_numerics::Matrix3x2;
+
+pub struct RenderFactory(ID2D1Factory1);
+unsafe impl Sync for RenderFactory {}
+unsafe impl Send for RenderFactory {}
+
+#[derive(Debug, Clone)]
+pub struct IDCompositionDeviceLocal(IDCompositionDevice);
+unsafe impl Sync for IDCompositionDeviceLocal {}
+unsafe impl Send for IDCompositionDeviceLocal {}
+
+#[derive(Debug, Clone)]
+pub struct IDCompositionTargetLocal(IDCompositionTarget);
+unsafe impl Sync for IDCompositionTargetLocal {}
+unsafe impl Send for IDCompositionTargetLocal {}
+
+#[derive(Debug, Clone)]
+pub struct IDCompositionVisualLocal(IDCompositionVisual);
+unsafe impl Sync for IDCompositionVisualLocal {}
+unsafe impl Send for IDCompositionVisualLocal {}
+
+#[derive(Debug, Clone)]
+pub struct IDCompositionSurfaceLocal(IDCompositionSurface);
+unsafe impl Sync for IDCompositionSurfaceLocal {}
+unsafe impl Send for IDCompositionSurfaceLocal {}
+
+impl Deref for RenderFactory {
+    type Target = ID2D1Factory1;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+struct D3DResources {
+    pub device: ID3D11Device,
+    pub device_context: ID3D11DeviceContext,
+}
+
+#[allow(clippy::expect_used)]
+static RENDER_FACTORY: LazyLock<RenderFactory> = unsafe {
+    LazyLock::new(|| {
+        RenderFactory(
+            D2D1CreateFactory::<ID2D1Factory1>(D2D1_FACTORY_TYPE_MULTI_THREADED, None)
+                .expect("creating RENDER_FACTORY failed"),
+        )
+    })
+};
+
+fn create_d3d_device() -> color_eyre::Result<D3DResources> {
+    let mut feature_levels = [
+        D3D_FEATURE_LEVEL_11_1,
+        D3D_FEATURE_LEVEL_11_0,
+        D3D_FEATURE_LEVEL_10_1,
+        D3D_FEATURE_LEVEL_10_0,
+    ];
+
+    let mut device = None;
+    let mut context = None;
+    let mut feature_level = D3D_FEATURE_LEVEL(0);
+
+    unsafe {
+        D3D11CreateDevice(
+            None,
+            D3D_DRIVER_TYPE_HARDWARE,
+            HMODULE(null_mut()),
+            D3D11_CREATE_DEVICE_DEBUG | D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+            Some(&mut feature_levels),
+            D3D11_SDK_VERSION,
+            Some(&mut device),
+            Some(&mut feature_level),
+            Some(&mut context),
+        )?;
+    }
+
+
+
+    Ok(D3DResources {
+        device: device.unwrap(),
+        device_context: context.unwrap(),
+    })
+}
+
+#[derive(Debug, Clone)]
+struct D2DResources {
+    // render_target: ID2D1RenderTarget,
+    // brush: ID2D1SolidColorBrush,
+    device: ID2D1Device,
+    context: ID2D1DeviceContext,
+    target: Option<ID2D1Bitmap1>,
+    brush: ID2D1SolidColorBrush,
+}
+
+
+unsafe fn create_d2d_resources(dxgi_device: &IDXGIDevice) -> color_eyre::Result<D2DResources> {
+        /* let render_target_properties = D2D1_RENDER_TARGET_PROPERTIES {
+            r#type: D2D1_RENDER_TARGET_TYPE_DEFAULT,
+            pixelFormat: D2D1_PIXEL_FORMAT {
+                format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+            },
+            dpiX: 96.0,
+            dpiY: 96.0,
+            ..Default::default()
+        };
+
+    let render_target: ID2D1RenderTarget =
+        RENDER_FACTORY.CreateDxgiSurfaceRenderTarget(dxgi_surface, &render_target_properties)?;
+    println!("D2D render target created"); */
+
+    let d2d_device = RENDER_FACTORY.CreateDevice(dxgi_device)?;
+    println!("D2D device created"); 
+
+    // Create brush
+    /* let brush = render_target.CreateSolidColorBrush(
+        &D2D1_COLOR_F {
+            r: 1.0,
+            g: 1.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        None,
+    )?; */
+
+    // println!("D2D brush created");
+
+    let d2d_context = d2d_device.CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE)?;
+    let brush = d2d_context.CreateSolidColorBrush(
+        &D2D1_COLOR_F {
+            r: 1.0,
+            g: 1.0,
+            b: 0.0,
+            a: 1.0,
+        },
+        None,
+    )?;
+        
+    Ok(D2DResources {
+        device: d2d_device,
+        context: d2d_context,
+        target: None,
+        brush,
+    })
+}
+
+
+
+#[allow(clippy::expect_used)]
+static D3D_DEVICE: LazyLock<D3DResources> = {
+    LazyLock::new(|| {
+        create_d3d_device().expect("creating D3D_DEVICE failed")
+    })
+};
+
+#[derive(Debug, Clone)]
+pub struct RenderTarget(pub ID2D1RenderTarget);
+unsafe impl Send for RenderTarget {}
+
+impl Deref for RenderTarget {
+    type Target = ID2D1RenderTarget;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceSwitchWindow {
+    pub hwnd: isize,
+    pub monitor_id: Option<isize>,
+    pub monitor_rect: Option<Rect>,
+    pub d3d_device: Option<ID3D11Device>,
+    pub d3d_device_context: Option<ID3D11DeviceContext>,
+    pub device: Option<IDCompositionDeviceLocal>,
+    pub visual: Option<IDCompositionVisualLocal>,
+    pub surface: Option<IDCompositionSurfaceLocal>,
+    pub target: Option<IDCompositionTargetLocal>,
+    pub d2d_resources: Option<D2DResources>,
+    pub brush_properties: D2D1_BRUSH_PROPERTIES,
+    pub capture_hash_map: HashMap<usize, Arc<Mutex<Capture>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Capture {
+    pub hwnd: isize,
+    pub last_frame: Arc<Mutex<Option<ID3D11Texture2D>>>,
+    pub need_stop: Arc<Mutex<bool>>,
+}
+
+trait CustomCaptureApiHandler: GraphicsCaptureApiHandler {
+    fn start_free_threaded_with_item<T: TryInto<GraphicsCaptureItemType> + Send + 'static>(
+        item: T,
+        d3d_device: ID3D11Device,
+        d3d_device_context: ID3D11DeviceContext,
+        settings: Settings<Self::Flags, T>,
+    ) -> Result<CaptureControl<Self, Self::Error>, GraphicsCaptureApiError<Self::Error>>
+    where
+        Self: Send + 'static,
+        <Self as GraphicsCaptureApiHandler>::Flags: Send;
+}
+
+impl CustomCaptureApiHandler for Capture {
+    fn start_free_threaded_with_item<T: TryInto<GraphicsCaptureItemType> + Send + 'static>(
+        item: T,
+        d3d_device: ID3D11Device,
+        d3d_device_context: ID3D11DeviceContext,
+        settings: Settings<Self::Flags, T>,
+    ) -> Result<CaptureControl<Self, Self::Error>, GraphicsCaptureApiError<Self::Error>>
+    where
+        Self: Send + 'static,
+        <Self as GraphicsCaptureApiHandler>::Flags: Send,
+    {
+        let (halt_sender, halt_receiver) = mpsc::channel::<Arc<AtomicBool>>();
+        let (callback_sender, callback_receiver) = mpsc::channel::<Arc<Mutex<Self>>>();
+
+        let thread_handle = std::thread::spawn(move || -> Result<(), GraphicsCaptureApiError<Self::Error>> {
+            // Initialize WinRT
+            static INIT_MTA: OnceLock<()> = OnceLock::new();
+            INIT_MTA.get_or_init(|| {
+                unsafe {
+                    CoIncrementMTAUsage().expect("Failed to increment MTA usage");
+                };
+            });
+
+            match unsafe { RoInitialize(RO_INIT_MULTITHREADED) } {
+                Ok(_) => (),
+                Err(e) => {
+                    if e.code() == S_FALSE {
+                        // Already initialized
+                    } else {
+                        return Err(GraphicsCaptureApiError::FailedToInitWinRT);
+                    }
+                }
+            }
+
+            // Create a dispatcher queue for the current thread
+            let options = DispatcherQueueOptions {
+                dwSize: u32::try_from(std::mem::size_of::<DispatcherQueueOptions>()).unwrap(),
+                threadType: DQTYPE_THREAD_CURRENT,
+                apartmentType: DQTAT_COM_NONE,
+            };
+            let controller = unsafe {
+                CreateDispatcherQueueController(options)
+                    .map_err(|_| GraphicsCaptureApiError::FailedToCreateDispatcherQueueController)?
+            };
+
+            // Get current thread ID
+            let thread_id = unsafe { GetCurrentThreadId() };
+
+            // Create direct3d device and context
+            // let (d3d_device, d3d_device_context) = create_d3d_device()?;
+
+            // Start capture
+            let result = Arc::new(Mutex::new(None));
+
+            let flags = settings.flags();
+
+            let ctx = Context {
+                flags: flags.clone(),
+                device: d3d_device.clone(),
+                device_context: d3d_device_context.clone(),
+            };
+
+            let callback = Arc::new(Mutex::new(Self::new(ctx).map_err(GraphicsCaptureApiError::NewHandlerError)?));
+
+            // let item = settings.item().clone();
+
+            let mut capture = GraphicsCaptureApi::new(
+                d3d_device,
+                d3d_device_context,
+                item.try_into().map_err(|_| GraphicsCaptureApiError::ItemConvertFailed)?,
+                callback.clone(),
+                settings.cursor_capture(),
+                settings.draw_border(),
+                windows_capture::settings::SecondaryWindowSettings::Default,
+                windows_capture::settings::MinimumUpdateIntervalSettings::Default,
+                windows_capture::settings::DirtyRegionSettings::Default,
+                windows_capture::settings::ColorFormat::Rgba8,
+                thread_id,
+                result.clone(),
+            )
+            .map_err(GraphicsCaptureApiError::GraphicsCaptureApiError)?;
+
+            capture.start_capture().map_err(GraphicsCaptureApiError::GraphicsCaptureApiError)?;
+
+            // Send halt handle
+            let halt_handle = capture.halt_handle();
+            halt_sender.send(halt_handle).unwrap();
+
+            // Send callback
+            callback_sender.send(callback).unwrap();
+
+            // Message loop
+            let mut message = MSG::default();
+            unsafe {
+                while GetMessageW(&mut message, None, 0, 0).as_bool() {
+                    let _ = TranslateMessage(&message);
+                    DispatchMessageW(&message);
+                }
+            }
+
+            // Shutdown dispatcher queue
+            let async_action = controller
+                .ShutdownQueueAsync()
+                .map_err(|_| GraphicsCaptureApiError::FailedToShutdownDispatcherQueue)?;
+
+            async_action
+                .SetCompleted(&AsyncActionCompletedHandler::new(move |_, _| -> Result<(), windows::core::Error> {
+                    unsafe { PostQuitMessage(0) };
+                    Ok(())
+                }))
+                .map_err(|_| GraphicsCaptureApiError::FailedToSetDispatcherQueueCompletedHandler)?;
+
+            // Final message loop
+            let mut message = MSG::default();
+            unsafe {
+                while GetMessageW(&mut message, None, 0, 0).as_bool() {
+                    let _ = TranslateMessage(&message);
+                    DispatchMessageW(&message);
+                }
+            }
+
+            // Stop capture
+            capture.stop_capture();
+
+            // Uninitialize WinRT
+            // unsafe { RoUninitialize() }; // Not sure if this is needed here
+
+            // Check handler result
+            let result = result.lock().take();
+            if let Some(e) = result {
+                return Err(GraphicsCaptureApiError::FrameHandlerError(e));
+            }
+
+            Ok(())
+        });
+
+        let Ok(halt_handle) = halt_receiver.recv() else {
+            match thread_handle.join() {
+                Ok(result) => return Err(result.err().unwrap()),
+                Err(_) => {
+                    return Err(GraphicsCaptureApiError::FailedToJoinThread);
+                }
+            }
+        };
+
+        let Ok(callback) = callback_receiver.recv() else {
+            match thread_handle.join() {
+                Ok(result) => return Err(result.err().unwrap()),
+                Err(_) => {
+                    return Err(GraphicsCaptureApiError::FailedToJoinThread);
+                }
+            }
+        };
+
+        Ok(CaptureControl::new(thread_handle, halt_handle, callback))
+    }
+
+}
+
+impl windows_capture::capture::GraphicsCaptureApiHandler for Capture {
+    type Flags = (i32, i32, isize);
+    type Error = color_eyre::Report;
+
+    fn new(ctx: windows_capture::capture::Context<Self::Flags>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            hwnd: ctx.flags.2,
+            last_frame: Arc::new(Mutex::new(None)),
+            need_stop: Arc::new(Mutex::new(false)),
+        })
+    }
+
+
+    // Called every time a new frame is available.
+    fn on_frame_arrived(
+        &mut self,
+        frame: &mut windows_capture::frame::Frame,
+        capture_control: windows_capture::graphics_capture_api::InternalCaptureControl,
+    ) -> Result<(), Self::Error> {
+        if *self.need_stop.lock() {
+            capture_control.stop();
+            return Ok(());
+        }
+        let  texture = frame.as_raw_texture();
+        self.last_frame.lock().replace(texture.clone());
+        /* if let Some(render_target) = self.render_target.lock().as_ref() {
+            let mut bitmap: Option<ID2D1Bitmap> = None;
+            unsafe {
+                // let mut surface = frame.as_raw_surface();
+        //         let mut desc = D3D11_TEXTURE2D_DESC::default();
+        //          texture.GetDesc(&mut desc);
+        //         println!("desc: {desc:?}");
+        //         
+        // let texture_desc = D3D11_TEXTURE2D_DESC {
+        //     Width: desc.Width,
+        //     Height: desc.Height,
+        //     MipLevels: desc.MipLevels,
+        //     ArraySize: desc.ArraySize,
+        //             Format: desc.Format,
+        //     SampleDesc: desc.SampleDesc,
+        //     Usage: D3D11_USAGE_DEFAULT,
+        //     BindFlags: desc.BindFlags,
+        //     CPUAccessFlags: 0,
+        //     MiscFlags: desc.MiscFlags | D3D11_RESOURCE_MISC_SHARED.0 as u32,
+        // };
+        //         let device: ID3D11Device = texture.GetDevice()?;
+        //         println!("device: {device:?}");
+        //         let device_context= device.GetImmediateContext()?;
+        //         println!("device_context: {device_context:?}");
+        //
+        //         let mut shared_texture: Option<ID3D11Texture2D> = None;
+        //         device.CreateTexture2D(
+        //             &texture_desc,
+        //             None,
+        //             Some(&mut shared_texture));
+        //         println!("shared_texture: {shared_texture:?}");
+        //         device_context.CopyResource(shared_texture.as_ref().unwrap(), texture);
+        //         println!("CopyResource");
+        //
+        //         let resource: IDXGIResource = shared_texture.as_ref().unwrap().cast()?;
+        //         println!("resource: {resource:?}");
+                // let handle = resource.GetSharedHandle().unwrap();
+                let result = render_target.CreateSharedBitmap(
+                    &IDXGISurface::IID as *const windows_core::GUID,
+                    std::mem::transmute_copy(&mut texture),
+                    Some(&D2D1_BITMAP_PROPERTIES {
+                    pixelFormat: D2D1_PIXEL_FORMAT {
+                        format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                        alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+                    }   ,
+                    dpiX: 96.0,
+                    dpiY: 96.0,
+                    }),
+                    &mut bitmap,
+                );
+                println!("CreateSharedBitmap result: {result:?}");
+
+            }
+            let mut last_frame = self.last_frame.lock();
+            *last_frame = bitmap;
+            drop(last_frame);
+        } */
+        Ok(())
+    }
+
+    // Optional handler called when the capture item (usually a window) is closed.
+    fn on_closed(&mut self) -> Result<(), Self::Error> {
+        println!("Capture session ended");
+
+        Ok(())
+    }
+}
+
+impl WorkspaceSwitchWindow {
+    pub const fn hwnd(&self) -> HWND {
+        HWND(windows_api::as_ptr!(self.hwnd))
+    }
+
+    pub fn create(monitor: Monitor) -> color_eyre::Result<Box<Self>> {
+        // println!("create workspace for rect: {monitor:#?}");
+        let monitor_id: isize = monitor.id;
+        let name: Vec<u16> = format!("komoanimation-{monitor_id}\0")
+            .encode_utf16()
+            .collect();
+        let class_name = PCWSTR(name.as_ptr());
+
+        let h_module = WindowsApi::module_handle_w()?;
+
+        let window_class = WNDCLASSW {
+            hInstance: h_module.into(),
+            lpszClassName: class_name,
+            lpfnWndProc: Some(Self::callback),
+            hbrBackground: WindowsApi::create_solid_brush(0),
+            ..Default::default()
+        };
+
+        let _ = WindowsApi::register_class_w(&window_class);
+
+        let instance = h_module.0 as isize;
+
+        let (workspace_switch_window_sender, workspace_switch_window_receiver) = mpsc::channel();
+
+        std::thread::spawn(move || -> color_eyre::Result<()> {
+            let mut workspace_switch_window = Self {
+                hwnd: 0,
+                d3d_device: None,
+                d3d_device_context: None,
+                device: None,
+                visual: None,
+                surface: None,
+                target: None,
+                d2d_resources: None,
+                monitor_id: Some(monitor.id),
+                monitor_rect: Some(monitor.size),
+                brush_properties: D2D1_BRUSH_PROPERTIES {
+                    opacity: 1.0,
+                    transform: Matrix3x2::identity(),
+                },
+                capture_hash_map: HashMap::default(),
+            };
+            let workspace_switch_window_pointer = &raw mut workspace_switch_window;
+            let hwnd = WindowsApi::create_workspace_switch_window(
+                PCWSTR(name.as_ptr()),
+                instance,
+                workspace_switch_window_pointer,
+            )?;
+
+            let boxed = unsafe {
+                (*workspace_switch_window_pointer).hwnd = hwnd;
+                Box::from_raw(workspace_switch_window_pointer)
+            };
+            workspace_switch_window_sender.send(boxed)?;
+
+            let mut msg: MSG = MSG::default();
+
+            loop {
+                unsafe {
+                    if !GetMessageW(&mut msg, None, 0, 0).as_bool() {
+                        tracing::debug!("border window event processing thread shutdown");
+                        break;
+                    };
+                    // TODO: error handling
+                    let _ = TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
+                }
+            }
+
+            Ok(())
+        });
+
+        let mut workspace_switch_window = workspace_switch_window_receiver.recv()?;
+
+        unsafe {
+            let pos: i32 = -GetSystemMetrics(SM_CXVIRTUALSCREEN) - 8;
+            let hrgn = CreateRectRgn(pos, 0, pos + 1, 1);
+            let mut bh: DWM_BLURBEHIND = Default::default();
+            if !hrgn.is_invalid() {
+                bh = DWM_BLURBEHIND {
+                    dwFlags: DWM_BB_ENABLE | DWM_BB_BLURREGION,
+                    fEnable: TRUE,
+                    hRgnBlur: hrgn,
+                    fTransitionOnMaximized: FALSE,
+                };
+            }
+
+            let _ = DwmEnableBlurBehindWindow(workspace_switch_window.hwnd(), &bh);
+        }
+
+        /* let hwnd_render_target_properties = D2D1_HWND_RENDER_TARGET_PROPERTIES {
+            hwnd: HWND(windows_api::as_ptr!(workspace_switch_window.hwnd)),
+            pixelSize: Default::default(),
+            presentOptions: D2D1_PRESENT_OPTIONS_IMMEDIATELY,
+        }; */
+
+        unsafe {
+            let dxgi_device: IDXGIDevice = D3D_DEVICE.device.cast()?;
+                    // 1. Create DComp device
+            let device: IDCompositionDevice = DCompositionCreateDevice2(&dxgi_device)?;
+            println!("DComp device created");
+
+            // 2. Create target for window
+            let target = device.CreateTargetForHwnd(workspace_switch_window.hwnd(), true)?;
+            println!("DComp target created");
+
+            // 3. Create visual
+            let visual = device.CreateVisual()?;
+            println!("DComp visual created");
+
+            let surface = device.CreateSurface(
+                workspace_switch_window.monitor_rect.unwrap().right as u32,
+                workspace_switch_window.monitor_rect.unwrap().bottom as u32,
+                DXGI_FORMAT_R8G8B8A8_UNORM,
+                DXGI_ALPHA_MODE_PREMULTIPLIED,
+            )?;
+
+            println!("DComp surface created");
+
+            // 5. Set visual content
+            visual.SetContent(&surface)?;
+
+            println!("DComp visual content set");
+
+            // 6. Set as root visual
+            target.SetRoot(&visual)?;
+
+
+            // Keep references to prevent early release
+            let dxgi_device = dxgi_device.clone();
+
+            let d3d_device: ID3D11Device = dxgi_device.cast()?;
+            let d3d_device_context: ID3D11DeviceContext = d3d_device.GetImmediateContext()?;
+            workspace_switch_window.d3d_device = Some(d3d_device);
+            workspace_switch_window.d3d_device_context = Some(d3d_device_context);
+            workspace_switch_window.device = Some(IDCompositionDeviceLocal(device));
+            workspace_switch_window.visual = Some(IDCompositionVisualLocal(visual));
+            workspace_switch_window.surface = Some(IDCompositionSurfaceLocal(surface));
+            workspace_switch_window.target = Some(IDCompositionTargetLocal(target));
+
+            workspace_switch_window.d2d_resources = Some(create_d2d_resources(
+                &dxgi_device,
+            )?);
+
+            println!("D3D device created");
+
+            Ok(workspace_switch_window)
+        }
+
+
+
+    }
+
+    pub fn begin_draw(&mut self) -> color_eyre::Result<()> {
+        unsafe {
+            if let Some(surface) = self.surface.as_ref() {
+                let mut offset = POINT { x: 0, y: 0 };
+                let dxgi_surface: IDXGISurface = surface.0.BeginDraw(None, &mut offset)?;
+
+                if let Some(d2d_resources) = self.d2d_resources.as_mut() {
+
+                    let bitmap_properties = D2D1_BITMAP_PROPERTIES1 {
+                            pixelFormat: D2D1_PIXEL_FORMAT {
+                                format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+                            }   ,
+                            dpiX: 96.0,
+                            dpiY: 96.0,
+                            colorContext: std::mem::ManuallyDrop::new(None),
+                            bitmapOptions:  D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+                    };
+                    let d2d_target = d2d_resources.context.CreateBitmapFromDxgiSurface(
+                        &dxgi_surface,
+                        Some(&bitmap_properties),
+                    )?;
+
+                    d2d_resources.context.SetTarget(&d2d_target);
+                    d2d_resources.target = Some(d2d_target);
+
+                    d2d_resources.context.BeginDraw();
+                    d2d_resources.context.Clear(None);
+                }
+
+            }
+
+            Ok(())
+        }
+    }
+
+    pub fn end_draw(&mut self) {
+        unsafe {
+            if let Some(mut d2d_resources) = self.d2d_resources.as_mut() {
+                let result = d2d_resources.context.EndDraw(None, None);
+                println!("EndDraw d2d result: {result:?}");
+                d2d_resources.target = None;
+            }
+
+            if let Some(surface) = self.surface.as_ref() {
+                let result = surface.0.EndDraw();
+                println!("EndDraw dxgi result: {result:?}");
+            }
+
+            if let Some(device) = self.device.as_ref() {
+                let result = device.0.Commit();
+
+                println!("Commit dcomp result: {result:?}");
+            }
+        }
+    }
+
+    pub fn draw_workspace(&mut self, workspace: &Workspace, x_offset: i32) -> color_eyre::Result<()> {
+        unsafe {
+                if let Some(d2d_resources) = self.d2d_resources.as_ref() {
+                    if let Some(monitor_rect) = self.monitor_rect.as_ref() {
+                        if workspace.containers().len() > 0 {
+                            for (container_index, container) in workspace.containers().iter().enumerate() {
+                                if self.capture_hash_map.contains_key(&container_index) {
+                                    continue;
+                                }
+
+                                let layout = workspace.latest_layout.get(container_index).unwrap();
+                                for window in container.windows() {
+                                    if !window.is_visible() {
+                                        println!("window not visible");
+                                        continue;
+                                    }
+
+                                    let hwnd = window.hwnd;
+                                    let settings = Settings::new(
+                                        Window::from_raw_hwnd(as_ptr!(hwnd)), 
+                                    windows_capture::settings::CursorCaptureSettings::WithoutCursor,
+                                    windows_capture::settings::DrawBorderSettings::WithoutBorder,
+                                    windows_capture::settings::SecondaryWindowSettings::Default,
+                                    windows_capture::settings::MinimumUpdateIntervalSettings::Default,
+                                    windows_capture::settings::DirtyRegionSettings::Default,
+                                    windows_capture::settings::ColorFormat::Rgba8,
+                                        (layout.right, layout.bottom, hwnd),
+                                    );
+                                    let capture = Capture::start_free_threaded_with_item(
+                                    Window::from_raw_hwnd(as_ptr!(hwnd)),
+                                    self.d3d_device.as_ref().unwrap().clone(),
+                                    self.d3d_device_context.as_ref().unwrap().clone(),
+                                    settings
+                                )?;
+                                    self.capture_hash_map.insert(container_index, capture.callback());
+                                    println!("capture started: {container_index} {hwnd}");
+                                }
+                            }
+                            for (index, rect) in workspace.latest_layout.iter().enumerate() {
+
+                                let target_rect = D2D_RECT_F {
+                                    left: (rect.left - monitor_rect.left + x_offset) as f32,
+                                    top: (rect.top - monitor_rect.top) as f32,
+                                    right: ((rect.left - monitor_rect.left) + rect.right + x_offset)
+                                        as f32,
+                                    bottom: ((rect.top - monitor_rect.top) + rect.bottom) as f32,
+                                };
+                                //
+                                d2d_resources.context.DrawRectangle(&target_rect, &d2d_resources.brush, 3.0, None);
+                                // d2d_resources.context.FillRectangle(&target_rect, &d2d_resources.brush);
+                                println!("rect: {target_rect:?}");
+                                
+                                let capture = self.capture_hash_map.get(&index);
+                                if capture.is_none() {
+                                    continue;
+                                }
+
+                                let capture = capture.unwrap().lock();
+                                println!("capture: {capture:?}");
+                                let last_frame = &capture.last_frame;
+                                println!("last_frame: {last_frame:?}");
+
+                                if let Some(mut texture) = last_frame.lock().as_ref() {
+                                    let bitmap_properties = D2D1_BITMAP_PROPERTIES1 {
+                                            pixelFormat: D2D1_PIXEL_FORMAT {
+                                                format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                                                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+                                            }   ,
+                                            dpiX: 96.0,
+                                            dpiY: 96.0,
+                                            colorContext: std::mem::ManuallyDrop::new(None),
+                                            bitmapOptions:  D2D1_BITMAP_OPTIONS_TARGET,
+                                    };
+                                    let texture_surface: IDXGISurface = texture.cast()?;
+                                    let bitmap = d2d_resources.context.CreateBitmapFromDxgiSurface(
+                                        &texture_surface,
+                                        Some(&bitmap_properties as *const _),
+                                    )?;
+                                    println!("bitmap: {bitmap:?}");
+                                    // println!("CreateSharedBitmap result: {:?}");
+                                    d2d_resources.context.DrawBitmap(
+                                        &bitmap,
+                                        Some(&target_rect as *const _),
+                                        1.0,
+                                        D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
+                                        None,
+                                        None,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+        }
+        Ok(())
+    }
+
+    pub fn destroy(&mut self) -> color_eyre::Result<()> {
+        self.monitor_id = None;
+        self.monitor_rect = None;
+        for capture in self.capture_hash_map.values() {
+            *capture.lock().need_stop.lock() = true;
+        }
+
+        self.capture_hash_map.clear();
+
+        unsafe {
+            SetWindowLongPtrW(self.hwnd(), GWLP_USERDATA, 0);
+        }
+        WindowsApi::close_window(self.hwnd)
+    }
+
+    pub extern "system" fn callback(
+        window: HWND,
+        message: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        unsafe {
+            match message {
+                WM_CREATE => {
+                    let mut workspace_switch_window_pointer: *mut WorkspaceSwitchWindow =
+                        GetWindowLongPtrW(window, GWLP_USERDATA) as _;
+
+                    if workspace_switch_window_pointer.is_null() {
+                        let create_struct: *mut CREATESTRUCTW = lparam.0 as *mut _;
+                        workspace_switch_window_pointer = (*create_struct).lpCreateParams as *mut _;
+                        SetWindowLongPtrW(
+                            window,
+                            GWLP_USERDATA,
+                            workspace_switch_window_pointer as _,
+                        );
+                    }
+
+                    if let Some(rect) = (*workspace_switch_window_pointer).monitor_rect {
+                        println!("monitor rect: {rect:?}");
+                        ShowWindow(window, SW_HIDE);
+                        let old_rect = WindowsApi::window_rect(window.0 as isize).unwrap();
+                        println!("old rect: {old_rect:?}");
+                        WindowsApi::position_window(window.0 as isize, &rect, false, false);
+                        ShowWindow(window, SW_MAXIMIZE);
+                        let new_rect = WindowsApi::window_rect(window.0 as isize).unwrap();
+                        println!("new rect: {new_rect:?}");
+                    }
+
+                    // InvalidateRect(Some(window), None, false);
+
+                    LRESULT(0)
+                }
+
+                WM_PAINT => {
+                    if let Ok(rect) = WindowsApi::window_rect(window.0 as isize) {
+                        let workspace_switch_pointer: *mut WorkspaceSwitchWindow =
+                            GetWindowLongPtrW(window, GWLP_USERDATA) as _;
+
+                        if workspace_switch_pointer.is_null() {
+                            return LRESULT(0);
+                        }
+
+                        tracing::trace!("updating workspace switch");
+                        // if let Err(error) =
+                        //     (*workspace_switch_pointer).set_position(&border_window_rect, reference_hwnd)
+                        // {
+                        //     tracing::error!("failed to update border position {error}");
+                        // }
+
+                        /* if let Some(render_target) =
+                            (*workspace_switch_pointer).render_target.lock().as_ref()
+                        {
+                            let _ = render_target.Resize(&D2D_SIZE_U {
+                                width: rect.right as u32,
+                                height: rect.bottom as u32,
+                            });
+
+                            // Get window kind and color
+                            if let Some(brush) = (*workspace_switch_pointer).brush.as_ref() {
+                                render_target.BeginDraw();
+                                render_target.Clear(None);
+
+                                render_target.FillRectangle(
+                                    &D2D_RECT_F {
+                                        left: 0.0,
+                                        top: 0.0,
+                                        right: rect.right as f32,
+                                        bottom: rect.bottom as f32,
+                                    },
+                                    brush,
+                                );
+
+                                let _ = render_target.EndDraw(None, None);
+                            }
+                        } */
+                    }
+                    let _ = ValidateRect(Option::from(window), None);
+                    LRESULT(0)
+                }
+                WM_DESTROY => {
+                    let workspace_switch_window_pointer: *mut WorkspaceSwitchWindow =
+                        GetWindowLongPtrW(window, GWLP_USERDATA) as _;
+                    if !workspace_switch_window_pointer.is_null() {
+                        (*workspace_switch_window_pointer).device = None;
+                        (*workspace_switch_window_pointer).surface = None;
+                        (*workspace_switch_window_pointer).visual = None;
+                        (*workspace_switch_window_pointer).d2d_resources = None;
+                        (*workspace_switch_window_pointer).target = None;
+                        (*workspace_switch_window_pointer).d3d_device = None;
+                        (*workspace_switch_window_pointer).d3d_device_context = None;
+                        // (*workspace_switch_window_pointer).brushes.clear();
+                        SetWindowLongPtrW(window, GWLP_USERDATA, 0);
+                    }
+                    PostQuitMessage(0);
+                    LRESULT(0)
+                }
+                _ => DefWindowProcW(window, message, wparam, lparam),
+            }
+        }
+    }
+}

--- a/komorebi/src/animation/workspace_switch.rs
+++ b/komorebi/src/animation/workspace_switch.rs
@@ -1,23 +1,69 @@
+use crate::WindowManager;
+use crate::WindowsApi;
 use crate::as_ptr;
 use crate::monitor::Monitor;
 use crate::windows_api;
 use crate::workspace::Workspace;
-use crate::WindowManager;
-use crate::WindowsApi;
 
 use komorebi_layouts::Rect;
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::io;
+use std::io::Write;
+use std::ops::Deref;
+use std::os::raw::c_void;
+use std::os::windows::raw::HANDLE;
+use std::ptr::null_mut;
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
+use std::time::Instant;
+use windows::Graphics::DirectX::Direct3D11::IDirect3DSurface;
+use windows::Win32::Foundation::FALSE;
 use windows::Win32::Foundation::HMODULE;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::Foundation::LPARAM;
+use windows::Win32::Foundation::LRESULT;
 use windows::Win32::Foundation::POINT;
+use windows::Win32::Foundation::S_FALSE;
+use windows::Win32::Foundation::TRUE;
+use windows::Win32::Foundation::WPARAM;
+use windows::Win32::Graphics::Direct2D::Common::D2D_RECT_F;
+use windows::Win32::Graphics::Direct2D::Common::D2D_SIZE_U;
+use windows::Win32::Graphics::Direct2D::Common::D2D1_ALPHA_MODE_PREMULTIPLIED;
+use windows::Win32::Graphics::Direct2D::Common::D2D1_COLOR_F;
+use windows::Win32::Graphics::Direct2D::Common::D2D1_PIXEL_FORMAT;
+use windows::Win32::Graphics::Direct2D::D2D1_ANTIALIAS_MODE_PER_PRIMITIVE;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
 use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_OPTIONS_CANNOT_DRAW;
 use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_OPTIONS_TARGET;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_PROPERTIES;
 use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_PROPERTIES1;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAPSOURCE_INTERPOLATION_MODE;
+use windows::Win32::Graphics::Direct2D::D2D1_BITMAPSOURCE_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
+use windows::Win32::Graphics::Direct2D::D2D1_BRUSH_PROPERTIES;
 use windows::Win32::Graphics::Direct2D::D2D1_DEVICE_CONTEXT_OPTIONS_NONE;
+use windows::Win32::Graphics::Direct2D::D2D1_FACTORY_TYPE_MULTI_THREADED;
+use windows::Win32::Graphics::Direct2D::D2D1_HWND_RENDER_TARGET_PROPERTIES;
+use windows::Win32::Graphics::Direct2D::D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
+use windows::Win32::Graphics::Direct2D::D2D1_PRESENT_OPTIONS_IMMEDIATELY;
+use windows::Win32::Graphics::Direct2D::D2D1_RENDER_TARGET_PROPERTIES;
+use windows::Win32::Graphics::Direct2D::D2D1_RENDER_TARGET_TYPE_DEFAULT;
+use windows::Win32::Graphics::Direct2D::D2D1CreateFactory;
+use windows::Win32::Graphics::Direct2D::ID2D1Bitmap;
 use windows::Win32::Graphics::Direct2D::ID2D1Bitmap1;
 use windows::Win32::Graphics::Direct2D::ID2D1Device;
 use windows::Win32::Graphics::Direct2D::ID2D1DeviceContext;
+use windows::Win32::Graphics::Direct2D::ID2D1Factory;
 use windows::Win32::Graphics::Direct2D::ID2D1Factory1;
 use windows::Win32::Graphics::Direct2D::ID2D1Factory2;
+use windows::Win32::Graphics::Direct2D::ID2D1HwndRenderTarget;
 use windows::Win32::Graphics::Direct2D::ID2D1RenderTarget;
+use windows::Win32::Graphics::Direct2D::ID2D1SolidColorBrush;
 use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
 use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL;
 use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_10_0;
@@ -26,33 +72,31 @@ use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_0;
 use windows::Win32::Graphics::Direct3D::D3D_FEATURE_LEVEL_11_1;
 use windows::Win32::Graphics::Direct3D11::D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 use windows::Win32::Graphics::Direct3D11::D3D11_CREATE_DEVICE_DEBUG;
+use windows::Win32::Graphics::Direct3D11::D3D11_RESOURCE_MISC_SHARED;
 use windows::Win32::Graphics::Direct3D11::D3D11_SDK_VERSION;
+use windows::Win32::Graphics::Direct3D11::D3D11_TEXTURE2D_DESC;
+use windows::Win32::Graphics::Direct3D11::D3D11_USAGE_DEFAULT;
 use windows::Win32::Graphics::Direct3D11::D3D11CreateDevice;
+use windows::Win32::Graphics::Direct3D11::ID3D11Device;
 use windows::Win32::Graphics::Direct3D11::ID3D11DeviceContext;
+use windows::Win32::Graphics::Direct3D11::ID3D11Texture2D;
 use windows::Win32::Graphics::DirectComposition::DCompositionCreateDevice2;
 use windows::Win32::Graphics::DirectComposition::IDCompositionDevice;
 use windows::Win32::Graphics::DirectComposition::IDCompositionSurface;
 use windows::Win32::Graphics::DirectComposition::IDCompositionTarget;
 use windows::Win32::Graphics::DirectComposition::IDCompositionVisual;
+use windows::Win32::Graphics::Dwm::DWM_BB_BLURREGION;
+use windows::Win32::Graphics::Dwm::DWM_BB_ENABLE;
+use windows::Win32::Graphics::Dwm::DWM_BLURBEHIND;
+use windows::Win32::Graphics::Dwm::DwmEnableBlurBehindWindow;
 use windows::Win32::Graphics::Dxgi::Common::DXGI_ALPHA_MODE_PREMULTIPLIED;
-use windows::Win32::Graphics::Dxgi::IDXGIDevice;
-use windows_future::AsyncActionCompletedHandler;
-use lazy_static::lazy_static;
-use parking_lot::Mutex;
-use windows::Graphics::DirectX::Direct3D11::IDirect3DSurface;
-use windows::Win32::Foundation::S_FALSE;
-use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
-use windows::Win32::Graphics::Direct2D::D2D1_BITMAP_PROPERTIES;
-use windows::Win32::Graphics::Direct2D::D2D1_BITMAPSOURCE_INTERPOLATION_MODE;
-use windows::Win32::Graphics::Direct2D::D2D1_BITMAPSOURCE_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
-use windows::Win32::Graphics::Direct2D::D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR;
-use windows::Win32::Graphics::Direct3D11::D3D11_RESOURCE_MISC_SHARED;
-use windows::Win32::Graphics::Direct3D11::D3D11_TEXTURE2D_DESC;
-use windows::Win32::Graphics::Direct3D11::D3D11_USAGE_DEFAULT;
-use windows::Win32::Graphics::Direct3D11::ID3D11Device;
-use windows::Win32::Graphics::Direct3D11::ID3D11Texture2D;
 use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R8G8B8A8_UNORM;
+use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_UNKNOWN;
+use windows::Win32::Graphics::Dxgi::IDXGIDevice;
 use windows::Win32::Graphics::Dxgi::IDXGIResource;
+use windows::Win32::Graphics::Dxgi::IDXGISurface;
+use windows::Win32::Graphics::Gdi::CreateRectRgn;
+use windows::Win32::Graphics::Gdi::ValidateRect;
 use windows::Win32::System::Com::CoIncrementMTAUsage;
 use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::Win32::System::WinRT::CreateDispatcherQueueController;
@@ -61,83 +105,39 @@ use windows::Win32::System::WinRT::DQTYPE_THREAD_CURRENT;
 use windows::Win32::System::WinRT::DispatcherQueueOptions;
 use windows::Win32::System::WinRT::RO_INIT_MULTITHREADED;
 use windows::Win32::System::WinRT::RoInitialize;
-use windows_capture::capture::CaptureControl;
-use windows_capture::capture::Context;
-use windows_capture::capture::GraphicsCaptureApiError;
-use windows_capture::graphics_capture_api::GraphicsCaptureApi;
-use windows_capture::settings::GraphicsCaptureItemType;
-use windows_capture::window::Window;
-use std::collections::HashMap;
-use std::io;
-use std::io::Write;
-use std::ops::Deref;
-use std::os::raw::c_void;
-use std::os::windows::raw::HANDLE;
-use std::ptr::null_mut;
-use std::sync::OnceLock;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
-use std::sync::mpsc;
-use std::sync::Arc;
-use std::sync::LazyLock;
-use std::time::Instant;
-use windows::Win32::Foundation::FALSE;
-use windows::Win32::Foundation::HWND;
-use windows::Win32::Foundation::LPARAM;
-use windows::Win32::Foundation::LRESULT;
-use windows::Win32::Foundation::TRUE;
-use windows::Win32::Foundation::WPARAM;
-use windows::Win32::Graphics::Direct2D::Common::D2D1_ALPHA_MODE_PREMULTIPLIED;
-use windows::Win32::Graphics::Direct2D::Common::D2D1_COLOR_F;
-use windows::Win32::Graphics::Direct2D::Common::D2D1_PIXEL_FORMAT;
-use windows::Win32::Graphics::Direct2D::Common::D2D_RECT_F;
-use windows::Win32::Graphics::Direct2D::Common::D2D_SIZE_U;
-use windows::Win32::Graphics::Direct2D::D2D1CreateFactory;
-use windows::Win32::Graphics::Direct2D::ID2D1Bitmap;
-use windows::Win32::Graphics::Direct2D::ID2D1Factory;
-use windows::Win32::Graphics::Direct2D::ID2D1HwndRenderTarget;
-use windows::Win32::Graphics::Direct2D::ID2D1SolidColorBrush;
-use windows::Win32::Graphics::Direct2D::D2D1_ANTIALIAS_MODE_PER_PRIMITIVE;
-use windows::Win32::Graphics::Direct2D::D2D1_BRUSH_PROPERTIES;
-use windows::Win32::Graphics::Direct2D::D2D1_FACTORY_TYPE_MULTI_THREADED;
-use windows::Win32::Graphics::Direct2D::D2D1_HWND_RENDER_TARGET_PROPERTIES;
-use windows::Win32::Graphics::Direct2D::D2D1_PRESENT_OPTIONS_IMMEDIATELY;
-use windows::Win32::Graphics::Direct2D::D2D1_RENDER_TARGET_PROPERTIES;
-use windows::Win32::Graphics::Direct2D::D2D1_RENDER_TARGET_TYPE_DEFAULT;
-use windows::Win32::Graphics::Dwm::DwmEnableBlurBehindWindow;
-use windows::Win32::Graphics::Dwm::DWM_BB_BLURREGION;
-use windows::Win32::Graphics::Dwm::DWM_BB_ENABLE;
-use windows::Win32::Graphics::Dwm::DWM_BLURBEHIND;
-use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_UNKNOWN;
-use windows::Win32::Graphics::Dxgi::IDXGISurface;
-use windows::Win32::Graphics::Gdi::CreateRectRgn;
-use windows::Win32::Graphics::Gdi::ValidateRect;
+use windows::Win32::UI::WindowsAndMessaging::CREATESTRUCTW;
 use windows::Win32::UI::WindowsAndMessaging::DefWindowProcW;
 use windows::Win32::UI::WindowsAndMessaging::DestroyWindow;
 use windows::Win32::UI::WindowsAndMessaging::DispatchMessageW;
+use windows::Win32::UI::WindowsAndMessaging::GWLP_USERDATA;
 use windows::Win32::UI::WindowsAndMessaging::GetMessageW;
 use windows::Win32::UI::WindowsAndMessaging::GetSystemMetrics;
 use windows::Win32::UI::WindowsAndMessaging::GetWindowLongPtrW;
-use windows::Win32::UI::WindowsAndMessaging::PostQuitMessage;
-use windows::Win32::UI::WindowsAndMessaging::SetWindowLongPtrW;
-use windows::Win32::UI::WindowsAndMessaging::ShowWindow;
-use windows::Win32::UI::WindowsAndMessaging::TranslateMessage;
-use windows::Win32::UI::WindowsAndMessaging::CREATESTRUCTW;
-use windows::Win32::UI::WindowsAndMessaging::GWLP_USERDATA;
 use windows::Win32::UI::WindowsAndMessaging::MSG;
+use windows::Win32::UI::WindowsAndMessaging::PostQuitMessage;
 use windows::Win32::UI::WindowsAndMessaging::SM_CXVIRTUALSCREEN;
 use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
 use windows::Win32::UI::WindowsAndMessaging::SW_MAXIMIZE;
 use windows::Win32::UI::WindowsAndMessaging::SW_MINIMIZE;
+use windows::Win32::UI::WindowsAndMessaging::SetWindowLongPtrW;
+use windows::Win32::UI::WindowsAndMessaging::ShowWindow;
+use windows::Win32::UI::WindowsAndMessaging::TranslateMessage;
 use windows::Win32::UI::WindowsAndMessaging::WM_CREATE;
 use windows::Win32::UI::WindowsAndMessaging::WM_DESTROY;
 use windows::Win32::UI::WindowsAndMessaging::WM_PAINT;
 use windows::Win32::UI::WindowsAndMessaging::WM_SETCURSOR;
 use windows::Win32::UI::WindowsAndMessaging::WNDCLASSW;
+use windows_capture::capture::CaptureControl;
+use windows_capture::capture::Context;
+use windows_capture::capture::GraphicsCaptureApiError;
 use windows_capture::capture::GraphicsCaptureApiHandler;
+use windows_capture::graphics_capture_api::GraphicsCaptureApi;
+use windows_capture::settings::GraphicsCaptureItemType;
 use windows_capture::settings::Settings;
+use windows_capture::window::Window;
 use windows_core::Interface;
 use windows_core::PCWSTR;
+use windows_future::AsyncActionCompletedHandler;
 use windows_numerics::Matrix3x2;
 
 pub struct RenderFactory(ID2D1Factory1);
@@ -213,8 +213,6 @@ fn create_d3d_device() -> color_eyre::Result<D3DResources> {
         )?;
     }
 
-
-
     Ok(D3DResources {
         device: device.unwrap(),
         device_context: context.unwrap(),
@@ -231,9 +229,8 @@ struct D2DResources {
     brush: ID2D1SolidColorBrush,
 }
 
-
 unsafe fn create_d2d_resources(dxgi_device: &IDXGIDevice) -> color_eyre::Result<D2DResources> {
-        /* let render_target_properties = D2D1_RENDER_TARGET_PROPERTIES {
+    /* let render_target_properties = D2D1_RENDER_TARGET_PROPERTIES {
             r#type: D2D1_RENDER_TARGET_TYPE_DEFAULT,
             pixelFormat: D2D1_PIXEL_FORMAT {
                 format: DXGI_FORMAT_R8G8B8A8_UNORM,
@@ -249,7 +246,7 @@ unsafe fn create_d2d_resources(dxgi_device: &IDXGIDevice) -> color_eyre::Result<
     println!("D2D render target created"); */
 
     let d2d_device = RENDER_FACTORY.CreateDevice(dxgi_device)?;
-    println!("D2D device created"); 
+    println!("D2D device created");
 
     // Create brush
     /* let brush = render_target.CreateSolidColorBrush(
@@ -274,7 +271,7 @@ unsafe fn create_d2d_resources(dxgi_device: &IDXGIDevice) -> color_eyre::Result<
         },
         None,
     )?;
-        
+
     Ok(D2DResources {
         device: d2d_device,
         context: d2d_context,
@@ -283,14 +280,9 @@ unsafe fn create_d2d_resources(dxgi_device: &IDXGIDevice) -> color_eyre::Result<
     })
 }
 
-
-
 #[allow(clippy::expect_used)]
-static D3D_DEVICE: LazyLock<D3DResources> = {
-    LazyLock::new(|| {
-        create_d3d_device().expect("creating D3D_DEVICE failed")
-    })
-};
+static D3D_DEVICE: LazyLock<D3DResources> =
+    { LazyLock::new(|| create_d3d_device().expect("creating D3D_DEVICE failed")) };
 
 #[derive(Debug, Clone)]
 pub struct RenderTarget(pub ID2D1RenderTarget);
@@ -317,7 +309,7 @@ pub struct WorkspaceSwitchWindow {
     pub target: Option<IDCompositionTargetLocal>,
     pub d2d_resources: Option<D2DResources>,
     pub brush_properties: D2D1_BRUSH_PROPERTIES,
-    pub capture_hash_map: HashMap<usize, Arc<Mutex<Capture>>>,
+    pub capture_hash_map: HashMap<String, Arc<Mutex<Capture>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -353,127 +345,139 @@ impl CustomCaptureApiHandler for Capture {
         let (halt_sender, halt_receiver) = mpsc::channel::<Arc<AtomicBool>>();
         let (callback_sender, callback_receiver) = mpsc::channel::<Arc<Mutex<Self>>>();
 
-        let thread_handle = std::thread::spawn(move || -> Result<(), GraphicsCaptureApiError<Self::Error>> {
-            // Initialize WinRT
-            static INIT_MTA: OnceLock<()> = OnceLock::new();
-            INIT_MTA.get_or_init(|| {
-                unsafe {
-                    CoIncrementMTAUsage().expect("Failed to increment MTA usage");
-                };
-            });
+        let thread_handle = std::thread::spawn(
+            move || -> Result<(), GraphicsCaptureApiError<Self::Error>> {
+                // Initialize WinRT
+                static INIT_MTA: OnceLock<()> = OnceLock::new();
+                INIT_MTA.get_or_init(|| {
+                    unsafe {
+                        CoIncrementMTAUsage().expect("Failed to increment MTA usage");
+                    };
+                });
 
-            match unsafe { RoInitialize(RO_INIT_MULTITHREADED) } {
-                Ok(_) => (),
-                Err(e) => {
-                    if e.code() == S_FALSE {
-                        // Already initialized
-                    } else {
-                        return Err(GraphicsCaptureApiError::FailedToInitWinRT);
+                match unsafe { RoInitialize(RO_INIT_MULTITHREADED) } {
+                    Ok(_) => (),
+                    Err(e) => {
+                        if e.code() == S_FALSE {
+                            // Already initialized
+                        } else {
+                            return Err(GraphicsCaptureApiError::FailedToInitWinRT);
+                        }
                     }
                 }
-            }
 
-            // Create a dispatcher queue for the current thread
-            let options = DispatcherQueueOptions {
-                dwSize: u32::try_from(std::mem::size_of::<DispatcherQueueOptions>()).unwrap(),
-                threadType: DQTYPE_THREAD_CURRENT,
-                apartmentType: DQTAT_COM_NONE,
-            };
-            let controller = unsafe {
-                CreateDispatcherQueueController(options)
-                    .map_err(|_| GraphicsCaptureApiError::FailedToCreateDispatcherQueueController)?
-            };
+                // Create a dispatcher queue for the current thread
+                let options = DispatcherQueueOptions {
+                    dwSize: u32::try_from(std::mem::size_of::<DispatcherQueueOptions>()).unwrap(),
+                    threadType: DQTYPE_THREAD_CURRENT,
+                    apartmentType: DQTAT_COM_NONE,
+                };
+                let controller = unsafe {
+                    CreateDispatcherQueueController(options).map_err(|_| {
+                        GraphicsCaptureApiError::FailedToCreateDispatcherQueueController
+                    })?
+                };
 
-            // Get current thread ID
-            let thread_id = unsafe { GetCurrentThreadId() };
+                // Get current thread ID
+                let thread_id = unsafe { GetCurrentThreadId() };
 
-            // Create direct3d device and context
-            // let (d3d_device, d3d_device_context) = create_d3d_device()?;
+                // Create direct3d device and context
+                // let (d3d_device, d3d_device_context) = create_d3d_device()?;
 
-            // Start capture
-            let result = Arc::new(Mutex::new(None));
+                // Start capture
+                let result = Arc::new(Mutex::new(None));
 
-            let flags = settings.flags();
+                let flags = settings.flags();
 
-            let ctx = Context {
-                flags: flags.clone(),
-                device: d3d_device.clone(),
-                device_context: d3d_device_context.clone(),
-            };
+                let ctx = Context {
+                    flags: flags.clone(),
+                    device: d3d_device.clone(),
+                    device_context: d3d_device_context.clone(),
+                };
 
-            let callback = Arc::new(Mutex::new(Self::new(ctx).map_err(GraphicsCaptureApiError::NewHandlerError)?));
+                let callback = Arc::new(Mutex::new(
+                    Self::new(ctx).map_err(GraphicsCaptureApiError::NewHandlerError)?,
+                ));
 
-            // let item = settings.item().clone();
+                // let item = settings.item().clone();
 
-            let mut capture = GraphicsCaptureApi::new(
-                d3d_device,
-                d3d_device_context,
-                item.try_into().map_err(|_| GraphicsCaptureApiError::ItemConvertFailed)?,
-                callback.clone(),
-                settings.cursor_capture(),
-                settings.draw_border(),
-                windows_capture::settings::SecondaryWindowSettings::Default,
-                windows_capture::settings::MinimumUpdateIntervalSettings::Default,
-                windows_capture::settings::DirtyRegionSettings::Default,
-                windows_capture::settings::ColorFormat::Rgba8,
-                thread_id,
-                result.clone(),
-            )
-            .map_err(GraphicsCaptureApiError::GraphicsCaptureApiError)?;
+                let mut capture = GraphicsCaptureApi::new(
+                    d3d_device,
+                    d3d_device_context,
+                    item.try_into()
+                        .map_err(|_| GraphicsCaptureApiError::ItemConvertFailed)?,
+                    callback.clone(),
+                    settings.cursor_capture(),
+                    settings.draw_border(),
+                    windows_capture::settings::SecondaryWindowSettings::Default,
+                    windows_capture::settings::MinimumUpdateIntervalSettings::Default,
+                    windows_capture::settings::DirtyRegionSettings::Default,
+                    windows_capture::settings::ColorFormat::Rgba8,
+                    thread_id,
+                    result.clone(),
+                )
+                .map_err(GraphicsCaptureApiError::GraphicsCaptureApiError)?;
 
-            capture.start_capture().map_err(GraphicsCaptureApiError::GraphicsCaptureApiError)?;
+                capture
+                    .start_capture()
+                    .map_err(GraphicsCaptureApiError::GraphicsCaptureApiError)?;
 
-            // Send halt handle
-            let halt_handle = capture.halt_handle();
-            halt_sender.send(halt_handle).unwrap();
+                // Send halt handle
+                let halt_handle = capture.halt_handle();
+                halt_sender.send(halt_handle).unwrap();
 
-            // Send callback
-            callback_sender.send(callback).unwrap();
+                // Send callback
+                callback_sender.send(callback).unwrap();
 
-            // Message loop
-            let mut message = MSG::default();
-            unsafe {
-                while GetMessageW(&mut message, None, 0, 0).as_bool() {
-                    let _ = TranslateMessage(&message);
-                    DispatchMessageW(&message);
+                // Message loop
+                let mut message = MSG::default();
+                unsafe {
+                    while GetMessageW(&mut message, None, 0, 0).as_bool() {
+                        let _ = TranslateMessage(&message);
+                        DispatchMessageW(&message);
+                    }
                 }
-            }
 
-            // Shutdown dispatcher queue
-            let async_action = controller
-                .ShutdownQueueAsync()
-                .map_err(|_| GraphicsCaptureApiError::FailedToShutdownDispatcherQueue)?;
+                // Shutdown dispatcher queue
+                let async_action = controller
+                    .ShutdownQueueAsync()
+                    .map_err(|_| GraphicsCaptureApiError::FailedToShutdownDispatcherQueue)?;
 
-            async_action
-                .SetCompleted(&AsyncActionCompletedHandler::new(move |_, _| -> Result<(), windows::core::Error> {
-                    unsafe { PostQuitMessage(0) };
-                    Ok(())
-                }))
-                .map_err(|_| GraphicsCaptureApiError::FailedToSetDispatcherQueueCompletedHandler)?;
+                async_action
+                    .SetCompleted(&AsyncActionCompletedHandler::new(
+                        move |_, _| -> Result<(), windows::core::Error> {
+                            unsafe { PostQuitMessage(0) };
+                            Ok(())
+                        },
+                    ))
+                    .map_err(|_| {
+                        GraphicsCaptureApiError::FailedToSetDispatcherQueueCompletedHandler
+                    })?;
 
-            // Final message loop
-            let mut message = MSG::default();
-            unsafe {
-                while GetMessageW(&mut message, None, 0, 0).as_bool() {
-                    let _ = TranslateMessage(&message);
-                    DispatchMessageW(&message);
+                // Final message loop
+                let mut message = MSG::default();
+                unsafe {
+                    while GetMessageW(&mut message, None, 0, 0).as_bool() {
+                        let _ = TranslateMessage(&message);
+                        DispatchMessageW(&message);
+                    }
                 }
-            }
 
-            // Stop capture
-            capture.stop_capture();
+                // Stop capture
+                capture.stop_capture();
 
-            // Uninitialize WinRT
-            // unsafe { RoUninitialize() }; // Not sure if this is needed here
+                // Uninitialize WinRT
+                // unsafe { RoUninitialize() }; // Not sure if this is needed here
 
-            // Check handler result
-            let result = result.lock().take();
-            if let Some(e) = result {
-                return Err(GraphicsCaptureApiError::FrameHandlerError(e));
-            }
+                // Check handler result
+                let result = result.lock().take();
+                if let Some(e) = result {
+                    return Err(GraphicsCaptureApiError::FrameHandlerError(e));
+                }
 
-            Ok(())
-        });
+                Ok(())
+            },
+        );
 
         let Ok(halt_handle) = halt_receiver.recv() else {
             match thread_handle.join() {
@@ -495,7 +499,6 @@ impl CustomCaptureApiHandler for Capture {
 
         Ok(CaptureControl::new(thread_handle, halt_handle, callback))
     }
-
 }
 
 impl windows_capture::capture::GraphicsCaptureApiHandler for Capture {
@@ -510,7 +513,6 @@ impl windows_capture::capture::GraphicsCaptureApiHandler for Capture {
         })
     }
 
-
     // Called every time a new frame is available.
     fn on_frame_arrived(
         &mut self,
@@ -521,7 +523,7 @@ impl windows_capture::capture::GraphicsCaptureApiHandler for Capture {
             capture_control.stop();
             return Ok(());
         }
-        let  texture = frame.as_raw_texture();
+        let texture = frame.as_raw_texture();
         self.last_frame.lock().replace(texture.clone());
         /* if let Some(render_target) = self.render_target.lock().as_ref() {
             let mut bitmap: Option<ID2D1Bitmap> = None;
@@ -530,7 +532,7 @@ impl windows_capture::capture::GraphicsCaptureApiHandler for Capture {
         //         let mut desc = D3D11_TEXTURE2D_DESC::default();
         //          texture.GetDesc(&mut desc);
         //         println!("desc: {desc:?}");
-        //         
+        //
         // let texture_desc = D3D11_TEXTURE2D_DESC {
         //     Width: desc.Width,
         //     Height: desc.Height,
@@ -694,7 +696,7 @@ impl WorkspaceSwitchWindow {
 
         unsafe {
             let dxgi_device: IDXGIDevice = D3D_DEVICE.device.cast()?;
-                    // 1. Create DComp device
+            // 1. Create DComp device
             let device: IDCompositionDevice = DCompositionCreateDevice2(&dxgi_device)?;
             println!("DComp device created");
 
@@ -723,7 +725,6 @@ impl WorkspaceSwitchWindow {
             // 6. Set as root visual
             target.SetRoot(&visual)?;
 
-
             // Keep references to prevent early release
             let dxgi_device = dxgi_device.clone();
 
@@ -736,17 +737,12 @@ impl WorkspaceSwitchWindow {
             workspace_switch_window.surface = Some(IDCompositionSurfaceLocal(surface));
             workspace_switch_window.target = Some(IDCompositionTargetLocal(target));
 
-            workspace_switch_window.d2d_resources = Some(create_d2d_resources(
-                &dxgi_device,
-            )?);
+            workspace_switch_window.d2d_resources = Some(create_d2d_resources(&dxgi_device)?);
 
             println!("D3D device created");
 
             Ok(workspace_switch_window)
         }
-
-
-
     }
 
     pub fn begin_draw(&mut self) -> color_eyre::Result<()> {
@@ -756,21 +752,19 @@ impl WorkspaceSwitchWindow {
                 let dxgi_surface: IDXGISurface = surface.0.BeginDraw(None, &mut offset)?;
 
                 if let Some(d2d_resources) = self.d2d_resources.as_mut() {
-
                     let bitmap_properties = D2D1_BITMAP_PROPERTIES1 {
-                            pixelFormat: D2D1_PIXEL_FORMAT {
-                                format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
-                            }   ,
-                            dpiX: 96.0,
-                            dpiY: 96.0,
-                            colorContext: std::mem::ManuallyDrop::new(None),
-                            bitmapOptions:  D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+                        pixelFormat: D2D1_PIXEL_FORMAT {
+                            format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                            alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+                        },
+                        dpiX: 96.0,
+                        dpiY: 96.0,
+                        colorContext: std::mem::ManuallyDrop::new(None),
+                        bitmapOptions: D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
                     };
-                    let d2d_target = d2d_resources.context.CreateBitmapFromDxgiSurface(
-                        &dxgi_surface,
-                        Some(&bitmap_properties),
-                    )?;
+                    let d2d_target = d2d_resources
+                        .context
+                        .CreateBitmapFromDxgiSurface(&dxgi_surface, Some(&bitmap_properties))?;
 
                     d2d_resources.context.SetTarget(&d2d_target);
                     d2d_resources.target = Some(d2d_target);
@@ -778,7 +772,6 @@ impl WorkspaceSwitchWindow {
                     d2d_resources.context.BeginDraw();
                     d2d_resources.context.Clear(None);
                 }
-
             }
 
             Ok(())
@@ -806,26 +799,36 @@ impl WorkspaceSwitchWindow {
         }
     }
 
-    pub fn draw_workspace(&mut self, workspace: &Workspace, x_offset: i32) -> color_eyre::Result<()> {
+    pub fn draw_workspace(
+        &mut self,
+        workspace_id: usize,
+        workspace: &Workspace,
+        x_offset: i32,
+    ) -> color_eyre::Result<()> {
         unsafe {
-                if let Some(d2d_resources) = self.d2d_resources.as_ref() {
-                    if let Some(monitor_rect) = self.monitor_rect.as_ref() {
-                        if workspace.containers().len() > 0 {
-                            for (container_index, container) in workspace.containers().iter().enumerate() {
-                                if self.capture_hash_map.contains_key(&container_index) {
+            if let Some(d2d_resources) = self.d2d_resources.as_ref() {
+                if let Some(monitor_rect) = self.monitor_rect.as_ref() {
+                    if workspace.containers().len() > 0 {
+                        for (container_index, container) in
+                            workspace.containers().iter().enumerate()
+                        {
+                            if self
+                                .capture_hash_map
+                                .contains_key(&format!("{workspace_id}:{container_index}"))
+                            {
+                                continue;
+                            }
+
+                            let layout = workspace.latest_layout.get(container_index).unwrap();
+                            for window in container.windows() {
+                                if !window.is_visible() {
+                                    println!("window not visible");
                                     continue;
                                 }
 
-                                let layout = workspace.latest_layout.get(container_index).unwrap();
-                                for window in container.windows() {
-                                    if !window.is_visible() {
-                                        println!("window not visible");
-                                        continue;
-                                    }
-
-                                    let hwnd = window.hwnd;
-                                    let settings = Settings::new(
-                                        Window::from_raw_hwnd(as_ptr!(hwnd)), 
+                                let hwnd = window.hwnd;
+                                let settings = Settings::new(
+                                        Window::from_raw_hwnd(as_ptr!(hwnd)),
                                     windows_capture::settings::CursorCaptureSettings::WithoutCursor,
                                     windows_capture::settings::DrawBorderSettings::WithoutBorder,
                                     windows_capture::settings::SecondaryWindowSettings::Default,
@@ -834,71 +837,80 @@ impl WorkspaceSwitchWindow {
                                     windows_capture::settings::ColorFormat::Rgba8,
                                         (layout.right, layout.bottom, hwnd),
                                     );
-                                    let capture = Capture::start_free_threaded_with_item(
+                                let capture = Capture::start_free_threaded_with_item(
                                     Window::from_raw_hwnd(as_ptr!(hwnd)),
                                     self.d3d_device.as_ref().unwrap().clone(),
                                     self.d3d_device_context.as_ref().unwrap().clone(),
-                                    settings
+                                    settings,
                                 )?;
-                                    self.capture_hash_map.insert(container_index, capture.callback());
-                                    println!("capture started: {container_index} {hwnd}");
-                                }
+                                self.capture_hash_map.insert(
+                                    format!("{workspace_id}:{container_index}"),
+                                    capture.callback(),
+                                );
+                                println!("capture started: {container_index} {hwnd}");
                             }
-                            for (index, rect) in workspace.latest_layout.iter().enumerate() {
+                        }
+                        for (index, rect) in workspace.latest_layout.iter().enumerate() {
+                            let target_rect = D2D_RECT_F {
+                                left: (rect.left - monitor_rect.left + x_offset) as f32,
+                                top: (rect.top - monitor_rect.top) as f32,
+                                right: ((rect.left - monitor_rect.left) + rect.right + x_offset)
+                                    as f32,
+                                bottom: ((rect.top - monitor_rect.top) + rect.bottom) as f32,
+                            };
+                            //
+                            d2d_resources.context.DrawRectangle(
+                                &target_rect,
+                                &d2d_resources.brush,
+                                3.0,
+                                None,
+                            );
+                            // d2d_resources.context.FillRectangle(&target_rect, &d2d_resources.brush);
+                            println!("rect: {target_rect:?}");
 
-                                let target_rect = D2D_RECT_F {
-                                    left: (rect.left - monitor_rect.left + x_offset) as f32,
-                                    top: (rect.top - monitor_rect.top) as f32,
-                                    right: ((rect.left - monitor_rect.left) + rect.right + x_offset)
-                                        as f32,
-                                    bottom: ((rect.top - monitor_rect.top) + rect.bottom) as f32,
+                            let capture = self
+                                .capture_hash_map
+                                .get(&format!("{workspace_id}:{index}"));
+                            if capture.is_none() {
+                                continue;
+                            }
+
+                            let capture = capture.unwrap().lock();
+                            println!("capture: {capture:?}");
+                            let last_frame = &capture.last_frame;
+                            println!("last_frame: {last_frame:?}");
+
+                            if let Some(mut texture) = last_frame.lock().as_ref() {
+                                let bitmap_properties = D2D1_BITMAP_PROPERTIES1 {
+                                    pixelFormat: D2D1_PIXEL_FORMAT {
+                                        format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                                        alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+                                    },
+                                    dpiX: 96.0,
+                                    dpiY: 96.0,
+                                    colorContext: std::mem::ManuallyDrop::new(None),
+                                    bitmapOptions: D2D1_BITMAP_OPTIONS_TARGET,
                                 };
-                                //
-                                d2d_resources.context.DrawRectangle(&target_rect, &d2d_resources.brush, 3.0, None);
-                                // d2d_resources.context.FillRectangle(&target_rect, &d2d_resources.brush);
-                                println!("rect: {target_rect:?}");
-                                
-                                let capture = self.capture_hash_map.get(&index);
-                                if capture.is_none() {
-                                    continue;
-                                }
-
-                                let capture = capture.unwrap().lock();
-                                println!("capture: {capture:?}");
-                                let last_frame = &capture.last_frame;
-                                println!("last_frame: {last_frame:?}");
-
-                                if let Some(mut texture) = last_frame.lock().as_ref() {
-                                    let bitmap_properties = D2D1_BITMAP_PROPERTIES1 {
-                                            pixelFormat: D2D1_PIXEL_FORMAT {
-                                                format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                                                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
-                                            }   ,
-                                            dpiX: 96.0,
-                                            dpiY: 96.0,
-                                            colorContext: std::mem::ManuallyDrop::new(None),
-                                            bitmapOptions:  D2D1_BITMAP_OPTIONS_TARGET,
-                                    };
-                                    let texture_surface: IDXGISurface = texture.cast()?;
-                                    let bitmap = d2d_resources.context.CreateBitmapFromDxgiSurface(
-                                        &texture_surface,
-                                        Some(&bitmap_properties as *const _),
-                                    )?;
-                                    println!("bitmap: {bitmap:?}");
-                                    // println!("CreateSharedBitmap result: {:?}");
-                                    d2d_resources.context.DrawBitmap(
-                                        &bitmap,
-                                        Some(&target_rect as *const _),
-                                        1.0,
-                                        D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
-                                        None,
-                                        None,
-                                    );
-                                }
+                                let texture_surface: IDXGISurface = texture.cast()?;
+                                let bitmap = d2d_resources.context.CreateBitmapFromDxgiSurface(
+                                    &texture_surface,
+                                    Some(&bitmap_properties as *const _),
+                                )?;
+                                println!("bitmap: {bitmap:?}");
+                                // println!("CreateSharedBitmap result: {:?}");
+                                d2d_resources.context.DrawBitmap(
+                                    &bitmap,
+                                    Some(&target_rect as *const _),
+                                    1.0,
+                                    D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
+                                    None,
+                                    None,
+                                );
                             }
                         }
                     }
                 }
+            }
         }
         Ok(())
     }

--- a/komorebi/src/animation/workspace_switch.rs
+++ b/komorebi/src/animation/workspace_switch.rs
@@ -5,6 +5,7 @@ use crate::workspace::Workspace;
 use crate::WindowManager;
 use crate::WindowsApi;
 
+use color_eyre::eyre::OptionExt;
 use komorebi_layouts::Rect;
 use lazy_static::lazy_static;
 use parking_lot::Mutex;
@@ -529,64 +530,9 @@ impl windows_capture::capture::GraphicsCaptureApiHandler for Capture {
             return Ok(());
         }
         let texture = frame.as_raw_texture();
-        self.last_frame.lock().replace(texture.clone());
-        /* if let Some(render_target) = self.render_target.lock().as_ref() {
-            let mut bitmap: Option<ID2D1Bitmap> = None;
-            unsafe {
-                // let mut surface = frame.as_raw_surface();
-        //         let mut desc = D3D11_TEXTURE2D_DESC::default();
-        //          texture.GetDesc(&mut desc);
-        //         println!("desc: {desc:?}");
-        //
-        // let texture_desc = D3D11_TEXTURE2D_DESC {
-        //     Width: desc.Width,
-        //     Height: desc.Height,
-        //     MipLevels: desc.MipLevels,
-        //     ArraySize: desc.ArraySize,
-        //             Format: desc.Format,
-        //     SampleDesc: desc.SampleDesc,
-        //     Usage: D3D11_USAGE_DEFAULT,
-        //     BindFlags: desc.BindFlags,
-        //     CPUAccessFlags: 0,
-        //     MiscFlags: desc.MiscFlags | D3D11_RESOURCE_MISC_SHARED.0 as u32,
-        // };
-        //         let device: ID3D11Device = texture.GetDevice()?;
-        //         println!("device: {device:?}");
-        //         let device_context= device.GetImmediateContext()?;
-        //         println!("device_context: {device_context:?}");
-        //
-        //         let mut shared_texture: Option<ID3D11Texture2D> = None;
-        //         device.CreateTexture2D(
-        //             &texture_desc,
-        //             None,
-        //             Some(&mut shared_texture));
-        //         println!("shared_texture: {shared_texture:?}");
-        //         device_context.CopyResource(shared_texture.as_ref().unwrap(), texture);
-        //         println!("CopyResource");
-        //
-        //         let resource: IDXGIResource = shared_texture.as_ref().unwrap().cast()?;
-        //         println!("resource: {resource:?}");
-                // let handle = resource.GetSharedHandle().unwrap();
-                let result = render_target.CreateSharedBitmap(
-                    &IDXGISurface::IID as *const windows_core::GUID,
-                    std::mem::transmute_copy(&mut texture),
-                    Some(&D2D1_BITMAP_PROPERTIES {
-                    pixelFormat: D2D1_PIXEL_FORMAT {
-                        format: DXGI_FORMAT_R8G8B8A8_UNORM,
-                        alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
-                    }   ,
-                    dpiX: 96.0,
-                    dpiY: 96.0,
-                    }),
-                    &mut bitmap,
-                );
-                println!("CreateSharedBitmap result: {result:?}");
 
-            }
-            let mut last_frame = self.last_frame.lock();
-            *last_frame = bitmap;
-            drop(last_frame);
-        } */
+        self.last_frame.lock().replace(texture.clone());
+
         Ok(())
     }
 
@@ -609,7 +555,6 @@ impl WorkspaceSwitchWindow {
     }
 
     pub fn create(monitor: Monitor) -> color_eyre::Result<Box<Self>> {
-        // println!("create workspace for rect: {monitor:#?}");
         let monitor_id: isize = monitor.id;
 
         if let Some(window) = WORKSPACE_SWITCH_WINDOWS.lock().remove(&monitor_id) {
@@ -821,16 +766,17 @@ impl WorkspaceSwitchWindow {
         x_offset: i32,
     ) -> color_eyre::Result<()> {
         unsafe {
+            let monitor_id = self.monitor_id.ok_or_eyre("monitor id not set")?;
+
             if let Some(d2d_resources) = self.d2d_resources.as_ref() {
                 if let Some(monitor_rect) = self.monitor_rect.as_ref() {
                     if workspace.containers().len() > 0 {
                         for (container_index, container) in
                             workspace.containers().iter().enumerate()
                         {
-                            if self
-                                .capture_hash_map
-                                .contains_key(&format!("{workspace_id}:{container_index}"))
-                            {
+                            if self.capture_hash_map.contains_key(&format!(
+                                "{monitor_id}:{workspace_id}:{container_index}"
+                            )) {
                                 continue;
                             }
 
@@ -866,7 +812,7 @@ impl WorkspaceSwitchWindow {
                                     settings,
                                 )?;
                                 self.capture_hash_map.insert(
-                                    format!("{workspace_id}:{container_index}"),
+                                    format!("{monitor_id}:{workspace_id}:{container_index}"),
                                     capture.callback(),
                                 );
                                 println!("capture started: {container_index} {hwnd}");
@@ -891,7 +837,7 @@ impl WorkspaceSwitchWindow {
 
                             let capture = self
                                 .capture_hash_map
-                                .get(&format!("{workspace_id}:{index}"));
+                                .get(&format!("{monitor_id}:{workspace_id}:{index}"));
                             if capture.is_none() {
                                 continue;
                             }

--- a/komorebi/src/animation/workspace_switch.rs
+++ b/komorebi/src/animation/workspace_switch.rs
@@ -296,6 +296,11 @@ impl Deref for RenderTarget {
     }
 }
 
+lazy_static! {
+    pub static ref WORKSPACE_SWITCH_WINDOWS: Arc<Mutex<HashMap<isize, Box<WorkspaceSwitchWindow>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+}
+
 #[derive(Debug, Clone)]
 pub struct WorkspaceSwitchWindow {
     pub hwnd: isize,
@@ -598,9 +603,19 @@ impl WorkspaceSwitchWindow {
         HWND(windows_api::as_ptr!(self.hwnd))
     }
 
+    pub fn cache_window(window: Box<Self>) {
+        let monitor_id: isize = window.monitor_id.unwrap();
+        WORKSPACE_SWITCH_WINDOWS.lock().insert(monitor_id, window);
+    }
+
     pub fn create(monitor: Monitor) -> color_eyre::Result<Box<Self>> {
         // println!("create workspace for rect: {monitor:#?}");
         let monitor_id: isize = monitor.id;
+
+        if let Some(window) = WORKSPACE_SWITCH_WINDOWS.lock().remove(&monitor_id) {
+            return Ok(window);
+        }
+
         let name: Vec<u16> = format!("komoanimation-{monitor_id}\0")
             .encode_utf16()
             .collect();
@@ -819,7 +834,14 @@ impl WorkspaceSwitchWindow {
                                 continue;
                             }
 
-                            let layout = workspace.latest_layout.get(container_index).unwrap();
+                            let layout = workspace.latest_layout.get(container_index);
+
+                            if layout.is_none() {
+                                continue;
+                            }
+
+                            let layout = layout.unwrap();
+
                             for window in container.windows() {
                                 if !window.is_visible() {
                                     println!("window not visible");

--- a/komorebi/src/animation/workspace_switch.rs
+++ b/komorebi/src/animation/workspace_switch.rs
@@ -795,7 +795,7 @@ impl WorkspaceSwitchWindow {
 
     pub fn end_draw(&mut self) {
         unsafe {
-            if let Some(mut d2d_resources) = self.d2d_resources.as_mut() {
+            if let Some(d2d_resources) = self.d2d_resources.as_mut() {
                 let result = d2d_resources.context.EndDraw(None, None);
                 println!("EndDraw d2d result: {result:?}");
                 d2d_resources.target = None;
@@ -880,15 +880,14 @@ impl WorkspaceSwitchWindow {
                                     as f32,
                                 bottom: ((rect.top - monitor_rect.top) + rect.bottom) as f32,
                             };
-                            //
-                            // d2d_resources.context.DrawRectangle(
-                            //     &target_rect,
-                            //     &d2d_resources.brush,
-                            //     3.0,
-                            //     None,
-                            // );
+
+                            d2d_resources.context.DrawRectangle(
+                                &target_rect,
+                                &d2d_resources.brush,
+                                3.0,
+                                None,
+                            );
                             // d2d_resources.context.FillRectangle(&target_rect, &d2d_resources.brush);
-                            println!("rect: {target_rect:?}");
 
                             let capture = self
                                 .capture_hash_map
@@ -898,11 +897,9 @@ impl WorkspaceSwitchWindow {
                             }
 
                             let capture = capture.unwrap().lock();
-                            println!("capture: {capture:?}");
                             let last_frame = &capture.last_frame;
-                            println!("last_frame: {last_frame:?}");
 
-                            if let Some(mut texture) = last_frame.lock().as_ref() {
+                            if let Some(texture) = last_frame.lock().as_ref() {
                                 let bitmap_properties = D2D1_BITMAP_PROPERTIES1 {
                                     pixelFormat: D2D1_PIXEL_FORMAT {
                                         format: DXGI_FORMAT_R8G8B8A8_UNORM,
@@ -918,8 +915,6 @@ impl WorkspaceSwitchWindow {
                                     &texture_surface,
                                     Some(&bitmap_properties as *const _),
                                 )?;
-                                println!("bitmap: {bitmap:?}");
-                                // println!("CreateSharedBitmap result: {:?}");
                                 d2d_resources.context.DrawBitmap(
                                     &bitmap,
                                     Some(&target_rect as *const _),

--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -346,7 +346,6 @@ fn main() -> eyre::Result<()> {
         listen_for_movements(wm.clone());
     }
 
-
     let (ctrlc_sender, ctrlc_receiver) = crossbeam_channel::bounded(1);
     ctrlc::set_handler(move || {
         ctrlc_sender

--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -346,6 +346,7 @@ fn main() -> eyre::Result<()> {
         listen_for_movements(wm.clone());
     }
 
+
     let (ctrlc_sender, ctrlc_receiver) = crossbeam_channel::bounded(1);
     ctrlc::set_handler(move || {
         ctrlc_sender

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -1,31 +1,173 @@
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use color_eyre::eyre;
-use color_eyre::eyre::OptionExt;
 use color_eyre::eyre::bail;
+use color_eyre::eyre::OptionExt;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::animation::lerp::Lerp;
+use crate::animation::prefix::new_animation_key;
+use crate::animation::prefix::AnimationPrefix;
+use crate::animation::workspace_switch::WorkspaceSwitchWindow;
+use crate::animation::AnimationEngine;
+use crate::animation::RenderDispatcher;
+use crate::animation::ANIMATION_MANAGER;
 use crate::border_manager::BORDER_ENABLED;
 use crate::border_manager::BORDER_OFFSET;
 use crate::border_manager::BORDER_WIDTH;
 use crate::core::Rect;
+use crate::stackbar_manager;
+use crate::AnimationStyle;
 
-use crate::DEFAULT_CONTAINER_PADDING;
-use crate::DEFAULT_WORKSPACE_PADDING;
+use crate::container::Container;
+use crate::ring::Ring;
+use crate::workspace::Workspace;
+use crate::workspace::WorkspaceGlobals;
+use crate::workspace::WorkspaceLayer;
 use crate::DefaultLayout;
 use crate::FloatingLayerBehaviour;
 use crate::Layout;
 use crate::OperationDirection;
 use crate::Wallpaper;
 use crate::WindowsApi;
-use crate::container::Container;
-use crate::ring::Ring;
-use crate::workspace::Workspace;
-use crate::workspace::WorkspaceGlobals;
-use crate::workspace::WorkspaceLayer;
+use crate::DEFAULT_CONTAINER_PADDING;
+use crate::DEFAULT_WORKSPACE_PADDING;
+
+struct WorkspaceSwitchRenderDispatcher {
+    monitor: Monitor,
+    workspace_idx: usize,
+    render_window: Option<Box<WorkspaceSwitchWindow>>,
+    to_left: bool,
+    style: AnimationStyle,
+}
+
+impl WorkspaceSwitchRenderDispatcher {
+    const PREFIX: AnimationPrefix = AnimationPrefix::WrokspaceSwitch;
+
+    pub fn new(
+        monitor: &Monitor,
+        workspace_idx: usize,
+        to_left: bool,
+        style: AnimationStyle,
+    ) -> Self {
+        Self {
+            monitor: monitor.clone(),
+            workspace_idx,
+            to_left,
+            render_window: None,
+            style,
+        }
+    }
+}
+
+impl RenderDispatcher for WorkspaceSwitchRenderDispatcher {
+    fn get_animation_key(&self) -> String {
+        new_animation_key(
+            WorkspaceSwitchRenderDispatcher::PREFIX,
+            self.monitor.id.to_string(),
+        )
+    }
+
+    fn pre_render(&mut self) -> eyre::Result<()> {
+        stackbar_manager::STACKBAR_TEMPORARILY_DISABLED.store(true, Ordering::SeqCst);
+        stackbar_manager::send_notification();
+        self.render_window = Some(WorkspaceSwitchWindow::create(self.monitor.clone()).unwrap());
+
+        Ok(())
+    }
+
+    fn render(&mut self, progress: f64) -> eyre::Result<()> {
+        if let Some(render_window) = &mut self.render_window {
+            let monitor_width = self.monitor.size.right;
+            let monitor_previous_workspace_idx = self.monitor.last_focused_workspace;
+            let workspace = &mut self
+                .monitor
+                .workspaces_mut()
+                .get_mut(self.workspace_idx)
+                .unwrap();
+            render_window.begin_draw();
+            let result = render_window.draw_workspace(
+                workspace,
+                (monitor_width).lerp(0, progress, self.style) as i32,
+            );
+
+            println!("result: {result:?}");
+            if let Some(previous_workspace) = self
+                .monitor
+                .workspaces_mut()
+                .get_mut(monitor_previous_workspace_idx.unwrap())
+            {
+                render_window.draw_workspace(
+                    previous_workspace,
+                    (0).lerp(-monitor_width, progress, self.style) as i32,
+                );
+            }
+            render_window.end_draw();
+        }
+        // let new_rect = self.start_rect.lerp(self.target_rect, progress, self.style);
+
+        // we don't check WINDOW_HANDLING_BEHAVIOUR here because animations
+        // are always run on a separate thread
+        // WindowsApi::move_window(self.hwnd, &new_rect, false)?;
+        // WindowsApi::invalidate_rect(self.hwnd, None, false);
+
+        Ok(())
+    }
+
+    fn post_render(&mut self) -> eyre::Result<()> {
+        // let mut monitor = ;
+        let hmonitor = self.monitor.id;
+        let monitor_wp = self.monitor.wallpaper.clone();
+        let workspace = &mut self
+            .monitor
+            .workspaces_mut()
+            .get_mut(self.workspace_idx)
+            .unwrap();
+
+        if let Some(render_window) = self.render_window.take() {
+            let raw_pointer = Box::into_raw(render_window);
+            unsafe {
+                (*raw_pointer).destroy()?;
+            };
+            self.render_window = None;
+        }
+
+        workspace.restore(false, hmonitor, &monitor_wp)?;
+        // we don't add the async_window_pos flag here because animations
+        // are always run on a separate thread
+        // WindowsApi::position_window(self.hwnd, &self.target_rect, self.top, false)?;
+        if ANIMATION_MANAGER
+            .lock()
+            .count_in_progress(WorkspaceSwitchRenderDispatcher::PREFIX)
+            == 0
+        {
+            // if WindowsApi::foreground_window().unwrap_or_default() == self.hwnd {
+            //     focus_manager::send_notification(self.hwnd)
+            // }
+
+            stackbar_manager::STACKBAR_TEMPORARILY_DISABLED.store(false, Ordering::SeqCst);
+
+            stackbar_manager::send_notification();
+            // transparency_manager::send_notification();
+        }
+
+        Ok(())
+    }
+
+    fn on_cancle(&mut self) {
+        if let Some(render_window) = self.render_window.take() {
+            let raw_pointer = Box::into_raw(render_window);
+            unsafe {
+                (*raw_pointer).destroy().unwrap();
+            };
+            self.render_window = None;
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -171,9 +313,19 @@ impl Monitor {
         let focused_idx = self.focused_workspace_idx();
         let hmonitor = self.id;
         let monitor_wp = self.wallpaper.clone();
+        let monitor = self.clone();
         for (i, workspace) in self.workspaces_mut().iter_mut().enumerate() {
             if i == focused_idx {
-                workspace.restore(mouse_follows_focus, hmonitor, &monitor_wp)?;
+                AnimationEngine::animate(
+                    WorkspaceSwitchRenderDispatcher::new(
+                        &monitor,
+                        i,
+                        focused_idx > monitor.last_focused_workspace.unwrap_or(focused_idx),
+                        AnimationStyle::EaseInSine,
+                    ),
+                    Duration::from_millis(1000),
+                )?;
+                // workspace.restore(mouse_follows_focus, hmonitor, &monitor_wp)?;
             } else {
                 workspace.hide(None);
             }

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -330,7 +330,7 @@ impl Monitor {
                         &monitor,
                         i,
                         focused_idx > monitor.last_focused_workspace.unwrap_or(focused_idx),
-                        AnimationStyle::EaseInSine,
+                        AnimationStyle::CubicBezier(0.32, 0.72, 0.0, 1.0),
                     ),
                     Duration::from_millis(500),
                 )?;

--- a/komorebi/src/monitor.rs
+++ b/komorebi/src/monitor.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::AnimationStyle;
+use crate::animation::ANIMATION_ENABLED_GLOBAL;
 use crate::animation::ANIMATION_MANAGER;
 use crate::animation::AnimationEngine;
 use crate::animation::RenderDispatcher;
@@ -43,6 +44,7 @@ struct WorkspaceSwitchRenderDispatcher {
     render_window: Option<Box<WorkspaceSwitchWindow>>,
     to_left: bool,
     style: AnimationStyle,
+    mouse_follows_focus: bool,
 }
 
 impl WorkspaceSwitchRenderDispatcher {
@@ -51,15 +53,16 @@ impl WorkspaceSwitchRenderDispatcher {
     pub fn new(
         monitor: &Monitor,
         workspace_idx: usize,
-        to_left: bool,
         style: AnimationStyle,
+        mouse_follows_focus: bool,
     ) -> Self {
         Self {
             monitor: monitor.clone(),
             workspace_idx,
-            to_left,
+            to_left: workspace_idx > monitor.last_focused_workspace.unwrap_or(workspace_idx),
             render_window: None,
             style,
+            mouse_follows_focus,
         }
     }
 }
@@ -77,6 +80,12 @@ impl RenderDispatcher for WorkspaceSwitchRenderDispatcher {
         stackbar_manager::send_notification();
         self.render_window = Some(WorkspaceSwitchWindow::create(self.monitor.clone()).unwrap());
 
+        self.render(0.0)?;
+
+        for workspace in self.monitor.workspaces_mut().iter_mut() {
+            workspace.hide(None);
+        }
+
         Ok(())
     }
 
@@ -89,7 +98,7 @@ impl RenderDispatcher for WorkspaceSwitchRenderDispatcher {
                 .workspaces_mut()
                 .get_mut(self.workspace_idx)
                 .unwrap();
-            render_window.begin_draw();
+            render_window.begin_draw()?;
             let result = render_window.draw_workspace(
                 self.workspace_idx,
                 workspace,
@@ -106,7 +115,7 @@ impl RenderDispatcher for WorkspaceSwitchRenderDispatcher {
                 .get_mut(monitor_previous_workspace_idx.unwrap())
                 && monitor_previous_workspace_idx.is_some_and(|idx| idx != self.workspace_idx)
             {
-                render_window.draw_workspace(
+                let result = render_window.draw_workspace(
                     monitor_previous_workspace_idx.unwrap(),
                     previous_workspace,
                     match self.to_left {
@@ -114,6 +123,8 @@ impl RenderDispatcher for WorkspaceSwitchRenderDispatcher {
                         false => (0).lerp(monitor_width, progress, self.style) as i32,
                     },
                 );
+
+                println!("result 2: {result:?}");
             }
             render_window.end_draw();
         }
@@ -137,6 +148,8 @@ impl RenderDispatcher for WorkspaceSwitchRenderDispatcher {
             .get_mut(self.workspace_idx)
             .unwrap();
 
+        workspace.restore(self.mouse_follows_focus, hmonitor, &monitor_wp)?;
+
         if let Some(render_window) = self.render_window.take() {
             let raw_pointer = Box::into_raw(render_window);
             unsafe {
@@ -145,7 +158,6 @@ impl RenderDispatcher for WorkspaceSwitchRenderDispatcher {
             self.render_window = None;
         }
 
-        workspace.restore(false, hmonitor, &monitor_wp)?;
         // we don't add the async_window_pos flag here because animations
         // are always run on a separate thread
         // WindowsApi::position_window(self.hwnd, &self.target_rect, self.top, false)?;
@@ -169,11 +181,7 @@ impl RenderDispatcher for WorkspaceSwitchRenderDispatcher {
 
     fn on_cancle(&mut self) {
         if let Some(render_window) = self.render_window.take() {
-            let raw_pointer = Box::into_raw(render_window);
-            unsafe {
-                (*raw_pointer).destroy().unwrap();
-            };
-            self.render_window = None;
+            WorkspaceSwitchWindow::cache_window(render_window);
         }
     }
 }
@@ -323,20 +331,24 @@ impl Monitor {
         let hmonitor = self.id;
         let monitor_wp = self.wallpaper.clone();
         let monitor = self.clone();
-        for (i, workspace) in self.workspaces_mut().iter_mut().enumerate() {
-            if i == focused_idx {
-                AnimationEngine::animate(
-                    WorkspaceSwitchRenderDispatcher::new(
-                        &monitor,
-                        i,
-                        focused_idx > monitor.last_focused_workspace.unwrap_or(focused_idx),
-                        AnimationStyle::CubicBezier(0.32, 0.72, 0.0, 1.0),
-                    ),
-                    Duration::from_millis(500),
-                )?;
-                // workspace.restore(mouse_follows_focus, hmonitor, &monitor_wp)?;
-            } else {
-                workspace.hide(None);
+
+        if ANIMATION_ENABLED_GLOBAL.load(Ordering::SeqCst) {
+            AnimationEngine::animate(
+                WorkspaceSwitchRenderDispatcher::new(
+                    &monitor,
+                    focused_idx,
+                    AnimationStyle::CubicBezier(0.32, 0.72, 0.0, 1.0),
+                    mouse_follows_focus,
+                ),
+                Duration::from_millis(500),
+            )?;
+        } else {
+            for (i, workspace) in self.workspaces_mut().iter_mut().enumerate() {
+                if i == focused_idx {
+                    workspace.restore(mouse_follows_focus, hmonitor, &monitor_wp)?;
+                } else {
+                    workspace.hide(None);
+                }
             }
         }
 

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -232,9 +232,7 @@ impl RenderDispatcher for MovementRenderDispatcher {
         Ok(())
     }
 
-    fn on_cancle(&mut self) {
-        
-    }
+    fn on_cancle(&mut self) {}
 }
 
 struct TransparencyRenderDispatcher {
@@ -302,9 +300,7 @@ impl RenderDispatcher for TransparencyRenderDispatcher {
         Ok(())
     }
 
-    fn on_cancle(&mut self) {
-        
-    }
+    fn on_cancle(&mut self) {}
 }
 
 #[derive(Copy, Clone, Debug, Display, EnumString, Serialize, Deserialize, PartialEq)]

--- a/komorebi/src/window.rs
+++ b/komorebi/src/window.rs
@@ -192,14 +192,14 @@ impl RenderDispatcher for MovementRenderDispatcher {
         new_animation_key(MovementRenderDispatcher::PREFIX, self.hwnd.to_string())
     }
 
-    fn pre_render(&self) -> eyre::Result<()> {
+    fn pre_render(&mut self) -> eyre::Result<()> {
         stackbar_manager::STACKBAR_TEMPORARILY_DISABLED.store(true, Ordering::SeqCst);
         stackbar_manager::send_notification();
 
         Ok(())
     }
 
-    fn render(&self, progress: f64) -> eyre::Result<()> {
+    fn render(&mut self, progress: f64) -> eyre::Result<()> {
         let new_rect = self.start_rect.lerp(self.target_rect, progress, self.style);
 
         // we don't check WINDOW_HANDLING_BEHAVIOUR here because animations
@@ -210,7 +210,7 @@ impl RenderDispatcher for MovementRenderDispatcher {
         Ok(())
     }
 
-    fn post_render(&self) -> eyre::Result<()> {
+    fn post_render(&mut self) -> eyre::Result<()> {
         // we don't add the async_window_pos flag here because animations
         // are always run on a separate thread
         WindowsApi::position_window(self.hwnd, &self.target_rect, self.top, false)?;
@@ -230,6 +230,10 @@ impl RenderDispatcher for MovementRenderDispatcher {
         }
 
         Ok(())
+    }
+
+    fn on_cancle(&mut self) {
+        
     }
 }
 
@@ -266,7 +270,7 @@ impl RenderDispatcher for TransparencyRenderDispatcher {
         new_animation_key(TransparencyRenderDispatcher::PREFIX, self.hwnd.to_string())
     }
 
-    fn pre_render(&self) -> eyre::Result<()> {
+    fn pre_render(&mut self) -> eyre::Result<()> {
         //transparent
         if !self.is_opaque {
             let window = Window::from(self.hwnd);
@@ -278,7 +282,7 @@ impl RenderDispatcher for TransparencyRenderDispatcher {
         Ok(())
     }
 
-    fn render(&self, progress: f64) -> eyre::Result<()> {
+    fn render(&mut self, progress: f64) -> eyre::Result<()> {
         WindowsApi::set_transparent(
             self.hwnd,
             self.start_opacity
@@ -286,7 +290,7 @@ impl RenderDispatcher for TransparencyRenderDispatcher {
         )
     }
 
-    fn post_render(&self) -> eyre::Result<()> {
+    fn post_render(&mut self) -> eyre::Result<()> {
         //opaque
         if self.is_opaque {
             let window = Window::from(self.hwnd);
@@ -296,6 +300,10 @@ impl RenderDispatcher for TransparencyRenderDispatcher {
         }
 
         Ok(())
+    }
+
+    fn on_cancle(&mut self) {
+        
     }
 }
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -1737,14 +1737,24 @@ impl WindowManager {
         tracing::info!("moving container");
 
         let mouse_follows_focus = self.mouse_follows_focus;
-        let monitor = self
-            .focused_monitor_mut()
-            .ok_or_eyre("there is no monitor")?;
 
-        monitor.move_container_to_workspace(idx, follow, direction)?;
-        monitor.load_focused_workspace(mouse_follows_focus)?;
+        {
+            let monitor = self
+                .focused_monitor_mut()
+                .ok_or_eyre("there is no monitor")?;
+
+            monitor.move_container_to_workspace(idx, follow, direction)?;
+        }
 
         self.update_focused_workspace(mouse_follows_focus, true)?;
+
+        {
+            let monitor = self
+                .focused_monitor_mut()
+                .ok_or_eyre("there is no monitor")?;
+            monitor.load_focused_workspace(mouse_follows_focus)?;
+        }
+
 
         Ok(())
     }

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -2,6 +2,7 @@ use color_eyre::eyre;
 use color_eyre::eyre::Error;
 use color_eyre::eyre::OptionExt;
 use color_eyre::eyre::bail;
+use windows::Win32::UI::WindowsAndMessaging::WS_MAXIMIZE;
 use core::ffi::c_void;
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -153,6 +154,7 @@ use windows::core::Result as WindowsCrateResult;
 use windows_core::BOOL;
 use windows_core::HSTRING;
 
+use crate::animation::workspace_switch::WorkspaceSwitchWindow;
 use crate::core::Rect;
 
 use crate::DISPLAY_INDEX_PREFERENCES;
@@ -1309,6 +1311,30 @@ impl WindowsApi {
                 None,
                 Option::from(HINSTANCE(as_ptr!(instance))),
                 Some(border as _),
+            )?
+        }
+        .process()
+    }
+
+    pub fn create_workspace_switch_window(
+        name: PCWSTR,
+        instance: isize,
+        workspace_switch_window: *mut WorkspaceSwitchWindow,
+    ) -> eyre::Result<isize> {
+        unsafe {
+            CreateWindowExW(
+                WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE , 
+                name,
+                name,
+                WS_POPUP | WS_SYSMENU,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                CW_USEDEFAULT,
+                None,
+                None,
+                Option::from(HINSTANCE(as_ptr!(instance))),
+                Some(workspace_switch_window as _),
             )?
         }
         .process()

--- a/komorebi/src/windows_api.rs
+++ b/komorebi/src/windows_api.rs
@@ -2,7 +2,6 @@ use color_eyre::eyre;
 use color_eyre::eyre::Error;
 use color_eyre::eyre::OptionExt;
 use color_eyre::eyre::bail;
-use windows::Win32::UI::WindowsAndMessaging::WS_MAXIMIZE;
 use core::ffi::c_void;
 use std::collections::HashMap;
 use std::collections::VecDeque;
@@ -145,6 +144,7 @@ use windows::Win32::UI::WindowsAndMessaging::WS_DISABLED;
 use windows::Win32::UI::WindowsAndMessaging::WS_EX_NOACTIVATE;
 use windows::Win32::UI::WindowsAndMessaging::WS_EX_TOOLWINDOW;
 use windows::Win32::UI::WindowsAndMessaging::WS_EX_TOPMOST;
+use windows::Win32::UI::WindowsAndMessaging::WS_MAXIMIZE;
 use windows::Win32::UI::WindowsAndMessaging::WS_POPUP;
 use windows::Win32::UI::WindowsAndMessaging::WS_SYSMENU;
 use windows::Win32::UI::WindowsAndMessaging::WindowFromPoint;
@@ -1323,7 +1323,7 @@ impl WindowsApi {
     ) -> eyre::Result<isize> {
         unsafe {
             CreateWindowExW(
-                WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE , 
+                WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE,
                 name,
                 name,
                 WS_POPUP | WS_SYSMENU,


### PR DESCRIPTION
This is proof of concept for workspace switch animation. At this state its buggy and requires a lot of work, but main idea is implemented and works as expected.

First implementation is hyperland-like animations from left to right and backwards. 

 It's still WIP, its crashes, its need monocle/maximazed/floating windows support, need to create and use config options for this animation, but it kinda works.

The main idea is create fullscreen window for monitor and capture windows in workspaces that involved in switch (new focused and previous focused workspaces) with directx apis, and then render this frames in that monitor fullscreen window.

Help wanted actually. Idk if I gonna work further on it. So, if you wanna work on this feature and bring it to life, your welcome 

Made this PR for history and more discoverability.