### PR TITLE
fix(wm): prevent command injection in bar process spawning

### DIFF
--- a/komorebi/src/process_command.rs
+++ b/komorebi/src/process_command.rs
@@ -14,6 +14,7 @@ use std::io::Read;
 use std::net::TcpListener;
 use std::net::TcpStream;
 use std::num::NonZeroUsize;
+use std::os::windows::process::CommandExt;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -1772,12 +1773,13 @@ Stop-Process -Name:komorebi-bar -ErrorAction SilentlyContinue
                                     &mut config.bar_configurations
                                 {
                                     for config_file_path in &mut *display_bar_configurations {
-                                        let script = r#"Start-Process "komorebi-bar" '"--config" "CONFIGFILE"' -WindowStyle hidden"#
-                                            .replace("CONFIGFILE", &config_file_path.to_string_lossy());
-
-                                        match powershell_script::run(&script) {
+                                        match std::process::Command::new("komorebi-bar")
+                                            .args(["--config", &config_file_path.to_string_lossy()])
+                                            .creation_flags(0x0800_0000) // CREATE_NO_WINDOW
+                                            .spawn()
+                                        {
                                             Ok(_) => {
-                                                println!("{script}");
+                                                println!("Started komorebi-bar with config: {}", config_file_path.display());
                                             }
                                             Err(error) => {
                                                 println!("Error: {error}");


### PR DESCRIPTION
## Summary

Fix a command injection vulnerability in the `ReplaceConfiguration` handler that allows arbitrary code execution via crafted `bar_configurations` paths.

## Vulnerability

When `ReplaceConfiguration` is received via IPC, `bar_configurations` paths are interpolated into a PowerShell string and executed via `powershell_script::run()`:

```rust
let script = r#"Start-Process "komorebi-bar" '"--config" "CONFIGFILE"' -WindowStyle hidden"#
    .replace("CONFIGFILE", &config_file_path.to_string_lossy());
powershell_script::run(&script)
```

`powershell_script::run()` pipes the script to PowerShell's stdin (see `powershell_script-1.1.0/src/target/windows.rs:48-53`). A single quote in the path closes the PowerShell string literal, and subsequent content executes as independent commands.

## Verified Proof of Concept

Payload in `bar_configurations`:
```json
"C:\x' ; New-Item -Path C:\temp\pwned.txt -Value pwned ; echo '"
```

After `.replace("CONFIGFILE", ...)`, the generated script becomes:
```powershell
Start-Process "komorebi-bar" '"--config" "C:\x' ; New-Item -Path C:\temp\pwned.txt -Value pwned ; echo '"' -WindowStyle hidden
```

The single quote at `C:\x'` closes the string literal. `New-Item -Path C:\temp\pwned.txt -Value pwned` executes as a standalone command. The trailing `echo '` absorbs the remaining quote.

Verification (replicating exact `powershell_script::run` behavior — stdin pipe to PowerShell):
```
$ cat /c/temp/test_injection.txt | powershell.exe -Command "-"

    目录: C:\temp

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         2026/5/18      3:40              5 pwned.txt

$ cat /c/temp/pwned.txt
pwned
```

Single quotes are valid Windows path characters, so the payload passes `PathBuf` deserialization without issue.

## Severity

- With `--tcp-port` (binds `0.0.0.0`): remote code execution, no authentication
- UDS only: local code execution from any process that can connect to `komorebi.sock`

## Fix

Replace `powershell_script::run()` string interpolation with `std::process::Command` using argument array separation. This matches the existing pattern in `komorebi-bar/src/bar.rs:97` and `komorebic-no-console/src/main.rs:16`.

```rust
std::process::Command::new("komorebi-bar")
    .args(["--config", &config_file_path.to_string_lossy()])
    .creation_flags(0x0800_0000) // CREATE_NO_WINDOW
    .spawn()
```

Arguments are passed directly to the process without shell interpretation, eliminating the injection vector entirely.