### PR TITLE
fix(cli): scope process detection to the current session

### DIFF
--- a/komorebi/src/main.rs
+++ b/komorebi/src/main.rs
@@ -233,10 +233,24 @@ fn main() -> eyre::Result<()> {
     if matched_procs.len() > 1 {
         let mut len = matched_procs.len();
         for proc in matched_procs {
+            let proc_session_id = proc.session_id();
+            match proc_session_id {
+                Some(p) if p.as_u32() != session_id => {
+                    len -= 1;
+                    continue;
+                }
+                None => {
+                    len -= 1;
+                    continue;
+                }
+                _ => {}
+            }
+
             if let Some(executable_path) = proc.exe()
                 && executable_path.to_string_lossy().contains("shims")
             {
                 len -= 1;
+                continue;
             }
         }
 

--- a/komorebic/src/main.rs
+++ b/komorebic/src/main.rs
@@ -41,6 +41,8 @@ use sysinfo::ProcessesToUpdate;
 use which::which;
 use win_msgbox::OkayCancel;
 use windows::Win32::Foundation::HWND;
+use windows::Win32::System::RemoteDesktop::ProcessIdToSessionId;
+use windows::Win32::System::Threading::GetCurrentProcessId;
 use windows::Win32::UI::WindowsAndMessaging::SHOW_WINDOW_CMD;
 use windows::Win32::UI::WindowsAndMessaging::SW_RESTORE;
 use windows::Win32::UI::WindowsAndMessaging::ShowWindow;
@@ -2438,6 +2440,8 @@ fn main() -> eyre::Result<()> {
                 flags.push("'--clean-state'".to_string());
             }
 
+            let session_id = current_session_id()?;
+
             let exec = exec.unwrap_or("komorebi.exe");
             let script = if flags.is_empty() {
                 format!("Start-Process '{exec}' -WindowStyle hidden",)
@@ -2452,7 +2456,10 @@ fn main() -> eyre::Result<()> {
             let mut attempts = 0;
             let mut running = system
                 .processes_by_name("komorebi.exe".as_ref())
-                .next()
+                .find(|proc| {
+                    proc.session_id()
+                        .map_or_default(|proc_session_id| proc_session_id.as_u32() == session_id)
+                })
                 .is_some();
 
             while !running && attempts <= 2 {
@@ -2472,7 +2479,10 @@ fn main() -> eyre::Result<()> {
 
                 if system
                     .processes_by_name("komorebi.exe".as_ref())
-                    .next()
+                    .find(|proc| {
+                        proc.session_id()
+                            .map_or_default(|proc_session_id| proc_session_id.as_u32() == session_id)
+                    })
                     .is_some()
                 {
                     println!("Started!");
@@ -2501,12 +2511,16 @@ fn main() -> eyre::Result<()> {
 
             if args.whkd {
                 let script = r"
-if (!(Get-Process whkd -ErrorAction SilentlyContinue))
+if (!(
+    Get-Process whkd -ErrorAction SilentlyContinue |
+        Where-Object { $_.SessionId -eq $SESSION_ID }
+))
 {
   Start-Process whkd -WindowStyle hidden
 }
-                ";
-                match powershell_script::run(script) {
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2574,12 +2588,16 @@ if (!(Get-Process whkd -ErrorAction SilentlyContinue))
 
                 if fallthrough {
                     let script = r"
-if (!(Get-Process komorebi-bar -ErrorAction SilentlyContinue))
+if (!(
+    Get-Process komorebi-bar -ErrorAction SilentlyContinue |
+        Where-Object { $_.SessionId -eq $SESSION_ID }
+))
 {
   Start-Process komorebi-bar -WindowStyle hidden
 }
-                ";
-                    match powershell_script::run(script) {
+                "
+                    .replace("$SESSION_ID", &session_id.to_string());
+                    match powershell_script::run(&script) {
                         Ok(_) => {
                             println!("{script}");
                         }
@@ -2592,12 +2610,16 @@ if (!(Get-Process komorebi-bar -ErrorAction SilentlyContinue))
 
             if args.masir {
                 let script = r"
-if (!(Get-Process masir -ErrorAction SilentlyContinue))
+if (!(
+    Get-Process masir -ErrorAction SilentlyContinue |
+        Where-Object { $_.SessionId -eq $SESSION_ID }
+))
 {
   Start-Process masir -WindowStyle hidden
 }
-                ";
-                match powershell_script::run(script) {
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2677,6 +2699,8 @@ if (!(Get-Process masir -ErrorAction SilentlyContinue))
             }
         }
         SubCommand::Stop(args) => {
+            let session_id = current_session_id()?;
+
             if args.ahk {
                 println!(
                     "EOL: The --ahk flag is now end-of-life and will not receive any further updates or bug fixes"
@@ -2685,9 +2709,12 @@ if (!(Get-Process masir -ErrorAction SilentlyContinue))
 
             if args.whkd {
                 let script = r"
-Stop-Process -Name:whkd -ErrorAction SilentlyContinue
-                ";
-                match powershell_script::run(script) {
+Get-Process whkd -ErrorAction SilentlyContinue |
+    Where-Object { $_.SessionId -eq $SESSION_ID } |
+    Stop-Process -ErrorAction SilentlyContinue
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2699,9 +2726,12 @@ Stop-Process -Name:whkd -ErrorAction SilentlyContinue
 
             if args.bar {
                 let script = r"
-Stop-Process -Name:komorebi-bar -ErrorAction SilentlyContinue
-                ";
-                match powershell_script::run(script) {
+Get-Process komorebi-bar -ErrorAction SilentlyContinue |
+    Where-Object { $_.SessionId -eq $SESSION_ID } |
+    Stop-Process -ErrorAction SilentlyContinue
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2713,9 +2743,12 @@ Stop-Process -Name:komorebi-bar -ErrorAction SilentlyContinue
 
             if args.masir {
                 let script = r"
-Stop-Process -Name:masir -ErrorAction SilentlyContinue
-                ";
-                match powershell_script::run(script) {
+Get-Process masir -ErrorAction SilentlyContinue |
+    Where-Object { $_.SessionId -eq $SESSION_ID } |
+    Stop-Process -ErrorAction SilentlyContinue
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2730,21 +2763,24 @@ Stop-Process -Name:masir -ErrorAction SilentlyContinue
 if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
     (Get-CimInstance Win32_Process | Where-Object {
         ($_.CommandLine -like '*komorebi.ahk"') -and
-        ($_.Name -in @('AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyUX.exe'))
+        ($_.Name -in @('AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyUX.exe')) -and
+        ($_.SessionId -eq $SESSION_ID)
     } | Select-Object -First 1) | ForEach-Object {
         Stop-Process -Id $_.ProcessId -ErrorAction SilentlyContinue
     }
 } else {
     (Get-WmiObject Win32_Process | Where-Object {
         ($_.CommandLine -like '*komorebi.ahk"') -and
-        ($_.Name -in @('AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyUX.exe'))
+        ($_.Name -in @('AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyUX.exe')) -and
+        ($_.SessionId -eq $SESSION_ID)
     } | Select-Object -First 1) | ForEach-Object {
         Stop-Process -Id $_.ProcessId -ErrorAction SilentlyContinue
     }
 }
-"#;
+"#
+                .replace("$SESSION_ID", &session_id.to_string());
 
-                match powershell_script::run(script) {
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2762,13 +2798,24 @@ if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
             let mut system = sysinfo::System::new_all();
             system.refresh_processes(ProcessesToUpdate::All, true);
 
-            if system.processes_by_name("komorebi.exe".as_ref()).count() >= 1 {
+            if system
+                .processes_by_name("komorebi.exe".as_ref())
+                .filter(|proc| {
+                    proc.session_id()
+                        .map_or_default(|proc_session_id| proc_session_id.as_u32() == session_id)
+                })
+                .count()
+                >= 1
+            {
                 println!("komorebi is still running, attempting to force-quit");
 
                 let script = r"
-Stop-Process -Name:komorebi -ErrorAction SilentlyContinue
-                ";
-                match powershell_script::run(script) {
+Get-Process komorebi -ErrorAction SilentlyContinue |
+    Where-Object { $_.SessionId -eq $SESSION_ID } |
+    Stop-Process -ErrorAction SilentlyContinue
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
 
@@ -2789,6 +2836,8 @@ Stop-Process -Name:komorebi -ErrorAction SilentlyContinue
             }
         }
         SubCommand::Kill(args) => {
+            let session_id = current_session_id()?;
+
             if args.ahk {
                 println!(
                     "EOL: The --ahk flag is now end-of-life and will not receive any further updates or bug fixes"
@@ -2797,9 +2846,12 @@ Stop-Process -Name:komorebi -ErrorAction SilentlyContinue
 
             if args.whkd {
                 let script = r"
-Stop-Process -Name:whkd -ErrorAction SilentlyContinue
-                ";
-                match powershell_script::run(script) {
+Get-Process whkd -ErrorAction SilentlyContinue |
+    Where-Object { $_.SessionId -eq $SESSION_ID } |
+    Stop-Process -ErrorAction SilentlyContinue
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2811,9 +2863,12 @@ Stop-Process -Name:whkd -ErrorAction SilentlyContinue
 
             if args.bar {
                 let script = r"
-Stop-Process -Name:komorebi-bar -ErrorAction SilentlyContinue
-                ";
-                match powershell_script::run(script) {
+Get-Process komorebi-bar -ErrorAction SilentlyContinue |
+    Where-Object { $_.SessionId -eq $SESSION_ID } |
+    Stop-Process -ErrorAction SilentlyContinue
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2825,9 +2880,12 @@ Stop-Process -Name:komorebi-bar -ErrorAction SilentlyContinue
 
             if args.masir {
                 let script = r"
-Stop-Process -Name:masir -ErrorAction SilentlyContinue
-                ";
-                match powershell_script::run(script) {
+Get-Process masir -ErrorAction SilentlyContinue |
+    Where-Object { $_.SessionId -eq $SESSION_ID } |
+    Stop-Process -ErrorAction SilentlyContinue
+                "
+                .replace("$SESSION_ID", &session_id.to_string());
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -2842,21 +2900,24 @@ Stop-Process -Name:masir -ErrorAction SilentlyContinue
 if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
     (Get-CimInstance Win32_Process | Where-Object {
         ($_.CommandLine -like '*komorebi.ahk"') -and
-        ($_.Name -in @('AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyUX.exe'))
+        ($_.Name -in @('AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyUX.exe')) -and
+        ($_.SessionId -eq $SESSION_ID)
     } | Select-Object -First 1) | ForEach-Object {
         Stop-Process -Id $_.ProcessId -ErrorAction SilentlyContinue
     }
 } else {
     (Get-WmiObject Win32_Process | Where-Object {
         ($_.CommandLine -like '*komorebi.ahk"') -and
-        ($_.Name -in @('AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyUX.exe'))
+        ($_.Name -in @('AutoHotkey.exe', 'AutoHotkey64.exe', 'AutoHotkey32.exe', 'AutoHotkeyUX.exe')) -and
+        ($_.SessionId -eq $SESSION_ID)
     } | Select-Object -First 1) | ForEach-Object {
         Stop-Process -Id $_.ProcessId -ErrorAction SilentlyContinue
     }
 }
-"#;
+"#
+                .replace("$SESSION_ID", &session_id.to_string());
 
-                match powershell_script::run(script) {
+                match powershell_script::run(&script) {
                     Ok(_) => {
                         println!("{script}");
                     }
@@ -3434,4 +3495,17 @@ fn remove_transparency(hwnd: isize) {
 fn restore_window(hwnd: isize) {
     show_window(HWND(hwnd as *mut core::ffi::c_void), SW_RESTORE);
     remove_transparency(hwnd);
+}
+
+fn current_session_id() -> eyre::Result<u32> {
+    let process_id = unsafe { GetCurrentProcessId() };
+    let mut session_id = 0;
+
+    unsafe {
+        if ProcessIdToSessionId(process_id, &mut session_id).is_err() {
+            bail!("could not determine current session id");
+        }
+    }
+
+    Ok(session_id)
 }


### PR DESCRIPTION
## Summary

Support running komorebi in multiple Windows sessions at the same time (e.g, Fast User Switching) without conflicts.

At the moment it is not possible to run Komorebi in two different Windows accounts if both are signed in.
I spotted this because i was trying to setup a new local account, and wasn't able to run the WM when the other user was already running it, but the CLI didn't give me any incling of what was happening. It just saw a process called "komorebi.exe" and assumed it was already running, so it skipped the `start` command entirely. 

- `komorebic start`/`stop`/`kill` matched `komorebi.exe` (and `whkd`, `komorebi-bar`, `masir`, AutoHotkey) by process name alone, system-wide. On a machine with more than one Windows session (RDP, Fast User Switching, a session-0 service instance), an instance running in a different session was indistinguishable from one in the caller's own session:
  - `start` could report an existing instance in another session as "already running" and skip launching a new one in the current session.
  - `stop`/`kill` could count/target processes across all sessions, producing false "still running" force-quit attempts and PowerShell scripts that filtered by name only.
- Resolve the caller's session id natively (`GetCurrentProcessId` + `ProcessIdToSessionId`, mirroring what komorebi's core already does via `WindowsApi::process_id_to_session_id`) and use that `session_id` in every PS script to filter processes.
- The `komorebi.exe` startup guard in `komorebi/src/main.rs` gets the same session filter so the duplicate-instance check only considers processes in the same session.
- Note: i opted to use `.replace` instead of a `format!` String because doing that would have needed some escaping (braces in particular) in the PowerShell scripts. I thought it might have been more valuable to avoid that, keeping the scripts as close as possible to native PS for readability and debuggability, at the cost of being a bit less idiomatic. It is surely possible to do better there.


### Test plan

- [x] `cargo check` and `cargo clippy` pass for both `komorebi` and `komorebic`
- [x] Manual verification of `komorebic start`/`stop`/`kill` in a single-session setup
- [x] Manual verification in a multi-session (RDP / Fast User Switching) setup

I used Devin to find the problems and write up the initial summary of this PR, but most of the code I wrote myself, and of course, I executed the manual tests.