### PR TITLE
fix(stackbar): drop containers lock before repositioning stackbar

### DIFF
--- a/komorebi/src/stackbar_manager/stackbar.rs
+++ b/komorebi/src/stackbar_manager/stackbar.rs
@@ -174,10 +174,8 @@ impl Stackbar {
         let focused_text_colour = STACKBAR_FOCUSED_TEXT_COLOUR.load_consume();
         let unfocused_text_colour = STACKBAR_UNFOCUSED_TEXT_COLOUR.load_consume();
 
-        // Scope the lock so it is released before the synchronous position_window
-        // call below; the window's wndproc takes the same lock on WM_LBUTTONDOWN,
-        // and holding it across a cross-thread SetWindowPos deadlocks the two
-        // threads against each other (mutex <-> message queue cycle)
+        // The wndproc takes this lock on WM_LBUTTONDOWN, so release it before the
+        // synchronous position_window call below or the two threads can deadlock
         {
             let mut stackbars_containers = STACKBARS_CONTAINERS.lock();
             stackbars_containers.insert(self.hwnd, container.clone());

--- a/komorebi/src/stackbar_manager/stackbar.rs
+++ b/komorebi/src/stackbar_manager/stackbar.rs
@@ -174,8 +174,14 @@ impl Stackbar {
         let focused_text_colour = STACKBAR_FOCUSED_TEXT_COLOUR.load_consume();
         let unfocused_text_colour = STACKBAR_UNFOCUSED_TEXT_COLOUR.load_consume();
 
-        let mut stackbars_containers = STACKBARS_CONTAINERS.lock();
-        stackbars_containers.insert(self.hwnd, container.clone());
+        // Scope the lock so it is released before the synchronous position_window
+        // call below; the window's wndproc takes the same lock on WM_LBUTTONDOWN,
+        // and holding it across a cross-thread SetWindowPos deadlocks the two
+        // threads against each other (mutex <-> message queue cycle)
+        {
+            let mut stackbars_containers = STACKBARS_CONTAINERS.lock();
+            stackbars_containers.insert(self.hwnd, container.clone());
+        }
 
         let mut layout = *layout;
         let workspace_specific_offset =


### PR DESCRIPTION
Fixes #1734

## Problem

`Stackbar::update` acquires `STACKBARS_CONTAINERS` and holds it for the remainder of the function — including across the synchronous `WindowsApi::position_window` (`SetWindowPos`) call. `SetWindowPos` on a window owned by another thread is serviced synchronously by that window's message pump. The stackbar wndproc (`Stackbar::callback`) acquires the same `STACKBARS_CONTAINERS` lock when handling `WM_LBUTTONDOWN`.

If a tab click is being processed while a stackbar update storm is in flight (e.g. cycling/switching a stacked view), the wndproc blocks on the lock, the updater blocks in `SetWindowPos` waiting for the wndproc's pump, and the process deadlocks permanently — all window management freezes and `komorebic` commands time out. Because one side of the cycle is the message queue rather than a lock, `--features deadlock_detection` reports nothing.

Full symbolized gdb backtraces of a live hang are in #1734 (Thread 12 = updater in `NtUserSetWindowPos` holding the lock, Thread 27 = wndproc in `lock_slow`).

## Fix

Scope the `STACKBARS_CONTAINERS` guard to the one statement that needs it (the `insert`), so it is released before `position_window`. Nothing after the insert reads or writes the map, and the wndproc reading the freshly-inserted clone concurrently with the rest of `update` was already possible pre-existing behavior whenever `update` wasn't running.

## Verification

- Reproduced the hang twice on v0.1.41 (release binary and an instrumented build) within minutes of normal stacked-view use, `stackbar.mode: OnStack`.
- With this patch applied (v0.1.41 base, running as daily driver): a stress harness posting alternating `WM_LBUTTONDOWN`/`WM_LBUTTONUP` to the stackbar window interleaved with 150 `komorebic retile` rounds — previously the exact deadlock interleaving — completed with the state pipe responsive at every checkpoint.
- `cargo check -p komorebi` passes on `master` with the patch.
