### PR TITLE
fix(wm): register regex patterns and fix workspace rule enforcement

### DIFF
--- a/komorebi/src/animation/engine.rs
+++ b/komorebi/src/animation/engine.rs
@@ -60,17 +60,30 @@ impl AnimationEngine {
     ) -> eyre::Result<()> {
         std::thread::spawn(move || {
             let animation_key = render_dispatcher.get_animation_key();
-            if ANIMATION_MANAGER.lock().in_progress(animation_key.as_str()) {
-                let should_animate = Self::cancel(animation_key.as_str());
 
+            // Hold the lock across both the check and the start so two threads
+            // can't both see in_progress=false and race into pre_render.
+            let was_in_progress = {
+                let mut manager = ANIMATION_MANAGER.lock();
+                let running = manager.in_progress(animation_key.as_str());
+                if !running {
+                    manager.start(animation_key.as_str());
+                }
+                running
+            };
+
+            if was_in_progress {
+                let should_animate = Self::cancel(animation_key.as_str());
                 if !should_animate {
                     return Ok(());
                 }
+                ANIMATION_MANAGER.lock().start(animation_key.as_str());
             }
 
-            render_dispatcher.pre_render()?;
-
-            ANIMATION_MANAGER.lock().start(animation_key.as_str());
+            if let Err(e) = render_dispatcher.pre_render() {
+                ANIMATION_MANAGER.lock().end(animation_key.as_str());
+                return Err(e);
+            }
 
             let target_frame_time =
                 Duration::from_millis(1000 / ANIMATION_FPS.load(Ordering::Relaxed));

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1338,7 +1338,7 @@ impl StaticConfig {
                     .unwrap_or(WindowContainerBehaviour::Create),
                 float_override: value.float_override.unwrap_or_default(),
                 floating_layer_override: false, // this value is always automatically calculated
-                floating_layer_behaviour: FloatingLayerBehaviour::default(),
+                floating_layer_behaviour: value.floating_layer_behaviour.unwrap_or_default(),
                 toggle_float_placement: value
                     .toggle_float_placement
                     .unwrap_or(Placement::CenterAndResize),

--- a/komorebi/src/static_config.rs
+++ b/komorebi/src/static_config.rs
@@ -1486,9 +1486,11 @@ impl StaticConfig {
                 }
 
                 let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
+                let mut regex_identifiers = REGEX_IDENTIFIERS.lock();
                 for (j, ws) in monitor_config.workspaces.iter().enumerate() {
                     if let Some(rules) = &ws.workspace_rules {
                         for r in rules {
+                            register_workspace_rule_regex(r, &mut regex_identifiers)?;
                             workspace_matching_rules.push(WorkspaceMatchingRule {
                                 monitor_index: i,
                                 workspace_index: j,
@@ -1500,6 +1502,7 @@ impl StaticConfig {
 
                     if let Some(rules) = &ws.initial_workspace_rules {
                         for r in rules {
+                            register_workspace_rule_regex(r, &mut regex_identifiers)?;
                             workspace_matching_rules.push(WorkspaceMatchingRule {
                                 monitor_index: i,
                                 workspace_index: j,
@@ -1654,9 +1657,11 @@ impl StaticConfig {
                 }
 
                 let mut workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
+                let mut regex_identifiers = REGEX_IDENTIFIERS.lock();
                 for (j, ws) in monitor_config.workspaces.iter().enumerate() {
                     if let Some(rules) = &ws.workspace_rules {
                         for r in rules {
+                            register_workspace_rule_regex(r, &mut regex_identifiers)?;
                             workspace_matching_rules.push(WorkspaceMatchingRule {
                                 monitor_index: i,
                                 workspace_index: j,
@@ -1668,6 +1673,7 @@ impl StaticConfig {
 
                     if let Some(rules) = &ws.initial_workspace_rules {
                         for r in rules {
+                            register_workspace_rule_regex(r, &mut regex_identifiers)?;
                             workspace_matching_rules.push(WorkspaceMatchingRule {
                                 monitor_index: i,
                                 workspace_index: j,
@@ -1813,6 +1819,22 @@ fn populate_option(
         }
     }
 
+    Ok(())
+}
+
+fn register_workspace_rule_regex(
+    rule: &MatchingRule,
+    regex_identifiers: &mut HashMap<String, Regex>,
+) -> eyre::Result<()> {
+    let identifiers = match rule {
+        MatchingRule::Simple(r) => std::slice::from_ref(r),
+        MatchingRule::Composite(r) => r.as_slice(),
+    };
+    for identifier in identifiers {
+        if matches!(identifier.matching_strategy, Some(MatchingStrategy::Regex)) {
+            regex_identifiers.insert(identifier.id.clone(), Regex::new(&identifier.id)?);
+        }
+    }
     Ok(())
 }
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -641,6 +641,18 @@ impl WindowManager {
 
         to_move.retain(|op| !op.is_enforced());
 
+        // A window may match multiple rules; keep only the last match per hwnd so that
+        // remove_window is called exactly once and later rules take precedence.
+        {
+            let mut seen = std::collections::HashSet::new();
+            to_move = to_move
+                .into_iter()
+                .rev()
+                .filter(|op| seen.insert(op.hwnd))
+                .collect::<Vec<_>>();
+            to_move.reverse();
+        }
+
         let mut origin_monitors = std::collections::HashSet::new();
         let mut target_monitors = std::collections::HashSet::new();
 

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -114,14 +114,6 @@ struct EnforceWorkspaceRuleOp {
     floating: bool,
 }
 impl EnforceWorkspaceRuleOp {
-    const fn is_origin(&self, monitor_idx: usize, workspace_idx: usize) -> bool {
-        self.origin_monitor_idx == monitor_idx && self.origin_workspace_idx == workspace_idx
-    }
-
-    const fn is_target(&self, monitor_idx: usize, workspace_idx: usize) -> bool {
-        self.target_monitor_idx == monitor_idx && self.target_workspace_idx == workspace_idx
-    }
-
     const fn is_enforced(&self) -> bool {
         (self.origin_monitor_idx == self.target_monitor_idx)
             && (self.origin_workspace_idx == self.target_workspace_idx)
@@ -565,17 +557,9 @@ impl WindowManager {
 
     #[tracing::instrument(skip(self), level = "debug")]
     pub fn enforce_workspace_rules(&mut self) -> eyre::Result<()> {
+        let pre_enforce_focused_monitor = self.focused_monitor_idx();
         let mut to_move = vec![];
 
-        let focused_monitor_idx = self.focused_monitor_idx();
-        let focused_workspace_idx = self
-            .monitors()
-            .get(focused_monitor_idx)
-            .ok_or_eyre("there is no monitor with that index")?
-            .focused_workspace_idx();
-
-        // scope mutex locks to avoid deadlock if should_update_focused_workspace evaluates to true
-        // at the end of this function
         {
             let workspace_matching_rules = WORKSPACE_MATCHING_RULES.lock();
             let regex_identifiers = REGEX_IDENTIFIERS.lock();
@@ -655,12 +639,10 @@ impl WindowManager {
             }
         }
 
-        // Only retain operations where the target is not the current workspace
-        to_move.retain(|op| !op.is_target(focused_monitor_idx, focused_workspace_idx));
-        // Only retain operations where the rule has not already been enforced
         to_move.retain(|op| !op.is_enforced());
 
-        let mut should_update_focused_workspace = false;
+        let mut origin_monitors = std::collections::HashSet::new();
+        let mut target_monitors = std::collections::HashSet::new();
 
         // Parse the operation and remove any windows that are not placed according to their rules
         for op in &to_move {
@@ -689,11 +671,11 @@ impl WindowManager {
                 window.move_to_area(&origin_area, &target_area)?;
             }
 
-            // Hide the window we are about to remove if it is on the currently focused workspace
-            if op.is_origin(focused_monitor_idx, focused_workspace_idx) {
-                window.hide();
-                should_update_focused_workspace = true;
-            }
+            // Do not hide here — load_focused_workspace handles visibility on
+            // the target monitor. Hiding unconditionally races with in-flight
+            // animation threads and can leave the window invisible.
+            origin_monitors.insert(op.origin_monitor_idx);
+            target_monitors.insert(op.target_monitor_idx);
 
             origin_workspace.remove_window(op.hwnd)?;
         }
@@ -738,9 +720,29 @@ impl WindowManager {
             }
         }
 
-        // Only re-tile the focused workspace if we need to
-        if should_update_focused_workspace {
-            self.update_focused_workspace(false, false)?;
+        let offset = self.work_area_offset;
+
+        for monitor_idx in &target_monitors {
+            if let Some(monitor) = self.monitors_mut().get_mut(*monitor_idx) {
+                monitor.load_focused_workspace(false)?;
+                monitor.update_focused_workspace(offset)?;
+            }
+        }
+
+        for monitor_idx in &origin_monitors {
+            if !target_monitors.contains(monitor_idx) {
+                if let Some(monitor) = self.monitors_mut().get_mut(*monitor_idx) {
+                    monitor.update_focused_workspace(offset)?;
+                }
+            }
+        }
+
+        // If the focused monitor lost a window to enforcement, follow it to its destination.
+        if !to_move.is_empty()
+            && origin_monitors.contains(&pre_enforce_focused_monitor)
+            && !target_monitors.contains(&pre_enforce_focused_monitor)
+        {
+            self.focus_monitor(to_move[0].target_monitor_idx)?;
         }
 
         Ok(())
@@ -1731,6 +1733,7 @@ impl WindowManager {
         }
 
         self.update_focused_workspace(self.mouse_follows_focus, true)?;
+        self.enforce_workspace_rules()?;
 
         Ok(())
     }
@@ -1755,6 +1758,7 @@ impl WindowManager {
         monitor.load_focused_workspace(mouse_follows_focus)?;
 
         self.update_focused_workspace(mouse_follows_focus, true)?;
+        self.enforce_workspace_rules()?;
 
         Ok(())
     }

--- a/komorebi/src/window_manager.rs
+++ b/komorebi/src/window_manager.rs
@@ -2555,29 +2555,22 @@ impl WindowManager {
         let mouse_follows_focus = self.mouse_follows_focus;
         let focused_workspace = self.focused_workspace()?;
 
+        let floating_windows = focused_workspace.floating_windows();
+        let len = floating_windows.len();
+
         let mut target_idx = None;
-        let len = focused_workspace.floating_windows().len();
 
         if len > 1 {
             let focused_hwnd = WindowsApi::foreground_window()?;
-            for (idx, window) in focused_workspace.floating_windows().iter().enumerate() {
+
+            for (idx, window) in floating_windows.iter().enumerate() {
                 if window.hwnd == focused_hwnd {
-                    match direction {
-                        CycleDirection::Previous => {
-                            if idx == 0 {
-                                target_idx = Some(len - 1)
-                            } else {
-                                target_idx = Some(idx - 1)
-                            }
-                        }
-                        CycleDirection::Next => {
-                            if idx == len - 1 {
-                                target_idx = Some(0)
-                            } else {
-                                target_idx = Some(idx - 1)
-                            }
-                        }
-                    }
+                    target_idx = Some(match direction {
+                        CycleDirection::Previous => (idx + len - 1) % len,
+                        CycleDirection::Next => (idx + 1) % len,
+                    });
+
+                    break;
                 }
             }
 
@@ -2587,7 +2580,7 @@ impl WindowManager {
         }
 
         if let Some(idx) = target_idx
-            && let Some(window) = focused_workspace.floating_windows().get(idx)
+            && let Some(window) = floating_windows.get(idx)
         {
             window.focus(mouse_follows_focus)?;
         }


### PR DESCRIPTION
## What

Regex patterns in `workspace_rules` and `initial_workspace_rules` were never registered in `REGEX_IDENTIFIERS`, causing them to silently fail to match windows at runtime.

Workspace rule enforcement also had a few bugs:
- Rules targeting the focused workspace were silently dropped
- Enforcement only fired on OS events, not on manual container moves
- `window.hide()` raced with in-flight animation threads, leaving windows invisible
- Focus was not redirected to the monitor that received the enforced window
- A window matching multiple workspace rules was removed twice, crashing with "there is no window"
- `CycleDirection::Next` was decrementing the focused window index (idx - 1) instead of incrementing it, causing focus traversal to move in the wrong direction and fail expected wraparound behavior.
- Global `floating_layer_behaviour` from static config was not applied during startup preload, so `"floating_layer_behaviour": "Float"` could work after reload but not on initial launch

## How

- Added `register_workspace_rule_regex` to compile and store regex patterns for both `Simple` and `Composite` rules on load and reload
- Removed the `is_target` filter that dropped enforcement for the focused workspace
- Replaced `window.hide()` with `load_focused_workspace` on the target monitor to avoid the animation race
- Added `enforce_workspace_rules` at the end of `move_container_to_monitor` and `move_container_to_workspace`
- After enforcement, redirect focus to the target monitor if the focused monitor lost a window to a rule
- Hold the animation slot check and claim under a single lock to prevent two threads racing into `pre_render`
- Deduplicate to_move by hwnd before processing so remove_window is called exactly once per window
- Fix floating window cycling by correcting Next traversal and simplifying wraparound logic using modulo arithmetic.
- Applied `floating_layer_behaviour` from static config during `StaticConfig::preload(...)` so startup behavior matches reload behavior

## Testing

- Verified regex-based `workspace_rules` and `initial_workspace_rules` correctly match and assign windows on launch
- Verified rules targeting the currently focused workspace are enforced instead of being skipped
- Verified manually moved containers/windows are immediately re-evaluated by workspace rule enforcement
- Verified enforced windows remain visible after transfer and do not get stuck hidden during animation
- Verified focus follows to the monitor/workspace that receives a window through rule enforcement
- Verified windows matching multiple workspace rules are processed safely without duplicate removal or crash
- Verified floating window cycling now moves in the correct `Next` direction and wraps correctly
- Verified `"floating_layer_behaviour": "Float"` now works on initial startup as