### PR TITLE
fix(wm): refocus selection on destroy when foreground goes null

### DIFF
--- a/komorebi/src/process_event.rs
+++ b/komorebi/src/process_event.rs
@@ -45,6 +45,16 @@ fn should_skip_focus_change(foreground_hwnd: Option<isize>, window_hwnd: isize) 
     matches!(foreground_hwnd, Some(hwnd) if hwnd != window_hwnd)
 }
 
+/// After a managed window is destroyed, Windows may promote no successor, leaving
+/// the foreground null with no FocusChange to reconcile from. The selection then
+/// never regains focus: every border renders unfocused and keystrokes fall through
+/// to nothing until the user refocuses by hand. Refocus only in that case, otherwise
+/// foreground successor is left to FocusChange so we don't fight the OS or desync
+/// focus.
+fn should_refocus_after_destroy(foreground_hwnd: Option<isize>) -> bool {
+    matches!(foreground_hwnd, None | Some(0))
+}
+
 #[cfg(test)]
 mod focus_change_tests {
     use super::should_skip_focus_change;
@@ -62,6 +72,26 @@ mod focus_change_tests {
     #[test]
     fn allows_focus_change_when_foreground_unknown() {
         assert!(!should_skip_focus_change(None, 1));
+    }
+}
+
+#[cfg(test)]
+mod destroy_focus_tests {
+    use super::should_refocus_after_destroy;
+
+    #[test]
+    fn refocuses_when_foreground_is_null() {
+        assert!(should_refocus_after_destroy(Some(0)));
+    }
+
+    #[test]
+    fn refocuses_when_foreground_is_unavailable() {
+        assert!(should_refocus_after_destroy(None));
+    }
+
+    #[test]
+    fn defers_when_a_successor_took_the_foreground() {
+        assert!(!should_refocus_after_destroy(Some(12345)));
     }
 }
 
@@ -282,7 +312,13 @@ impl WindowManager {
             WindowManagerEvent::Destroy(_, window) | WindowManagerEvent::Unmanage(window) => {
                 if self.focused_workspace()?.contains_window(window.hwnd) {
                     self.focused_workspace_mut()?.remove_window(window.hwnd)?;
-                    self.update_focused_workspace(false, false)?;
+
+                    // With refocus true, update_focused_workspace focuses the surviving
+                    // selection (maximized/monocle/tiling); with refocus false it only
+                    // re-tiles.
+                    let refocus =
+                        should_refocus_after_destroy(WindowsApi::foreground_window().ok());
+                    self.update_focused_workspace(refocus, refocus)?;
 
                     let mut already_moved_window_handles = self.already_moved_window_handles.lock();
 


### PR DESCRIPTION
### Problem

Closing the focused (foreground) tiled window sometimes does not move focus to a surviving neighbor. komorebi removes the window and re-tiles, but no managed window regains focus. Borders render unfocused on every window and keystrokes do nothing until the user refocuses by hand.

### Root cause

The removal handlers (`Destroy`/`Unmanage`, `Minimize`, `Hide`) call `update_focused_workspace(false, false)`, which re-tiles but leaves focus to the OS. komorebi reconciles its selection in the `FocusChange` handler once Windows promotes a successor. From looking at `git blame`, this appears intended to prevent focus fights.

When the focused window is destroyed, Windows does not always promote a successor. When it promotes nothing, the foreground becomes null, no `FocusChange` arrives, and the selection never regains OS focus.

### Fix

Keep the reactive no-force-focus default and add a narrow fallback in the `Destroy`/`Unmanage` handler: when the OS foreground is null after removal, follow and trigger focus so `update_focused_workspace` restores komorebi's own selection (maximized/monocle/tiling). A non-null foreground is still left to `FocusChange`, so the OS is not fought and the `should_skip_focus_change` desync should not occur.

Added a small predicate (`should_refocus_after_destroy`) with unit tests, mirroring the existing `should_skip_focus_change`.

### Notes

I haven't been able to reproduce the behavior in the `Minimize` or `Hide` paths, so I haven't touched them. It's probably safe to extend the fix there too, so happy to include those paths as well if desired.
